### PR TITLE
fix(release): honor Code 6 API boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --lib --bins -- -D warnings
 
+      - name: Check public API compatibility with v5.3.5
+        run: |
+          cargo install cargo-semver-checks --version 0.48.0 --locked
+          bash scripts/check_semver.sh 5.3.5
+
       - name: Default tests
         run: cargo test --workspace
 
@@ -75,3 +80,26 @@ jobs:
 
       - name: Check Python SDK
         run: cargo check --manifest-path sdk/python/Cargo.toml
+
+  windows-check:
+    name: Windows check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup workspace context
+        shell: bash
+        run: bash .github/setup-workspace.sh
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy --workspace --lib --bins -- -D warnings
+
+      - name: Library tests
+        run: cargo test --workspace --lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.3.6] - 2026-07-19
+## [6.0.0] - 2026-07-19
 
 ### Added
 
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserved standard MCP tool metadata and call results end to end, including
   output schemas, annotations, icons, `_meta`, `structuredContent`, decoded
   images, embedded resources, and bounded content-addressed artifacts.
+
+### Changed
+
+- Raised the major version because the standard MCP metadata support extends
+  the public `McpTool` and `CallToolResult` structures with new fields.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ac
 
 [[package]]
 name = "a3s-code-core"
-version = "5.3.6"
+version = "6.0.0"
 dependencies = [
  "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
  "a3s-common",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "5.3.6"
+version = "6.0.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/code_intelligence/language_profile.rs
+++ b/core/src/code_intelligence/language_profile.rs
@@ -242,8 +242,7 @@ impl LanguageServerProfile {
                     && marker.kind == ProjectMarkerKind::CargoManifest
             })
             .map(|marker| {
-                canonical_root
-                    .join(marker.path.as_str())
+                join_workspace_path(canonical_root, &marker.path)
                     .to_string_lossy()
                     .replace('\\', "/")
             })
@@ -305,7 +304,7 @@ impl LanguageServerProfile {
                 if root.is_root() {
                     canonical_root.to_path_buf()
                 } else {
-                    canonical_root.join(root.as_str())
+                    join_workspace_path(canonical_root, &root)
                 }
             })
             .collect::<Vec<_>>();
@@ -332,10 +331,21 @@ impl LanguageServerProfile {
 
 fn typescript_package_roots(search_root: &Path) -> [PathBuf; 3] {
     [
-        search_root.join("node_modules/typescript"),
-        search_root.join(".yarn/sdks/typescript"),
-        search_root.join(".vscode/pnpify/typescript"),
+        search_root.join("node_modules").join("typescript"),
+        search_root.join(".yarn").join("sdks").join("typescript"),
+        search_root
+            .join(".vscode")
+            .join("pnpify")
+            .join("typescript"),
     ]
+}
+
+fn join_workspace_path(root: &Path, path: &WorkspacePath) -> PathBuf {
+    path.as_str()
+        .split('/')
+        .fold(root.to_path_buf(), |joined, component| {
+            joined.join(component)
+        })
 }
 
 fn push_unique_path(target: &mut Vec<PathBuf>, seen: &mut BTreeSet<PathBuf>, path: PathBuf) {
@@ -433,7 +443,7 @@ mod tests {
         tokio::fs::create_dir_all(package.join("lib"))
             .await
             .expect("create TypeScript SDK");
-        tokio::fs::write(package.join("lib/tsserver.js"), "")
+        tokio::fs::write(package.join("lib").join("tsserver.js"), "")
             .await
             .expect("write tsserver entry");
         tokio::fs::write(package.join("package.json"), r#"{"version":"5.9.3"}"#)
@@ -459,7 +469,7 @@ mod tests {
             launch.initialization_options,
             json!({
                 "tsserver": {
-                    "path": protocol_path(&package.join("lib/tsserver.js")),
+                    "path": protocol_path(&package.join("lib").join("tsserver.js")),
                 },
             })
         );
@@ -477,7 +487,7 @@ mod tests {
         tokio::fs::create_dir_all(package.join("lib"))
             .await
             .expect("create TypeScript SDK");
-        tokio::fs::write(package.join("lib/tsc.js"), "")
+        tokio::fs::write(package.join("lib").join("tsc.js"), "")
             .await
             .expect("write native TypeScript entry");
         tokio::fs::write(package.join("package.json"), r#"{"version":"7.0.2"}"#)
@@ -498,7 +508,7 @@ mod tests {
         assert_eq!(
             launch.command.args,
             [
-                package.join("lib/tsc.js").into_os_string(),
+                package.join("lib").join("tsc.js").into_os_string(),
                 OsString::from("--lsp"),
                 OsString::from("--stdio"),
             ]
@@ -509,13 +519,18 @@ mod tests {
     #[tokio::test]
     async fn workspace_typescript_prefers_package_sdk_over_hoisted_sdk() {
         let workspace = tempfile::tempdir().expect("temporary workspace");
-        let hoisted = workspace.path().join("node_modules/typescript");
-        let local = workspace.path().join("packages/ui/node_modules/typescript");
+        let hoisted = workspace.path().join("node_modules").join("typescript");
+        let local = workspace
+            .path()
+            .join("packages")
+            .join("ui")
+            .join("node_modules")
+            .join("typescript");
         for package in [&hoisted, &local] {
             tokio::fs::create_dir_all(package.join("lib"))
                 .await
                 .expect("create TypeScript SDK");
-            tokio::fs::write(package.join("lib/tsserver.js"), "")
+            tokio::fs::write(package.join("lib").join("tsserver.js"), "")
                 .await
                 .expect("write tsserver entry");
             tokio::fs::write(package.join("package.json"), r#"{"version":"5.9.3"}"#)
@@ -535,7 +550,7 @@ mod tests {
 
         assert_eq!(
             launch.initialization_options["tsserver"]["path"],
-            protocol_path(&local.join("lib/tsserver.js"))
+            protocol_path(&local.join("lib").join("tsserver.js"))
         );
     }
 

--- a/core/src/code_intelligence/language_profile.rs
+++ b/core/src/code_intelligence/language_profile.rs
@@ -424,7 +424,12 @@ mod tests {
     #[tokio::test]
     async fn built_in_typescript_uses_nested_classic_sdk() {
         let workspace = tempfile::tempdir().expect("temporary workspace");
-        let package = workspace.path().join("apps/web/node_modules/typescript");
+        let package = workspace
+            .path()
+            .join("apps")
+            .join("web")
+            .join("node_modules")
+            .join("typescript");
         tokio::fs::create_dir_all(package.join("lib"))
             .await
             .expect("create TypeScript SDK");
@@ -463,7 +468,12 @@ mod tests {
     #[tokio::test]
     async fn built_in_typescript_uses_nested_native_sdk() {
         let workspace = tempfile::tempdir().expect("temporary workspace");
-        let package = workspace.path().join("apps/web/node_modules/typescript");
+        let package = workspace
+            .path()
+            .join("apps")
+            .join("web")
+            .join("node_modules")
+            .join("typescript");
         tokio::fs::create_dir_all(package.join("lib"))
             .await
             .expect("create TypeScript SDK");

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -15,7 +15,7 @@ source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ac
 
 [[package]]
 name = "a3s-code-core"
-version = "5.3.6"
+version = "6.0.0"
 dependencies = [
  "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
  "a3s-common",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "5.3.6"
+version = "6.0.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "5.3.6"
+version = "6.0.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "5.3.6", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.0.0", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "5.3.6",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "5.3.6",
-        "@a3s-lab/code-linux-arm64-gnu": "5.3.6",
-        "@a3s-lab/code-linux-arm64-musl": "5.3.6",
-        "@a3s-lab/code-linux-x64-gnu": "5.3.6",
-        "@a3s-lab/code-linux-x64-musl": "5.3.6",
-        "@a3s-lab/code-win32-x64-msvc": "5.3.6"
+        "@a3s-lab/code-darwin-arm64": "6.0.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.0.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.0.0",
+        "@a3s-lab/code-linux-x64-musl": "6.0.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.0.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "5.3.6",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "5.3.6",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "5.3.6",
-        "@a3s-lab/code-linux-arm64-gnu": "5.3.6",
-        "@a3s-lab/code-linux-arm64-musl": "5.3.6",
-        "@a3s-lab/code-linux-x64-gnu": "5.3.6",
-        "@a3s-lab/code-linux-x64-musl": "5.3.6",
-        "@a3s-lab/code-win32-x64-msvc": "5.3.6"
+        "@a3s-lab/code-darwin-arm64": "6.0.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.0.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.0.0",
+        "@a3s-lab/code-linux-x64-musl": "6.0.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.0.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "5.3.6",
+  "version": "6.0.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "5.3.6",
-    "@a3s-lab/code-linux-x64-gnu": "5.3.6",
-    "@a3s-lab/code-linux-x64-musl": "5.3.6",
-    "@a3s-lab/code-linux-arm64-gnu": "5.3.6",
-    "@a3s-lab/code-linux-arm64-musl": "5.3.6",
-    "@a3s-lab/code-win32-x64-msvc": "5.3.6"
+    "@a3s-lab/code-darwin-arm64": "6.0.0",
+    "@a3s-lab/code-linux-x64-gnu": "6.0.0",
+    "@a3s-lab/code-linux-x64-musl": "6.0.0",
+    "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
+    "@a3s-lab/code-linux-arm64-musl": "6.0.0",
+    "@a3s-lab/code-win32-x64-msvc": "6.0.0"
   }
 }

--- a/sdk/python-bootstrap/README.md
+++ b/sdk/python-bootstrap/README.md
@@ -44,4 +44,4 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `5.3.6`.
+Replace `<VERSION>` with the release to install, for example `6.0.0`.

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "5.3.6"
+version = "6.0.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "5.3.6"
+__version__ = "6.0.0"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
-## [5.3.6] - 2026-07-19
+## [6.0.0] - 2026-07-19
 
 ### Changed
 
 - Updated the bundled Core with expanded TypeScript language profiles, PDF
   fetching, invariant-safe session forks, typed MCP results and artifacts,
   delegated permission boundaries, and tool-free standalone greetings.
+- Raised the major version with Core's public standard MCP metadata fields.
 
 ## [5.3.5] - 2026-07-17
 

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -15,7 +15,7 @@ source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ac
 
 [[package]]
 name = "a3s-code-core"
-version = "5.3.6"
+version = "6.0.0"
 dependencies = [
  "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
  "a3s-common",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "5.3.6"
+version = "6.0.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "5.3.6"
+version = "6.0.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "5.3.6", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.0.0", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -28,7 +28,7 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `5.3.6`.
+Replace `<VERSION>` with the release to install, for example `6.0.0`.
 
 ## Quick Start
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "5.3.6"
+version = "6.0.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- release the integrated MCP protocol expansion as 6.0.0 because it adds fields to public constructible Rust structs
- fix the nested TypeScript native-SDK test to construct platform-native paths on Windows
- run the SemVer comparison and Windows library suite on pull requests so release-only failures are caught before tagging
- retain the failed v5.3.6 tag as immutable history; no release artifacts were published from it

## Validation

- `scripts/check_release_versions.sh 6.0.0`
- `cargo fmt --all -- --check`
- targeted nested native TypeScript SDK test after the standalone workspace setup
- `bash scripts/check_semver.sh 5.3.5` (verified as a major change)
- `git diff --check`

The new PR checks provide the authoritative Windows and full CI evidence before merge.