### PR TITLE
fix(llm): keep reasoning deltas out of OpenAI-compatible final text

### DIFF
--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -669,14 +669,9 @@ impl LlmClient for OpenAiClient {
                                                             as u64,
                                                     );
                                                 }
-                                                if let Some(delta) = Self::merge_stream_text(
-                                                    &mut text_content,
-                                                    &reasoning,
-                                                ) {
-                                                    let _ = tx
-                                                        .send(StreamEvent::ReasoningDelta(delta))
-                                                        .await;
-                                                }
+                                                let _ = tx
+                                                    .send(StreamEvent::ReasoningDelta(reasoning))
+                                                    .await;
                                             }
                                             if !skip_content {
                                                 if let Some(content) = message
@@ -720,13 +715,9 @@ impl LlmClient for OpenAiClient {
                                                             as u64,
                                                     );
                                                 }
-                                                if let Some(delta) =
-                                                    Self::merge_stream_text(&mut text_content, rc)
-                                                {
-                                                    let _ = tx
-                                                        .send(StreamEvent::ReasoningDelta(delta))
-                                                        .await;
-                                                }
+                                                let _ = tx
+                                                    .send(StreamEvent::ReasoningDelta(rc.clone()))
+                                                    .await;
                                             }
 
                                             if let Some(content) = delta.content {
@@ -840,11 +831,7 @@ impl LlmClient for OpenAiClient {
                                         first_token_ms =
                                             Some(request_started_at.elapsed().as_millis() as u64);
                                     }
-                                    if let Some(delta) =
-                                        Self::merge_stream_text(&mut text_content, &reasoning)
-                                    {
-                                        let _ = tx.send(StreamEvent::ReasoningDelta(delta)).await;
-                                    }
+                                    let _ = tx.send(StreamEvent::ReasoningDelta(reasoning)).await;
                                 }
                                 if !skip_content {
                                     if let Some(content) =
@@ -877,11 +864,7 @@ impl LlmClient for OpenAiClient {
                                         first_token_ms =
                                             Some(request_started_at.elapsed().as_millis() as u64);
                                     }
-                                    if let Some(delta) =
-                                        Self::merge_stream_text(&mut text_content, rc)
-                                    {
-                                        let _ = tx.send(StreamEvent::ReasoningDelta(delta)).await;
-                                    }
+                                    let _ = tx.send(StreamEvent::ReasoningDelta(rc.clone())).await;
                                 }
                                 if let Some(content) = delta.content {
                                     if first_token_ms.is_none() {

--- a/core/src/llm/tests.rs
+++ b/core/src/llm/tests.rs
@@ -1391,6 +1391,53 @@ mod extra_llm_tests2 {
         assert_eq!(message.reasoning_content.as_deref(), Some("done"));
     }
 
+    #[tokio::test]
+    async fn test_openai_stream_reasoning_delta_does_not_pollute_final_text() {
+        let sse = vec![
+            "data: {\"choices\":[{\"delta\":{\"reasoning\":\"I should answer the greeting.\"},\"finish_reason\":null}],\"usage\":null}\n\n".to_string(),
+            "data: {\"choices\":[{\"delta\":{\"content\":\"你好\"},\"finish_reason\":null}],\"usage\":null}\n\n".to_string(),
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n".to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+
+        let client = OpenAiClient::new("key".to_string(), "glm-5.2".to_string())
+            .with_http_client(Arc::new(MockStreamingHttpClient { chunks: sse }));
+
+        let mut rx = client
+            .complete_streaming(
+                &[Message::user("你好")],
+                None,
+                &[],
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut text_deltas = String::new();
+        let mut reasoning_deltas = String::new();
+        let mut final_response = None;
+        while let Some(event) = rx.recv().await {
+            match event {
+                StreamEvent::TextDelta(delta) => text_deltas.push_str(&delta),
+                StreamEvent::ReasoningDelta(delta) => reasoning_deltas.push_str(&delta),
+                StreamEvent::Done(response) => {
+                    final_response = Some(response);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let response = final_response.expect("expected final response");
+        assert_eq!(text_deltas, "你好");
+        assert_eq!(reasoning_deltas, "I should answer the greeting.");
+        assert_eq!(response.text(), "你好");
+        assert_eq!(
+            response.message.reasoning_content.as_deref(),
+            Some("I should answer the greeting.")
+        );
+    }
+
     // ========================================================================
     // LlmConfig and create_client_with_config
     // ========================================================================


### PR DESCRIPTION
 ## Summary  
Fix OpenAI-compatible streaming parsing so reasoning
  deltas are not merged into final assistant text.

  GLM/Kimi-style providers can stream internal reasoning
  via `reasoning` or `reasoning_content` before normal
  `content`. The previous parser emitted those deltas as
  reasoning, but also appended them to the final text
  buffer. This could make `response.text()` include
  internal reasoning and incorrectly trigger continuation
  heuristics.

  ## Changes

  - Keep reasoning deltas out of `text_content`.
  - Preserve reasoning through `ReasoningDelta` and
  `message.reasoning_content`.
  - Add a regression test for reasoning followed by final
  content in an OpenAI-compatible stream. 
 ## Verification

  - [x] `cargo test
  test_openai_stream_reasoning_delta_does_not_pollute_fin
  al_text --manifest-path /home/chensicheng/a3s/terminal/
  Code/core/Cargo.toml` — passed
  - [x] `cargo test
  glm_reasoning_aliases_to_reasoning_content_in_streaming
  _delta --manifest-path /home/chensicheng/a3s/terminal/
  Code/core/Cargo.toml` — passed
  - [x] `cargo test
  test_openai_stream_chunk_minimax_final_message_content
  --manifest-path /home/chensicheng/a3s/terminal/Code/
  core/Cargo.toml` — passed
  - [x] `cargo test llm::tests_file --manifest-path /
  home/chensicheng/a3s/terminal/Code/core/Cargo.toml` —
  238 passed, 0 failed, 2 ignored
  - [x] `cargo fmt --all --manifest-path /home/
  chensicheng/a3s/terminal/Code/core/Cargo.toml` — passed
  - [x] `cargo clippy --all-targets --manifest-path /
  home/chensicheng/a3s/terminal/Code/core/Cargo.toml --
  -D warnings` — passed