### PR TITLE
[codex] Clarify Python SDK skill invocation

### DIFF
--- a/examples/test_skill_tool.py
+++ b/examples/test_skill_tool.py
@@ -9,7 +9,6 @@ This script tests the Skill tool implementation by:
 4. Verifying permission isolation works
 """
 
-import asyncio
 import os
 import sys
 import tempfile
@@ -21,7 +20,7 @@ sys.path.insert(0, str(sdk_path))
 
 from a3s_code import Agent
 
-async def main():
+def main():
     print("=" * 80)
     print("Skill Tool Test with Kimi Model")
     print("=" * 80)
@@ -90,7 +89,7 @@ You CANNOT:
 
         try:
             print("\n💬 Prompt: Use the file-reader skill to read test.txt")
-            result = await session.send(
+            result = session.send(
                 "Use the file-reader skill to read test.txt and tell me what it contains"
             )
             print(f"\n✅ Response:\n{result.text}")
@@ -107,7 +106,7 @@ You CANNOT:
 
         try:
             print("\n💬 Prompt: Use the file-reader skill to search for 'test' in all files")
-            result = await session.send(
+            result = session.send(
                 "Use the file-reader skill to search for the word 'test' in all files"
             )
             print(f"\n✅ Response:\n{result.text}")
@@ -124,7 +123,7 @@ You CANNOT:
 
         try:
             print("\n💬 Prompt: Use the file-reader skill to write a summary to output.txt")
-            result = await session.send(
+            result = session.send(
                 "Use the file-reader skill to write a summary of test.txt to output.txt"
             )
             print(f"\n✅ Response:\n{result.text}")
@@ -146,4 +145,4 @@ You CANNOT:
         print("=" * 80)
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -24,11 +24,11 @@ Air-gapped or hermetic install? Grab the wheel matching your
 interpreter directly:
 
 ```bash
+VERSION=5.3.5  # replace with the release version you are installing
+PYTAG=cp312-cp312-manylinux_2_28_x86_64
 pip install \
-  'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
+  "https://github.com/A3S-Lab/Code/releases/download/v${VERSION}/a3s_code-${VERSION}-${PYTAG}.whl"
 ```
-
-Replace `<VERSION>` with the release to install, for example `5.3.5`.
 
 ## Quick Start
 
@@ -279,6 +279,24 @@ session.tool("dynamic_workflow", {
     "input": {"message": "hello from Flow"},
 })
 session.unregister_dynamic_tool("dynamic_workflow")
+
+# Folder-style skills
+workspace = "/my-project"
+skill_dir = f"{workspace}/skills"
+session = agent.session(workspace, skill_dirs=[skill_dir])
+matches = session.tool("search_skills", {"query": "review database schema", "limit": 5})
+print(matches.output)
+
+skill_result = session.tool("Skill", {
+    "skill_name": "db-review",
+    "prompt": "Review the migrations and summarize correctness risks.",
+})
+print(skill_result.output)
+
+# Or configure skill directories through SessionOptions.
+opts = SessionOptions()
+opts.skill_dirs = [skill_dir]
+session = agent.session(workspace, opts)
 
 # S3-compatible workspace — point the same direct tools at object storage.
 # `bash`, `git`, `grep`, `glob` are automatically hidden because object

--- a/sdk/python/docs/QUICK_REFERENCE.md
+++ b/sdk/python/docs/QUICK_REFERENCE.md
@@ -1,4 +1,4 @@
-# A3S Code Python SDK 2.3 Quick Reference
+# A3S Code Python SDK Quick Reference
 
 This page is the short, current reference for the Python SDK.
 
@@ -73,6 +73,29 @@ session.unregister_dynamic_tool("dynamic_workflow")
 
 Direct tools bypass the LLM and are useful for deterministic checks,
 diagnostics, and tests.
+
+## Skills
+
+```python
+session = agent.session(".", skill_dirs=["./skills"])
+
+matches = session.tool("search_skills", {
+    "query": "review database schema",
+    "limit": 5,
+})
+print(matches.output)
+
+result = session.tool("Skill", {
+    "skill_name": "db-review",
+    "prompt": "Review the migrations and summarize correctness risks.",
+})
+print(result.output)
+```
+
+`search_skills` is a deterministic direct tool. `Skill` loads the selected
+folder-style skill and then runs the configured model with that skill's
+temporary allowed-tools grant, so the session still needs a working provider
+configuration.
 
 ## Evidence
 

--- a/sdk/python/src/session.rs
+++ b/sdk/python/src/session.rs
@@ -846,7 +846,7 @@ impl PySession {
     ///         return f"pong! session={ctx['session_id']}"
     ///
     ///     session.register_command("ping", "Pong!", ping_handler)
-    ///     result = await session.send("/ping hello")
+    ///     result = session.send("/ping hello")
     #[pyo3(signature = (name, description, handler))]
     fn register_command(
         &self,


### PR DESCRIPTION
## Summary

Clarifies the Python SDK path for folder-style skills and direct skill invocation.

- document `skill_dirs`, `search_skills`, and `Skill` usage in the Python SDK README
- add a concise Skills section to the Python quick reference
- update the skill-tool example from obsolete `await session.send(...)` usage to the current synchronous API
- fix one Python binding docstring that still showed `await session.send(...)`

## Why

The SDK already supports loading folder-style skills through `skill_dirs` and invoking them with `session.tool("Skill", {...})`, but the Python-facing docs did not show that path clearly. The old example also mixed in async-style usage that does not match the current PyO3 API.

## Validation

- `git diff --check origin/main..HEAD`
- `python3 -m py_compile examples/test_skill_tool.py`

Rust checks were not run locally because `cargo` is not installed in this environment.