### PR TITLE
新增 Codex 认证模型提供方

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,15 @@ providers "provider" {
   }
 }
 
+# Optional: use Codex CLI / ChatGPT account auth instead of an API key.
+# Run `codex login`, then use a model slug from `a3s code models`.
+# default_model = "codex/model-slug"
+# providers "codex" {
+#   models "model-slug" {
+#     tool_call = true
+#   }
+# }
+
 os = env("A3S_OS_URL")
 
 agent_dirs = ["./.a3s/agents"]

--- a/core/src/agent_api/agent_bootstrap.rs
+++ b/core/src/agent_api/agent_bootstrap.rs
@@ -53,7 +53,7 @@ pub(super) fn load_code_config(config_source: String) -> Result<CodeConfig> {
 pub(super) async fn build_agent_from_config(config: CodeConfig) -> Result<Agent> {
     config
         .default_llm_config()
-        .context("default_model must be set in 'provider/model' format with a valid API key")?;
+        .context("default_model must be set in 'provider/model' format with a valid provider")?;
 
     let mut agent_config = base_agent_config(&config);
     install_global_skill_registry(&mut agent_config, &config);

--- a/core/src/compaction.rs
+++ b/core/src/compaction.rs
@@ -107,7 +107,7 @@ pub(crate) async fn compact_messages(
     // Call LLM to generate summary
     let summary_message = Message::user(&summarization_prompt);
     let response = llm_client
-        .complete(&[summary_message], None, &[])
+        .complete_with_request_kind(&[summary_message], None, &[], "context_compaction")
         .await
         .context("Failed to generate conversation summary")?;
 
@@ -235,6 +235,59 @@ fn estimate_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::{LlmResponse, TokenUsage, ToolDefinition};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    struct RequestKindClient {
+        seen_request_kinds: Arc<Mutex<Vec<String>>>,
+    }
+
+    fn summary_response() -> LlmResponse {
+        LlmResponse {
+            message: Message::assistant("summary"),
+            usage: TokenUsage::default(),
+            stop_reason: Some("stop".to_string()),
+            token_logprobs: Vec::new(),
+            meta: None,
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for RequestKindClient {
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _system: Option<&str>,
+            _tools: &[ToolDefinition],
+        ) -> Result<LlmResponse> {
+            Ok(summary_response())
+        }
+
+        async fn complete_streaming(
+            &self,
+            _messages: &[Message],
+            _system: Option<&str>,
+            _tools: &[ToolDefinition],
+            _cancel_token: tokio_util::sync::CancellationToken,
+        ) -> Result<tokio::sync::mpsc::Receiver<crate::llm::StreamEvent>> {
+            anyhow::bail!("streaming is not used by context compaction")
+        }
+
+        async fn complete_with_request_kind(
+            &self,
+            _messages: &[Message],
+            _system: Option<&str>,
+            _tools: &[ToolDefinition],
+            request_kind: &str,
+        ) -> Result<LlmResponse> {
+            self.seen_request_kinds
+                .lock()
+                .expect("request-kind mutex poisoned")
+                .push(request_kind.to_string());
+            Ok(summary_response())
+        }
+    }
 
     // -- should_auto_compact tests --
 
@@ -408,5 +461,29 @@ mod tests {
         assert!(KEEP_INITIAL_MESSAGES > 0);
         assert!(TOOL_OUTPUT_PROTECT_TOKENS > 0);
         assert!(MIN_PRUNE_SAVINGS_TOKENS > 0);
+    }
+
+    #[tokio::test]
+    async fn test_compaction_marks_summary_as_internal_request() {
+        let seen_request_kinds = Arc::new(Mutex::new(Vec::new()));
+        let client: Arc<dyn LlmClient> = Arc::new(RequestKindClient {
+            seen_request_kinds: Arc::clone(&seen_request_kinds),
+        });
+        let messages = (0..31)
+            .map(|index| make_text_msg("user", &format!("message-{index}")))
+            .collect::<Vec<_>>();
+
+        let compacted = compact_messages("session", &messages, &client)
+            .await
+            .expect("compaction succeeds")
+            .expect("message count triggers compaction");
+
+        assert!(compacted.len() < messages.len());
+        assert_eq!(
+            *seen_request_kinds
+                .lock()
+                .expect("request-kind mutex poisoned"),
+            vec!["context_compaction".to_string()]
+        );
     }
 }

--- a/core/src/config/loader.rs
+++ b/core/src/config/loader.rs
@@ -233,6 +233,19 @@ fn acl_path_list_attr(block: &a3s_acl::Block, keys: &[&str]) -> Option<Vec<PathB
     }
 }
 
+fn provider_uses_codex_auth(provider_name: &str) -> bool {
+    matches!(
+        provider_name.to_ascii_lowercase().as_str(),
+        "codex" | "openai-codex"
+    )
+}
+
+fn effective_api_key<'a>(provider: &'a ProviderConfig, model: &'a ModelConfig) -> Option<&'a str> {
+    provider
+        .get_api_key(model)
+        .or_else(|| provider_uses_codex_auth(&provider.name).then_some(""))
+}
+
 // ============================================================================
 // CodeConfig Implementation
 // ============================================================================
@@ -574,7 +587,7 @@ impl CodeConfig {
     /// Returns None if default provider/model is not configured or API key is missing.
     pub fn default_llm_config(&self) -> Option<LlmConfig> {
         let (provider, model) = self.default_model_config()?;
-        let api_key = provider.get_api_key(model)?;
+        let api_key = effective_api_key(provider, model)?;
         let base_url = provider.get_base_url(model);
         let headers = provider.get_headers(model);
         let session_id_header = provider.get_session_id_header(model);
@@ -602,7 +615,7 @@ impl CodeConfig {
     pub fn llm_config(&self, provider_name: &str, model_id: &str) -> Option<LlmConfig> {
         let provider = self.find_provider(provider_name)?;
         let model = provider.find_model(model_id)?;
-        let api_key = provider.get_api_key(model)?;
+        let api_key = effective_api_key(provider, model)?;
         let base_url = provider.get_base_url(model);
         let headers = provider.get_headers(model);
         let session_id_header = provider.get_session_id_header(model);

--- a/core/src/config/tests.rs
+++ b/core/src/config/tests.rs
@@ -394,6 +394,30 @@ fn test_default_llm_config() {
 }
 
 #[test]
+fn test_codex_provider_uses_local_auth_without_api_key() {
+    let config = CodeConfig::from_acl(
+        r#"
+            default_model = "codex/test-codex-model"
+
+            providers "codex" {
+              models "test-codex-model" {
+                name = "Test Codex Model"
+                toolCall = true
+                limit = { output = 1234 }
+              }
+            }
+        "#,
+    )
+    .unwrap();
+
+    let llm_config = config.default_llm_config().unwrap();
+    assert_eq!(llm_config.provider, "codex");
+    assert_eq!(llm_config.model, "test-codex-model");
+    assert_eq!(llm_config.api_key.expose(), "");
+    assert_eq!(llm_config.max_tokens, Some(1234));
+}
+
+#[test]
 fn test_model_api_key_override() {
     let provider = ProviderConfig {
         name: "openai".to_string(),

--- a/core/src/llm/codex.rs
+++ b/core/src/llm/codex.rs
@@ -1,0 +1,540 @@
+//! Codex / ChatGPT-account LLM client.
+//!
+//! This provider reads the local Codex CLI login (`$CODEX_HOME/auth.json` or
+//! `~/.codex/auth.json`) and talks to the ChatGPT Codex Responses backend. It
+//! exists because the ChatGPT-account backend uses a different wire format from
+//! OpenAI chat completions.
+
+use super::{
+    default_http_client, ContentBlock, HttpClient, LlmClient, LlmResponse, LlmResponseMeta,
+    Message, StreamEvent, TokenUsage, ToolDefinition,
+};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+const CODEX_BASE: &str = "https://chatgpt.com/backend-api/codex";
+const ORIGINATOR: &str = "codex_cli_rs";
+const UA: &str = "codex_cli_rs (a3s)";
+
+pub fn codex_home() -> Option<PathBuf> {
+    if let Some(configured) = std::env::var_os("CODEX_HOME").filter(|value| !value.is_empty()) {
+        return Some(expand_home_path(PathBuf::from(configured)));
+    }
+    std::env::var_os("HOME").map(|home| Path::new(&home).join(".codex"))
+}
+
+pub fn codex_auth_path() -> Option<PathBuf> {
+    codex_home().map(|home| home.join("auth.json"))
+}
+
+fn codex_models_cache_path() -> Option<PathBuf> {
+    codex_home().map(|home| home.join("models_cache.json"))
+}
+
+fn expand_home_path(path: PathBuf) -> PathBuf {
+    let Some(raw) = path.to_str() else {
+        return path;
+    };
+    let Some(rest) = raw.strip_prefix("~/") else {
+        return path;
+    };
+    std::env::var_os("HOME")
+        .map(|home| Path::new(&home).join(rest))
+        .unwrap_or(path)
+}
+
+/// User-facing Codex models from `models_cache.json`, ordered by priority.
+pub fn codex_models() -> Vec<String> {
+    fn from_cache() -> Option<Vec<String>> {
+        let path = codex_models_cache_path()?;
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+        let mut list: Vec<(i64, String)> = v
+            .get("models")?
+            .as_array()?
+            .iter()
+            .filter_map(|model| {
+                if model.get("visibility").and_then(|value| value.as_str()) != Some("list") {
+                    return None;
+                }
+                let slug = model
+                    .get("slug")
+                    .and_then(|value| value.as_str())?
+                    .to_string();
+                let priority = model
+                    .get("priority")
+                    .and_then(|value| value.as_i64())
+                    .unwrap_or(999);
+                Some((priority, slug))
+            })
+            .collect();
+        list.sort_by_key(|(priority, _)| *priority);
+        let out: Vec<String> = list.into_iter().map(|(_, slug)| slug).collect();
+        (!out.is_empty()).then_some(out)
+    }
+    from_cache().unwrap_or_else(|| vec!["gpt-5.5".to_string()])
+}
+
+pub fn codex_model_context(model: &str) -> Option<u32> {
+    let path = codex_models_cache_path()?;
+    let v: Value = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    v.get("models")?
+        .as_array()?
+        .iter()
+        .find(|entry| entry.get("slug").and_then(|value| value.as_str()) == Some(model))
+        .and_then(parse_model_context)
+}
+
+fn parse_model_context(model: &Value) -> Option<u32> {
+    const KEYS: &[&str] = &[
+        "context_length",
+        "max_context_length",
+        "max_model_len",
+        "context_window",
+        "max_input_tokens",
+    ];
+    for key in KEYS {
+        if let Some(n) = model
+            .get(key)
+            .and_then(|value| value.as_u64())
+            .filter(|n| *n > 0)
+        {
+            return Some(n as u32);
+        }
+    }
+    model
+        .get("model_info")
+        .and_then(|info| info.get("max_input_tokens"))
+        .and_then(|value| value.as_u64())
+        .filter(|n| *n > 0)
+        .map(|n| n as u32)
+}
+
+pub struct CodexClient {
+    access_token: String,
+    account_id: String,
+    model: String,
+    session_id: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl CodexClient {
+    /// Read Codex CLI auth and bind to `model`.
+    pub fn from_codex_login(model: &str, session_id: &str) -> Result<Self> {
+        let path = codex_auth_path().ok_or_else(|| anyhow!("HOME unset and CODEX_HOME unset"))?;
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("read {} (run `codex login`)", path.display()))?;
+        let value: Value =
+            serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+
+        let access_token = value
+            .pointer("/tokens/access_token")
+            .or_else(|| value.get("access_token"))
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| anyhow!("no access_token in {} - run `codex login`", path.display()))?
+            .to_string();
+
+        let account_id = value
+            .pointer("/tokens/account_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                value
+                    .pointer("/tokens/id_token")
+                    .and_then(|value| value.as_str())
+                    .and_then(account_id_from_id_token)
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "no ChatGPT account id in {} - re-run `codex login`",
+                    path.display()
+                )
+            })?;
+
+        Ok(Self {
+            access_token,
+            account_id,
+            model: model.to_string(),
+            session_id: session_id.to_string(),
+            http: default_http_client(),
+        })
+    }
+
+    pub fn with_http_client(mut self, http: Arc<dyn HttpClient>) -> Self {
+        self.http = http;
+        self
+    }
+
+    fn build_body(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        tools: &[ToolDefinition],
+        stream: bool,
+    ) -> Value {
+        json!({
+            "model": self.model,
+            "instructions": system.unwrap_or(""),
+            "input": convert_messages(messages),
+            "tools": convert_tools(tools),
+            "tool_choice": "auto",
+            "parallel_tool_calls": false,
+            "store": false,
+            "stream": stream,
+            "prompt_cache_key": self.session_id,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmClient for CodexClient {
+    async fn complete(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        tools: &[ToolDefinition],
+    ) -> Result<LlmResponse> {
+        let mut rx = self
+            .complete_streaming(messages, system, tools, CancellationToken::new())
+            .await?;
+        while let Some(event) = rx.recv().await {
+            if let StreamEvent::Done(response) = event {
+                return Ok(response);
+            }
+        }
+        Err(anyhow!("codex stream closed before response.completed"))
+    }
+
+    async fn complete_streaming(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        tools: &[ToolDefinition],
+        cancel_token: CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let body = self.build_body(messages, system, tools, true);
+        let url = format!("{CODEX_BASE}/responses");
+        let bearer = format!("Bearer {}", self.access_token);
+        let headers = vec![
+            ("Authorization", bearer.as_str()),
+            ("chatgpt-account-id", self.account_id.as_str()),
+            ("OpenAI-Beta", "responses=experimental"),
+            ("originator", ORIGINATOR),
+            ("session_id", self.session_id.as_str()),
+            ("Accept", "text/event-stream"),
+            ("User-Agent", UA),
+        ];
+
+        let response = self
+            .http
+            .post_streaming(&url, headers, &body, cancel_token.clone())
+            .await?;
+        if !(200..300).contains(&response.status) {
+            return Err(anyhow!(
+                "codex /responses HTTP {}: {}",
+                response.status,
+                response.error_body
+            ));
+        }
+
+        let (tx, rx) = mpsc::channel(128);
+        let model = self.model.clone();
+        let request_url = url.clone();
+        let mut stream = response.byte_stream;
+
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            let mut buf = String::new();
+            let mut text = String::new();
+            let mut reasoning = String::new();
+            let mut response_id: Option<String> = None;
+            let mut usage = TokenUsage::default();
+            let mut calls: Vec<(String, (String, String, String))> = Vec::new();
+
+            while let Some(chunk) = stream.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(_) => break,
+                };
+                buf.push_str(&String::from_utf8_lossy(&chunk));
+                while let Some(end) = buf.find("\n\n") {
+                    let frame: String = buf.drain(..end).collect();
+                    buf.drain(..2);
+                    for line in frame.lines() {
+                        let Some(data) = line
+                            .strip_prefix("data: ")
+                            .or_else(|| line.strip_prefix("data:"))
+                        else {
+                            continue;
+                        };
+                        let Ok(event) = serde_json::from_str::<Value>(data.trim()) else {
+                            continue;
+                        };
+                        match event
+                            .get("type")
+                            .and_then(|kind| kind.as_str())
+                            .unwrap_or("")
+                        {
+                            "response.created" => {
+                                response_id = event
+                                    .pointer("/response/id")
+                                    .and_then(|value| value.as_str())
+                                    .map(str::to_string);
+                            }
+                            "response.output_text.delta" => {
+                                if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
+                                    text.push_str(delta);
+                                    let _ =
+                                        tx.send(StreamEvent::TextDelta(delta.to_string())).await;
+                                }
+                            }
+                            "response.reasoning_text.delta"
+                            | "response.reasoning_summary_text.delta" => {
+                                if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
+                                    reasoning.push_str(delta);
+                                    let _ = tx
+                                        .send(StreamEvent::ReasoningDelta(delta.to_string()))
+                                        .await;
+                                }
+                            }
+                            "response.output_item.added" => {
+                                let item = event.get("item");
+                                if item
+                                    .and_then(|value| value.get("type"))
+                                    .and_then(|value| value.as_str())
+                                    == Some("function_call")
+                                {
+                                    let id = item_str(item, "id");
+                                    let call_id = item_str(item, "call_id");
+                                    let name = item_str(item, "name");
+                                    calls
+                                        .push((id, (call_id.clone(), name.clone(), String::new())));
+                                    let _ = tx
+                                        .send(StreamEvent::ToolUseStart { id: call_id, name })
+                                        .await;
+                                }
+                            }
+                            "response.function_call_arguments.delta" => {
+                                let item_id =
+                                    event.get("item_id").and_then(|v| v.as_str()).unwrap_or("");
+                                if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
+                                    if let Some(entry) =
+                                        calls.iter_mut().find(|(key, _)| key == item_id)
+                                    {
+                                        entry.1 .2.push_str(delta);
+                                    }
+                                    let _ = tx
+                                        .send(StreamEvent::ToolUseInputDelta(delta.to_string()))
+                                        .await;
+                                }
+                            }
+                            "response.output_item.done" => {
+                                let item = event.get("item");
+                                if item
+                                    .and_then(|value| value.get("type"))
+                                    .and_then(|value| value.as_str())
+                                    == Some("function_call")
+                                {
+                                    let id = item_str(item, "id");
+                                    let entry = (
+                                        item_str(item, "call_id"),
+                                        item_str(item, "name"),
+                                        item_str(item, "arguments"),
+                                    );
+                                    if let Some(existing) =
+                                        calls.iter_mut().find(|(key, _)| *key == id)
+                                    {
+                                        existing.1 = entry;
+                                    } else {
+                                        calls.push((id, entry));
+                                    }
+                                }
+                            }
+                            "response.completed" => {
+                                if let Some(raw_usage) = event.pointer("/response/usage") {
+                                    usage.prompt_tokens = raw_usage
+                                        .get("input_tokens")
+                                        .and_then(|value| value.as_u64())
+                                        .unwrap_or(0)
+                                        as usize;
+                                    usage.completion_tokens = raw_usage
+                                        .get("output_tokens")
+                                        .and_then(|value| value.as_u64())
+                                        .unwrap_or(0)
+                                        as usize;
+                                    usage.total_tokens = raw_usage
+                                        .get("total_tokens")
+                                        .and_then(|value| value.as_u64())
+                                        .unwrap_or(0)
+                                        as usize;
+                                    usage.cache_read_tokens = raw_usage
+                                        .pointer("/input_tokens_details/cached_tokens")
+                                        .and_then(|value| value.as_u64())
+                                        .map(|value| value as usize);
+                                }
+
+                                let mut content = Vec::new();
+                                if !text.is_empty() {
+                                    content.push(ContentBlock::Text {
+                                        text: std::mem::take(&mut text),
+                                    });
+                                }
+                                let has_calls = !calls.is_empty();
+                                for (_, (call_id, name, args)) in calls.drain(..) {
+                                    content.push(ContentBlock::ToolUse {
+                                        id: call_id,
+                                        name,
+                                        input: parse_args(&args),
+                                    });
+                                }
+                                let response = LlmResponse {
+                                    message: Message {
+                                        role: "assistant".into(),
+                                        content,
+                                        reasoning_content: (!reasoning.is_empty())
+                                            .then(|| std::mem::take(&mut reasoning)),
+                                    },
+                                    usage: usage.clone(),
+                                    stop_reason: Some(
+                                        if has_calls { "tool_calls" } else { "stop" }.into(),
+                                    ),
+                                    token_logprobs: Vec::new(),
+                                    meta: Some(LlmResponseMeta {
+                                        provider: Some("codex".into()),
+                                        request_model: Some(model.clone()),
+                                        request_url: Some(request_url.clone()),
+                                        response_id: response_id.clone(),
+                                        ..Default::default()
+                                    }),
+                                };
+                                let _ = tx.send(StreamEvent::Done(response)).await;
+                                return;
+                            }
+                            "response.failed" | "error" => return,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+fn item_str(item: Option<&Value>, key: &str) -> String {
+    item.and_then(|value| value.get(key))
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn parse_args(value: &str) -> Value {
+    if value.trim().is_empty() {
+        return json!({});
+    }
+    serde_json::from_str(value).unwrap_or_else(|_| json!({}))
+}
+
+fn account_id_from_id_token(jwt: &str) -> Option<String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let payload = jwt.split('.').nth(1)?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let claims: Value = serde_json::from_slice(&bytes).ok()?;
+    claims
+        .pointer("/https:~1~1api.openai.com~1auth/chatgpt_account_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn convert_messages(messages: &[Message]) -> Vec<Value> {
+    let mut out = Vec::new();
+    for message in messages {
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } => {
+                    let kind = if message.role == "assistant" {
+                        "output_text"
+                    } else {
+                        "input_text"
+                    };
+                    out.push(json!({
+                        "type": "message",
+                        "role": message.role,
+                        "content": [{"type": kind, "text": text}],
+                    }));
+                }
+                ContentBlock::ToolUse { id, name, input } => {
+                    out.push(json!({
+                        "type": "function_call",
+                        "name": name,
+                        "arguments": input.to_string(),
+                        "call_id": id,
+                    }));
+                }
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    ..
+                } => {
+                    out.push(json!({
+                        "type": "function_call_output",
+                        "call_id": tool_use_id,
+                        "output": content.as_text(),
+                    }));
+                }
+                ContentBlock::Image { source } => {
+                    out.push(json!({
+                        "type": "message",
+                        "role": message.role,
+                        "content": [{
+                            "type": "input_image",
+                            "image_url": format!(
+                                "data:{};base64,{}",
+                                source.media_type, source.data
+                            ),
+                        }],
+                    }));
+                }
+            }
+        }
+    }
+    out
+}
+
+fn convert_tools(tools: &[ToolDefinition]) -> Vec<Value> {
+    tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "type": "function",
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_model_context_from_cache_shapes() {
+        assert_eq!(
+            parse_model_context(&json!({"context_length": 200000})),
+            Some(200_000)
+        );
+        assert_eq!(
+            parse_model_context(&json!({"model_info": {"max_input_tokens": 1000000}})),
+            Some(1_000_000)
+        );
+        assert_eq!(parse_model_context(&json!({"context_window": 0})), None);
+        assert_eq!(parse_model_context(&json!({"slug": "gpt"})), None);
+    }
+}

--- a/core/src/llm/factory.rs
+++ b/core/src/llm/factory.rs
@@ -1,15 +1,20 @@
 //! LLM client factory
 
 use super::anthropic::AnthropicClient;
+use super::codex::CodexClient;
 use super::http::ReqwestHttpClient;
 use super::openai::OpenAiClient;
 use super::types::SecretString;
 use super::zhipu::ZhipuClient;
-use super::LlmClient;
+use super::{LlmClient, LlmResponse, Message, StreamEvent, ToolDefinition};
 use crate::retry::RetryConfig;
+use anyhow::Result;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 /// LLM client configuration
 #[derive(Clone, Default)]
@@ -167,6 +172,20 @@ pub fn create_client_with_config(config: LlmConfig) -> Arc<dyn LlmClient> {
     let headers = config.resolved_headers();
 
     match config.provider.as_str() {
+        "codex" | "openai-codex" => {
+            let session_id = config.session_id.as_deref().unwrap_or_default();
+            match CodexClient::from_codex_login(&config.model, session_id) {
+                Ok(mut client) => {
+                    if let Some(http) = http.clone() {
+                        client = client.with_http_client(http);
+                    }
+                    Arc::new(client)
+                }
+                Err(error) => Arc::new(FailingLlmClient {
+                    message: format!("failed to create Codex auth LLM client: {error}"),
+                }),
+            }
+        }
         "anthropic" | "claude" => {
             let mut client = AnthropicClient::new(api_key, config.model)
                 .with_provider_name(config.provider.clone())
@@ -277,5 +296,31 @@ pub fn create_client_with_config(config: LlmConfig) -> Arc<dyn LlmClient> {
             }
             Arc::new(client)
         }
+    }
+}
+
+struct FailingLlmClient {
+    message: String,
+}
+
+#[async_trait]
+impl LlmClient for FailingLlmClient {
+    async fn complete(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+    ) -> Result<LlmResponse> {
+        anyhow::bail!("{}", self.message)
+    }
+
+    async fn complete_streaming(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+        _cancel_token: CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        anyhow::bail!("{}", self.message)
     }
 }

--- a/core/src/llm/mod.rs
+++ b/core/src/llm/mod.rs
@@ -4,6 +4,7 @@
 //! (Anthropic Claude, OpenAI, Zhipu AI GLM, and OpenAI-compatible providers).
 
 pub mod anthropic;
+pub mod codex;
 pub mod factory;
 pub mod http;
 pub mod openai;
@@ -13,6 +14,7 @@ pub mod zhipu;
 
 // Re-export public types
 pub use anthropic::AnthropicClient;
+pub use codex::CodexClient;
 pub use factory::{create_client_with_config, LlmConfig};
 pub use http::{
     clear_http_metrics_callback, default_http_client, set_http_metrics_callback, HttpClient,

--- a/core/src/llm/mod.rs
+++ b/core/src/llm/mod.rs
@@ -40,6 +40,20 @@ pub trait LlmClient: Send + Sync {
         tools: &[ToolDefinition],
     ) -> Result<LlmResponse>;
 
+    /// Complete an internal runtime request with a machine-readable purpose.
+    ///
+    /// Providers that support request extensions can forward ``request_kind``
+    /// to an RL adapter. Other providers retain the normal completion behavior.
+    async fn complete_with_request_kind(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        tools: &[ToolDefinition],
+        _request_kind: &str,
+    ) -> Result<LlmResponse> {
+        self.complete(messages, system, tools).await
+    }
+
     /// Complete a conversation with streaming
     /// Returns a receiver for streaming events.
     /// The cancel_token is checked during the HTTP request; if cancelled, the request is aborted.

--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -696,7 +696,7 @@ impl OpenAiClient {
                                             text: text_content.clone(),
                                         });
                                     }
-                                    for (_, (id, name, args)) in tool_calls.iter() {
+                                    for (id, name, args) in tool_calls.values() {
                                         content_blocks.push(ContentBlock::ToolUse {
                                             id: id.clone(),
                                             name: name.clone(),
@@ -1093,7 +1093,7 @@ impl OpenAiClient {
                             text: text_content.clone(),
                         });
                     }
-                    for (_, (id, name, args)) in tool_calls.iter() {
+                    for (id, name, args) in tool_calls.values() {
                         content_blocks.push(ContentBlock::ToolUse {
                             id: id.clone(),
                             name: name.clone(),

--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -326,6 +326,10 @@ impl OpenAiClient {
         }
     }
 
+    fn apply_request_kind(request: &mut serde_json::Value, request_kind: &str) {
+        request["a3s_request_kind"] = serde_json::json!(request_kind);
+    }
+
     /// Build a chat-completions request body, optionally applying a directive.
     fn build_chat_request(
         &self,
@@ -519,6 +523,18 @@ impl LlmClient for OpenAiClient {
     ) -> Result<LlmResponse> {
         self.send_request(self.build_chat_request(messages, system, tools, None))
             .await
+    }
+
+    async fn complete_with_request_kind(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        tools: &[ToolDefinition],
+        request_kind: &str,
+    ) -> Result<LlmResponse> {
+        let mut request = self.build_chat_request(messages, system, tools, None);
+        Self::apply_request_kind(&mut request, request_kind);
+        self.send_request(request).await
     }
 
     async fn complete_structured(
@@ -1500,6 +1516,13 @@ mod tests {
             },
         );
         assert_eq!(req["response_format"]["type"], "json_object");
+    }
+
+    #[test]
+    fn test_apply_request_kind_marks_internal_completion() {
+        let mut req = serde_json::json!({ "model": "m" });
+        OpenAiClient::apply_request_kind(&mut req, "context_compaction");
+        assert_eq!(req["a3s_request_kind"], "context_compaction");
     }
 
     #[test]

--- a/core/src/tools/builtin/web_search.rs
+++ b/core/src/tools/builtin/web_search.rs
@@ -421,15 +421,14 @@ fn parse_proxy_url(url: &str) -> Option<ProxyConfig> {
     };
 
     // Parse host:port
-    let (host, port) = if let Some(colon_pos) = rest.rfind(':') {
+    let (host, port) = {
+        let colon_pos = rest.rfind(':')?;
         let host = &rest[..colon_pos];
         let port_str = &rest[colon_pos + 1..];
         match port_str.parse::<u16>() {
             Ok(p) => (host, p),
             Err(_) => return None,
         }
-    } else {
-        return None;
     };
 
     let mut config = ProxyConfig::new(host, port);


### PR DESCRIPTION
## 变更
- 将 Codex CLI/ChatGPT 账号认证接入为 a3s-code core 的 LLM provider
- 支持 providers "codex" / "openai-codex" 无需 apiKey，从 CODEX_HOME 或 ~/.codex 读取认证
- 复用 Codex Responses backend，并补充配置和模型上下文测试

## 验证
- cargo test --manifest-path crates/code/core/Cargo.toml config::tests::test_codex_provider_uses_local_auth_without_api_key
- cargo test --manifest-path crates/code/core/Cargo.toml llm::codex::tests::parses_model_context_from_cache_shapes