### PR TITLE
feat(store): support invariant-safe session forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added an invariant-checked session snapshot fork operation that rebinds the
+  session, workspace, run ownership, and subagent parent ownership while
+  preserving the complete persisted generation.
+
 ## [5.3.5] - 2026-07-17
 
 ### Added

--- a/core/src/store/session_snapshot.rs
+++ b/core/src/store/session_snapshot.rs
@@ -62,6 +62,39 @@ impl SessionSnapshotV1 {
         )
     }
 
+    /// Rebind a complete snapshot to a new session and workspace.
+    ///
+    /// Session forks retain historical artifacts, traces, run ids, and child
+    /// session ids. Top-level run ownership and subagent parent ownership must
+    /// move with the new session or the aggregate would no longer be loadable.
+    pub fn fork_for_session(
+        mut self,
+        session_id: impl Into<String>,
+        workspace: impl Into<String>,
+    ) -> Result<Self> {
+        let source_session_id = self.session.id.clone();
+        self.validate_for_session(&source_session_id)?;
+
+        let session_id = session_id.into();
+        if session_id.trim().is_empty() {
+            bail!("forked session id cannot be empty");
+        }
+
+        self.session.id = session_id.clone();
+        self.session.config.workspace = workspace.into();
+        for record in &mut self.run_records {
+            record.snapshot.session_id.clone_from(&session_id);
+        }
+        for task in &mut self.subagent_tasks {
+            if !task.parent_session_id.is_empty() {
+                task.parent_session_id.clone_from(&session_id);
+            }
+        }
+
+        self.validate_for_session(&session_id)?;
+        Ok(self)
+    }
+
     pub fn artifact_store(&self) -> ArtifactStore {
         artifact_store_from(&self.artifacts)
     }

--- a/core/src/store/tests.rs
+++ b/core/src/store/tests.rs
@@ -155,6 +155,31 @@ async fn create_test_snapshot() -> SessionSnapshotV1 {
     )
 }
 
+#[tokio::test]
+async fn snapshot_fork_rebinds_every_top_level_session_owner() {
+    let mut snapshot = create_test_snapshot().await;
+    for record in &mut snapshot.run_records {
+        record.snapshot.session_id = snapshot.session.id.clone();
+    }
+    snapshot.validate_for_session("test-session-1").unwrap();
+
+    let fork = snapshot
+        .fork_for_session("fork-session", "/tmp/fork-workspace")
+        .unwrap();
+
+    assert_eq!(fork.session.id, "fork-session");
+    assert_eq!(fork.session.config.workspace, "/tmp/fork-workspace");
+    assert!(fork
+        .run_records
+        .iter()
+        .all(|record| record.snapshot.session_id == "fork-session"));
+    assert!(fork
+        .subagent_tasks
+        .iter()
+        .all(|task| task.parent_session_id == "fork-session"));
+    fork.validate_for_session("fork-session").unwrap();
+}
+
 // ========================================================================
 // FileSessionStore Tests
 // ========================================================================


### PR DESCRIPTION
## Summary

- add `SessionSnapshotV1::fork_for_session` for rebinding a complete persisted generation to a new session id and workspace
- preserve artifacts, traces, run ids, verification reports, and child-session ids
- rebind top-level run ownership and non-empty subagent parent ownership so the fork remains loadable under existing invariants
- validate both the source and resulting snapshot, and reject empty destination session ids

## Why

The CLI recovery work for `/fork`, isolated worktree forks, and conflict-safe `/rewind` needs one canonical Core operation. Copying only `SessionData` would silently discard or mis-own the rest of the atomic session snapshot.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p a3s-code-core snapshot_fork_rebinds_every_top_level_session_owner`
- `git diff --check`

A focused dependent CLI PR will follow separately after this Core seam is available.
