### PR TITLE
feat(release): define immutable Agent manifest contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a closed, bounded `.a3s/asset.acl` Agent release contract with immutable
+  OCI and provenance digests, static entrypoint and health declarations, typed
+  storage boundaries, schema-aware canonical identity, and pre-activation
+  protocol and capability checks.
+
+### Security
+
+- Restricted release secret requirements to unique environment or
+  `/run/secrets/` injection slots, rejected embedded values and ambiguous
+  destinations, and kept admission diagnostics from echoing manifest values.
+
 ## [6.0.0] - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,19 @@ checksum = "35b83be97f61abdd33096446eae063f9d65d98e84c446560b59d3c744194287e"
 
 [[package]]
 name = "a3s-acl"
-version = "0.2.1"
-source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22#6e2a6469edc0f4c61b1e588d0ace873aaf15ce22"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add06e627b80ea0d3f6de5ecfb2708cfcf4c6d022806ae33aec0905aeffde3ce"
+dependencies = [
+ "ryu-js",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "a3s-code-core"
 version = "6.0.0"
 dependencies = [
- "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
+ "a3s-acl 0.3.0",
  "a3s-common",
  "a3s-flow",
  "a3s-lane",
@@ -149,7 +154,7 @@ dependencies = [
 name = "a3s-search"
 version = "1.4.3"
 dependencies = [
- "a3s-acl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "a3s-acl 0.2.1",
  "a3s-updater",
  "a3s-use-browser",
  "anyhow",
@@ -4423,6 +4428,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ the session for its next transcript operation.
   explicitly registered A3S Flow-backed dynamic workflows
 - **Durable Evidence**: Persist atomic snapshots, versioned events, traces,
   artifacts, verification reports, checkpoints, and optional RL trajectories
+- **Immutable Release Admission**: Validate bounded `.a3s/asset.acl` manifests,
+  derive schema-aware identities, and reject incompatible runtime capabilities
+  before activation
 - **Event-Sourced State Graph**: Coordinate typed objects and relations through
   hash-linked records, optimistic patches, strict replay, forks, and diffs
 
@@ -116,6 +119,7 @@ explicit even when the supporting types are available.
 | MCP | Config or session registration | stdio, SSE, streamable HTTP, OAuth, refresh, and live add/remove management |
 | Skills | Filesystem, registry, or live session registration | Search/execute tools, model-visible catalog, live add/remove with shadow restoration, and child-run inheritance |
 | Search runtime | Explicit host operation | Browser status, install, update, and repair APIs for managed search runtimes |
+| Agent release contract | Baseline admission API | Closed, bounded manifest validation, immutable OCI/provenance binding, canonical identity, typed storage and secret slots, and pre-activation compatibility checks |
 | S3 workspace | Cargo feature `s3` | S3-compatible object storage backend with capability-aware tool visibility |
 | Agent daemon | Cargo feature `serve` | Filesystem-first agent serving and cron schedules |
 | OpenTelemetry | Cargo feature `telemetry` | OTLP trace export; normal `tracing` remains available without it |
@@ -210,6 +214,19 @@ sources asynchronously. Synchronous constructors remain compatibility APIs for
 already initialized resources and never start or block a Tokio runtime.
 
 ## Application Model
+
+### Release admission and identity
+
+`AgentReleaseManifest` admits the versioned `.a3s/asset.acl` contract, returns
+schema-aware canonical ACL and its SHA-256 identity, and verifies an
+`AgentReleaseCompatibility` before activation. Secret declarations are typed
+injection slots only; values and external secret identifiers remain outside
+the release document.
+
+This API does not build or run the declared OCI artifact and does not implement
+its readiness, liveness, or shutdown behavior. See the
+[Agent Release Contract](manual/AGENT_RELEASE_CONTRACT.md) for the complete v1
+schema, compatibility policy, security boundary, and fixture status.
 
 ### Sessions and lifecycle
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 
 # ACL config parsing
-a3s-acl = { git = "https://github.com/A3S-Lab/ACL.git", rev = "6e2a6469edc0f4c61b1e588d0ace873aaf15ce22", version = "0.2.1" }
+a3s-acl = "=0.3.0"
 
 # Error handling
 anyhow = "1.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -103,6 +103,7 @@ pub mod planning;
 pub mod program;
 pub(crate) mod prompts;
 pub mod queue;
+pub mod release;
 pub mod retention;
 pub(crate) mod retry;
 pub mod rl_trajectory;

--- a/core/src/release/error.rs
+++ b/core/src/release/error.rs
@@ -1,0 +1,202 @@
+use a3s_acl::{CanonicalError, ParseError, SchemaDiagnosticCode};
+use std::fmt;
+
+/// Typed Agent release field used by value-redacting admission errors.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReleaseField {
+    Contract,
+    Protocol,
+    ArtifactDigest,
+    ArtifactMediaType,
+    EntrypointCommand,
+    EntrypointArgument,
+    HealthTransport,
+    HealthPort,
+    ReadinessPath,
+    LivenessPath,
+    ShutdownGraceSeconds,
+    WorkspaceMode,
+    CacheMode,
+    PersistentDataMode,
+    CapabilityName,
+    CapabilityLevel,
+    SecretName,
+    SecretTarget,
+    SecretDestination,
+    ProvenanceKind,
+    ProvenanceUri,
+    ProvenanceDigest,
+}
+
+impl fmt::Display for AgentReleaseField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Contract => "agent_release.schema",
+            Self::Protocol => "agent_release.protocol",
+            Self::ArtifactDigest => "agent_release.artifact.digest",
+            Self::ArtifactMediaType => "agent_release.artifact.media_type",
+            Self::EntrypointCommand => "agent_release.entrypoint.command",
+            Self::EntrypointArgument => "agent_release.entrypoint.args",
+            Self::HealthTransport => "agent_release.health.transport",
+            Self::HealthPort => "agent_release.health.port",
+            Self::ReadinessPath => "agent_release.health.readiness_path",
+            Self::LivenessPath => "agent_release.health.liveness_path",
+            Self::ShutdownGraceSeconds => "agent_release.health.shutdown_grace_seconds",
+            Self::WorkspaceMode => "agent_release.storage.workspace",
+            Self::CacheMode => "agent_release.storage.cache",
+            Self::PersistentDataMode => "agent_release.storage.persistent_data",
+            Self::CapabilityName => "agent_release.capability.name",
+            Self::CapabilityLevel => "agent_release.capability.level",
+            Self::SecretName => "agent_release.secret.name",
+            Self::SecretTarget => "agent_release.secret.target",
+            Self::SecretDestination => "agent_release.secret.destination",
+            Self::ProvenanceKind => "agent_release.provenance.kind",
+            Self::ProvenanceUri => "agent_release.provenance.uri",
+            Self::ProvenanceDigest => "agent_release.provenance.digest",
+        })
+    }
+}
+
+/// Stable, value-redacting failure returned by Agent release admission.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum AgentReleaseError {
+    Io(std::io::Error),
+    InputTooLarge,
+    InvalidEncoding,
+    Parse(ParseError),
+    Schema {
+        diagnostic: SchemaDiagnosticCode,
+        truncated: bool,
+    },
+    SchemaBudgetExceeded,
+    Canonical(CanonicalError),
+    CanonicalEncoding,
+    UnsupportedContract,
+    InvalidField(AgentReleaseField),
+    DuplicateCapability,
+    DuplicateSecret,
+    DuplicateProvenance,
+    IncompatibleProtocol,
+    UnsupportedCapability {
+        required_index: usize,
+    },
+}
+
+impl AgentReleaseError {
+    /// Stable machine-readable error code.
+    pub const fn code(&self) -> &'static str {
+        match self {
+            Self::Io(_) => "a3s.code.agent_release.io",
+            Self::InputTooLarge | Self::InvalidEncoding | Self::Parse(_) => {
+                "a3s.code.agent_release.parse"
+            }
+            Self::Schema { .. } | Self::SchemaBudgetExceeded => "a3s.code.agent_release.schema",
+            Self::Canonical(_) | Self::CanonicalEncoding => "a3s.code.agent_release.canonical",
+            Self::UnsupportedContract => "a3s.code.agent_release.unsupported_contract",
+            Self::InvalidField(_) => "a3s.code.agent_release.invalid_field",
+            Self::DuplicateCapability => "a3s.code.agent_release.duplicate_capability",
+            Self::DuplicateSecret => "a3s.code.agent_release.duplicate_secret",
+            Self::DuplicateProvenance => "a3s.code.agent_release.duplicate_provenance",
+            Self::IncompatibleProtocol => "a3s.code.agent_release.incompatible_protocol",
+            Self::UnsupportedCapability { .. } => "a3s.code.agent_release.unsupported_capability",
+        }
+    }
+
+    /// Invalid semantic field, when this is an `invalid_field` error.
+    pub const fn field(&self) -> Option<AgentReleaseField> {
+        match self {
+            Self::InvalidField(field) => Some(*field),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for AgentReleaseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "could not read Agent release manifest: {error}"),
+            Self::InputTooLarge => {
+                formatter.write_str("Agent release manifest exceeds its input budget")
+            }
+            Self::InvalidEncoding => {
+                formatter.write_str("Agent release manifest must be valid UTF-8")
+            }
+            Self::Parse(error) => write!(formatter, "Agent release manifest parse failed: {error}"),
+            Self::Schema {
+                diagnostic,
+                truncated,
+            } => {
+                write!(
+                    formatter,
+                    "Agent release manifest schema rejected the document ({diagnostic})"
+                )?;
+                if *truncated {
+                    formatter.write_str("; additional diagnostics were truncated")?;
+                }
+                Ok(())
+            }
+            Self::SchemaBudgetExceeded => {
+                formatter.write_str("Agent release schema diagnostics exceeded their budget")
+            }
+            Self::Canonical(error) => {
+                write!(formatter, "Agent release canonicalization failed: {error}")
+            }
+            Self::CanonicalEncoding => {
+                formatter.write_str("Agent release canonical bytes are not UTF-8")
+            }
+            Self::UnsupportedContract => {
+                formatter.write_str("Agent release contract version is not supported")
+            }
+            Self::InvalidField(field) => {
+                write!(formatter, "Agent release field {field} is invalid")
+            }
+            Self::DuplicateCapability => {
+                formatter.write_str("Agent release capability requirements must be unique")
+            }
+            Self::DuplicateSecret => {
+                formatter.write_str("Agent release secret requirements must be unique")
+            }
+            Self::DuplicateProvenance => {
+                formatter.write_str("Agent release provenance kinds must be unique")
+            }
+            Self::IncompatibleProtocol => {
+                formatter.write_str("Agent release protocol is not supported by the runtime")
+            }
+            Self::UnsupportedCapability { required_index } => write!(
+                formatter,
+                "Agent release capability requirement at index {required_index} is unavailable"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AgentReleaseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Parse(error) => Some(error),
+            Self::Canonical(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for AgentReleaseError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<ParseError> for AgentReleaseError {
+    fn from(error: ParseError) -> Self {
+        Self::Parse(error)
+    }
+}
+
+impl From<CanonicalError> for AgentReleaseError {
+    fn from(error: CanonicalError) -> Self {
+        Self::Canonical(error)
+    }
+}

--- a/core/src/release/manifest.rs
+++ b/core/src/release/manifest.rs
@@ -1,0 +1,216 @@
+use super::schema::release_schema;
+use super::types::{
+    AgentReleaseArtifact, AgentReleaseCapability, AgentReleaseCompatibility,
+    AgentReleaseEntrypoint, AgentReleaseHealth, AgentReleaseProvenance,
+    AgentReleaseSecretRequirement, AgentReleaseStorage,
+};
+use super::validation::{
+    parse_artifact, parse_capability, parse_entrypoint, parse_health, parse_provenance,
+    parse_secret, parse_storage, required_block, required_string, unique_capabilities,
+    unique_provenance, unique_secrets, validate_protocol,
+};
+use super::{
+    AgentReleaseError, AgentReleaseField, AGENT_RELEASE_CONTRACT_V1, AGENT_RELEASE_LIMITS,
+};
+use a3s_acl::{
+    canonical_bytes_with_schema, canonical_digest_with_schema, parse_with_limits,
+    validate_document_with_limits,
+};
+use std::io::Read;
+use std::path::Path;
+
+/// Admitted, canonical Agent release manifest.
+#[derive(Debug, Clone)]
+pub struct AgentReleaseManifest {
+    contract: String,
+    protocol: String,
+    artifact: AgentReleaseArtifact,
+    entrypoint: AgentReleaseEntrypoint,
+    health: AgentReleaseHealth,
+    storage: AgentReleaseStorage,
+    required_capabilities: Vec<AgentReleaseCapability>,
+    required_secrets: Vec<AgentReleaseSecretRequirement>,
+    provenance: Vec<AgentReleaseProvenance>,
+    identity: String,
+    canonical_acl: String,
+}
+
+impl AgentReleaseManifest {
+    /// Parse, admit, and canonicalize one untrusted `.a3s/asset.acl` document.
+    pub fn parse(source: &str) -> Result<Self, AgentReleaseError> {
+        let document = parse_with_limits(source, AGENT_RELEASE_LIMITS)?;
+        let schema = release_schema();
+        let report = validate_document_with_limits(&document, &schema, AGENT_RELEASE_LIMITS);
+        if !report.is_empty() {
+            let Some(diagnostic) = report.diagnostics.first() else {
+                return Err(AgentReleaseError::SchemaBudgetExceeded);
+            };
+            return Err(AgentReleaseError::Schema {
+                diagnostic: diagnostic.code,
+                truncated: report.truncated,
+            });
+        }
+
+        let root = required_block(
+            &document.blocks,
+            "agent_release",
+            AgentReleaseField::Contract,
+        )?;
+        let contract = required_string(root, "schema", AgentReleaseField::Contract)?;
+        if contract != AGENT_RELEASE_CONTRACT_V1 {
+            return Err(AgentReleaseError::UnsupportedContract);
+        }
+
+        let protocol = required_string(root, "protocol", AgentReleaseField::Protocol)?;
+        validate_protocol(&protocol)?;
+
+        let artifact = parse_artifact(required_block(
+            &root.blocks,
+            "artifact",
+            AgentReleaseField::ArtifactDigest,
+        )?)?;
+        let entrypoint = parse_entrypoint(required_block(
+            &root.blocks,
+            "entrypoint",
+            AgentReleaseField::EntrypointCommand,
+        )?)?;
+        let health = parse_health(required_block(
+            &root.blocks,
+            "health",
+            AgentReleaseField::HealthTransport,
+        )?)?;
+        let storage = parse_storage(required_block(
+            &root.blocks,
+            "storage",
+            AgentReleaseField::WorkspaceMode,
+        )?)?;
+
+        let required_capabilities = unique_capabilities(
+            root.blocks
+                .iter()
+                .filter(|block| block.name == "capability")
+                .map(parse_capability)
+                .collect::<Result<Vec<_>, _>>()?,
+        )?;
+        let required_secrets = unique_secrets(
+            root.blocks
+                .iter()
+                .filter(|block| block.name == "secret")
+                .map(parse_secret)
+                .collect::<Result<Vec<_>, _>>()?,
+        )?;
+        if !required_secrets.is_empty()
+            && !required_capabilities
+                .iter()
+                .any(|capability| capability.name == "secrets.external")
+        {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::CapabilityName,
+            ));
+        }
+        let provenance = unique_provenance(
+            root.blocks
+                .iter()
+                .filter(|block| block.name == "provenance")
+                .map(parse_provenance)
+                .collect::<Result<Vec<_>, _>>()?,
+        )?;
+
+        let canonical_acl = String::from_utf8(canonical_bytes_with_schema(&document, &schema)?)
+            .map_err(|_| AgentReleaseError::CanonicalEncoding)?;
+        let identity = canonical_digest_with_schema(&document, &schema)?;
+
+        Ok(Self {
+            contract,
+            protocol,
+            artifact,
+            entrypoint,
+            health,
+            storage,
+            required_capabilities,
+            required_secrets,
+            provenance,
+            identity,
+            canonical_acl,
+        })
+    }
+
+    /// Read at most the manifest budget plus one byte before parsing.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, AgentReleaseError> {
+        let file = std::fs::File::open(path)?;
+        let mut bytes = Vec::new();
+        file.take(AGENT_RELEASE_LIMITS.max_document_bytes as u64 + 1)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > AGENT_RELEASE_LIMITS.max_document_bytes {
+            return Err(AgentReleaseError::InputTooLarge);
+        }
+        let source = std::str::from_utf8(&bytes).map_err(|_| AgentReleaseError::InvalidEncoding)?;
+        Self::parse(source)
+    }
+
+    pub fn contract(&self) -> &str {
+        &self.contract
+    }
+
+    pub fn protocol(&self) -> &str {
+        &self.protocol
+    }
+
+    pub fn artifact(&self) -> &AgentReleaseArtifact {
+        &self.artifact
+    }
+
+    pub fn entrypoint(&self) -> &AgentReleaseEntrypoint {
+        &self.entrypoint
+    }
+
+    pub fn health(&self) -> &AgentReleaseHealth {
+        &self.health
+    }
+
+    pub fn storage(&self) -> &AgentReleaseStorage {
+        &self.storage
+    }
+
+    pub fn required_capabilities(&self) -> &[AgentReleaseCapability] {
+        &self.required_capabilities
+    }
+
+    pub fn required_secrets(&self) -> &[AgentReleaseSecretRequirement] {
+        &self.required_secrets
+    }
+
+    pub fn provenance(&self) -> &[AgentReleaseProvenance] {
+        &self.provenance
+    }
+
+    /// Lowercase SHA-256 digest of the schema-aware canonical ACL bytes.
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+
+    /// Schema-aware canonical ACL bytes as UTF-8 with one final newline.
+    pub fn canonical_acl(&self) -> &str {
+        &self.canonical_acl
+    }
+
+    /// Fail before activation unless protocol and every required capability match.
+    pub fn verify_compatibility(
+        &self,
+        available: &AgentReleaseCompatibility,
+    ) -> Result<(), AgentReleaseError> {
+        if self.protocol != available.protocol {
+            return Err(AgentReleaseError::IncompatibleProtocol);
+        }
+        for (required_index, required) in self.required_capabilities.iter().enumerate() {
+            let supported = available
+                .capabilities
+                .iter()
+                .find(|capability| capability.name == required.name);
+            if supported.is_none_or(|capability| capability.level < required.level) {
+                return Err(AgentReleaseError::UnsupportedCapability { required_index });
+            }
+        }
+        Ok(())
+    }
+}

--- a/core/src/release/mod.rs
+++ b/core/src/release/mod.rs
@@ -1,0 +1,43 @@
+//! Immutable, bounded Agent release manifests.
+//!
+//! This module owns admission and identity for `.a3s/asset.acl`. It does not
+//! start an Agent daemon or claim that a Runtime Service is ready.
+
+mod error;
+mod manifest;
+mod schema;
+mod types;
+mod validation;
+
+pub use error::{AgentReleaseError, AgentReleaseField};
+pub use manifest::AgentReleaseManifest;
+pub use types::{
+    AgentReleaseArtifact, AgentReleaseCacheMode, AgentReleaseCapability, AgentReleaseCompatibility,
+    AgentReleaseEntrypoint, AgentReleaseHealth, AgentReleasePersistentDataMode,
+    AgentReleaseProvenance, AgentReleaseSecretRequirement, AgentReleaseSecretTarget,
+    AgentReleaseStorage, AgentReleaseWorkspaceMode,
+};
+
+use a3s_acl::ParseLimits;
+
+/// Versioned ACL schema identifier accepted by this release contract.
+pub const AGENT_RELEASE_CONTRACT_V1: &str = "a3s.code.agent-release.v1";
+
+/// Version-one headless Agent request protocol identifier.
+pub const AGENT_PROTOCOL_V1: &str = "a3s.code.agent.v1";
+
+/// OCI image-manifest media type accepted by the version-one artifact contract.
+pub const AGENT_RELEASE_OCI_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
+/// Limits applied before an untrusted Agent release manifest is admitted.
+pub const AGENT_RELEASE_LIMITS: ParseLimits = ParseLimits {
+    max_document_bytes: 64 * 1024,
+    max_nesting_depth: 8,
+    max_collection_items: 256,
+    max_token_bytes: 8 * 1024,
+    max_diagnostics: 20,
+};
+
+pub(crate) const MAX_CAPABILITY_LEVEL: u32 = 65_535;
+pub(crate) const MAX_ENTRYPOINT_ARGS: usize = 64;
+pub(crate) const MAX_SHUTDOWN_GRACE_SECONDS: u32 = 3_600;

--- a/core/src/release/schema.rs
+++ b/core/src/release/schema.rs
@@ -1,0 +1,99 @@
+use a3s_acl::{AttributeSchema, BlockSchema, Cardinality, Schema, ValueSchema};
+
+pub(crate) fn release_schema() -> Schema {
+    let artifact = Schema::new()
+        .attribute("digest", AttributeSchema::required(ValueSchema::string()))
+        .attribute(
+            "media_type",
+            AttributeSchema::required(ValueSchema::string()),
+        );
+    let entrypoint = Schema::new()
+        .attribute("command", AttributeSchema::required(ValueSchema::string()))
+        .attribute(
+            "args",
+            AttributeSchema::required(ValueSchema::list(ValueSchema::string())),
+        );
+    let health = Schema::new()
+        .attribute(
+            "transport",
+            AttributeSchema::required(ValueSchema::string()),
+        )
+        .attribute("port", AttributeSchema::required(ValueSchema::number()))
+        .attribute(
+            "readiness_path",
+            AttributeSchema::required(ValueSchema::string()),
+        )
+        .attribute(
+            "liveness_path",
+            AttributeSchema::required(ValueSchema::string()),
+        )
+        .attribute(
+            "shutdown_grace_seconds",
+            AttributeSchema::required(ValueSchema::number()),
+        );
+    let storage = Schema::new()
+        .attribute(
+            "workspace",
+            AttributeSchema::required(ValueSchema::string()),
+        )
+        .attribute("cache", AttributeSchema::required(ValueSchema::string()))
+        .attribute(
+            "persistent_data",
+            AttributeSchema::required(ValueSchema::string()),
+        );
+    let capability =
+        Schema::new().attribute("level", AttributeSchema::required(ValueSchema::number()));
+    let secret = Schema::new()
+        .attribute("target", AttributeSchema::required(ValueSchema::string()))
+        .attribute(
+            "destination",
+            AttributeSchema::required(ValueSchema::string()),
+        );
+    let provenance = Schema::new()
+        .attribute("uri", AttributeSchema::required(ValueSchema::string()))
+        .attribute("digest", AttributeSchema::required(ValueSchema::string()));
+    let release = Schema::new()
+        .attribute("schema", AttributeSchema::required(ValueSchema::string()))
+        .attribute("protocol", AttributeSchema::required(ValueSchema::string()))
+        .block(
+            "artifact",
+            BlockSchema::new(artifact).occurrences(Cardinality::exactly(1)),
+        )
+        .block(
+            "entrypoint",
+            BlockSchema::new(entrypoint).occurrences(Cardinality::exactly(1)),
+        )
+        .block(
+            "health",
+            BlockSchema::new(health).occurrences(Cardinality::exactly(1)),
+        )
+        .block(
+            "storage",
+            BlockSchema::new(storage).occurrences(Cardinality::exactly(1)),
+        )
+        .block(
+            "capability",
+            BlockSchema::new(capability)
+                .occurrences(Cardinality::at_least(1))
+                .labels(Cardinality::exactly(1))
+                .unordered(true),
+        )
+        .block(
+            "secret",
+            BlockSchema::new(secret)
+                .occurrences(Cardinality::at_least(0))
+                .labels(Cardinality::exactly(1))
+                .unordered(true),
+        )
+        .block(
+            "provenance",
+            BlockSchema::new(provenance)
+                .occurrences(Cardinality::at_least(1))
+                .labels(Cardinality::exactly(1))
+                .unordered(true),
+        );
+    Schema::new().block(
+        "agent_release",
+        BlockSchema::new(release).occurrences(Cardinality::exactly(1)),
+    )
+}

--- a/core/src/release/types.rs
+++ b/core/src/release/types.rs
@@ -1,0 +1,260 @@
+use super::validation::{unique_capabilities, validate_dotted_name, validate_protocol};
+use super::{AgentReleaseError, AgentReleaseField, MAX_CAPABILITY_LEVEL};
+
+/// Immutable artifact metadata covered by the Agent release identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseArtifact {
+    pub(crate) digest: String,
+    pub(crate) media_type: String,
+}
+
+impl AgentReleaseArtifact {
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    pub fn media_type(&self) -> &str {
+        &self.media_type
+    }
+}
+
+/// Static container entrypoint covered by the Agent release identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseEntrypoint {
+    pub(crate) command: String,
+    pub(crate) args: Vec<String>,
+}
+
+impl AgentReleaseEntrypoint {
+    pub fn command(&self) -> &str {
+        &self.command
+    }
+
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+}
+
+/// Bounded health and shutdown contract declared by one release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseHealth {
+    pub(crate) transport: String,
+    pub(crate) port: u16,
+    pub(crate) readiness_path: String,
+    pub(crate) liveness_path: String,
+    pub(crate) shutdown_grace_seconds: u32,
+}
+
+impl AgentReleaseHealth {
+    pub fn transport(&self) -> &str {
+        &self.transport
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn readiness_path(&self) -> &str {
+        &self.readiness_path
+    }
+
+    pub fn liveness_path(&self) -> &str {
+        &self.liveness_path
+    }
+
+    pub fn shutdown_grace_seconds(&self) -> u32 {
+        self.shutdown_grace_seconds
+    }
+}
+
+/// Writable workspace boundary declared by one release.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReleaseWorkspaceMode {
+    ReadOnly,
+    Ephemeral,
+}
+
+impl AgentReleaseWorkspaceMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::Ephemeral => "ephemeral",
+        }
+    }
+}
+
+/// Cache lifetime declared by one release.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReleaseCacheMode {
+    None,
+    Ephemeral,
+}
+
+impl AgentReleaseCacheMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Ephemeral => "ephemeral",
+        }
+    }
+}
+
+/// Persistent-data ownership declared by one release.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReleasePersistentDataMode {
+    None,
+    External,
+}
+
+impl AgentReleasePersistentDataMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::External => "external",
+        }
+    }
+}
+
+/// Explicit workspace, cache, and persistent-data boundaries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseStorage {
+    pub(crate) workspace: AgentReleaseWorkspaceMode,
+    pub(crate) cache: AgentReleaseCacheMode,
+    pub(crate) persistent_data: AgentReleasePersistentDataMode,
+}
+
+impl AgentReleaseStorage {
+    pub const fn workspace(&self) -> AgentReleaseWorkspaceMode {
+        self.workspace
+    }
+
+    pub const fn cache(&self) -> AgentReleaseCacheMode {
+        self.cache
+    }
+
+    pub const fn persistent_data(&self) -> AgentReleasePersistentDataMode {
+        self.persistent_data
+    }
+}
+
+/// Injection surface for a secret requirement.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentReleaseSecretTarget {
+    Environment,
+    File,
+}
+
+impl AgentReleaseSecretTarget {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::File => "file",
+        }
+    }
+}
+
+/// Named secret slot. It declares no external secret identifier or value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseSecretRequirement {
+    pub(crate) name: String,
+    pub(crate) target: AgentReleaseSecretTarget,
+    pub(crate) destination: String,
+}
+
+impl AgentReleaseSecretRequirement {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn target(&self) -> AgentReleaseSecretTarget {
+        self.target
+    }
+
+    pub fn destination(&self) -> &str {
+        &self.destination
+    }
+}
+
+/// One versioned capability required or provided by an Agent runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseCapability {
+    pub(crate) name: String,
+    pub(crate) level: u32,
+}
+
+impl AgentReleaseCapability {
+    pub fn new(name: impl Into<String>, level: u32) -> Result<Self, AgentReleaseError> {
+        let name = name.into();
+        validate_dotted_name(&name, AgentReleaseField::CapabilityName)?;
+        if !(1..=MAX_CAPABILITY_LEVEL).contains(&level) {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::CapabilityLevel,
+            ));
+        }
+        Ok(Self { name, level })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn level(&self) -> u32 {
+        self.level
+    }
+}
+
+/// One immutable, digest-bound provenance reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseProvenance {
+    pub(crate) kind: String,
+    pub(crate) uri: String,
+    pub(crate) digest: String,
+}
+
+impl AgentReleaseProvenance {
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+}
+
+/// Runtime protocol and capability levels available before activation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentReleaseCompatibility {
+    pub(crate) protocol: String,
+    pub(crate) capabilities: Vec<AgentReleaseCapability>,
+}
+
+impl AgentReleaseCompatibility {
+    pub fn new(
+        protocol: impl Into<String>,
+        capabilities: impl IntoIterator<Item = AgentReleaseCapability>,
+    ) -> Result<Self, AgentReleaseError> {
+        let protocol = protocol.into();
+        validate_protocol(&protocol)?;
+        let capabilities = unique_capabilities(capabilities)?;
+        Ok(Self {
+            protocol,
+            capabilities,
+        })
+    }
+
+    pub fn protocol(&self) -> &str {
+        &self.protocol
+    }
+
+    pub fn capabilities(&self) -> &[AgentReleaseCapability] {
+        &self.capabilities
+    }
+}

--- a/core/src/release/validation.rs
+++ b/core/src/release/validation.rs
@@ -1,0 +1,428 @@
+use super::types::{
+    AgentReleaseArtifact, AgentReleaseCacheMode, AgentReleaseCapability, AgentReleaseEntrypoint,
+    AgentReleaseHealth, AgentReleasePersistentDataMode, AgentReleaseProvenance,
+    AgentReleaseSecretRequirement, AgentReleaseSecretTarget, AgentReleaseStorage,
+    AgentReleaseWorkspaceMode,
+};
+use super::{
+    AgentReleaseError, AgentReleaseField, AGENT_RELEASE_OCI_MEDIA_TYPE, MAX_CAPABILITY_LEVEL,
+    MAX_ENTRYPOINT_ARGS, MAX_SHUTDOWN_GRACE_SECONDS,
+};
+use a3s_acl::{Block, Value};
+use std::collections::{BTreeMap, BTreeSet};
+use url::Url;
+
+const MAX_COMMAND_BYTES: usize = 1_024;
+const MAX_ENTRYPOINT_ARGUMENT_BYTES: usize = 4_096;
+const MAX_HEALTH_PATH_BYTES: usize = 256;
+const MAX_NAME_BYTES: usize = 128;
+const MAX_PROVENANCE_URI_BYTES: usize = 2_048;
+const MAX_SECRET_DESTINATION_BYTES: usize = 256;
+const SECRET_FILE_PREFIX: &str = "/run/secrets/";
+
+pub(crate) fn parse_artifact(block: &Block) -> Result<AgentReleaseArtifact, AgentReleaseError> {
+    let digest = required_string(block, "digest", AgentReleaseField::ArtifactDigest)?;
+    validate_digest(&digest, AgentReleaseField::ArtifactDigest)?;
+    let media_type = required_string(block, "media_type", AgentReleaseField::ArtifactMediaType)?;
+    if media_type != AGENT_RELEASE_OCI_MEDIA_TYPE {
+        return Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::ArtifactMediaType,
+        ));
+    }
+    Ok(AgentReleaseArtifact { digest, media_type })
+}
+
+pub(crate) fn parse_entrypoint(block: &Block) -> Result<AgentReleaseEntrypoint, AgentReleaseError> {
+    let command = required_string(block, "command", AgentReleaseField::EntrypointCommand)?;
+    if command.len() > MAX_COMMAND_BYTES
+        || !command.starts_with('/')
+        || command
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::EntrypointCommand,
+        ));
+    }
+
+    let args = match block.attributes.get("args") {
+        Some(Value::List(values)) if values.len() <= MAX_ENTRYPOINT_ARGS => values
+            .iter()
+            .map(|value| match value {
+                Value::String(value)
+                    if value.len() <= MAX_ENTRYPOINT_ARGUMENT_BYTES
+                        && !value.chars().any(char::is_control) =>
+                {
+                    Ok(value.clone())
+                }
+                _ => Err(AgentReleaseError::InvalidField(
+                    AgentReleaseField::EntrypointArgument,
+                )),
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::EntrypointArgument,
+            ))
+        }
+    };
+    Ok(AgentReleaseEntrypoint { command, args })
+}
+
+pub(crate) fn parse_health(block: &Block) -> Result<AgentReleaseHealth, AgentReleaseError> {
+    let transport = required_string(block, "transport", AgentReleaseField::HealthTransport)?;
+    if transport != "http" {
+        return Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::HealthTransport,
+        ));
+    }
+    let port = required_integer(
+        block,
+        "port",
+        AgentReleaseField::HealthPort,
+        u16::MAX as u32,
+    )? as u16;
+    let readiness_path =
+        required_string(block, "readiness_path", AgentReleaseField::ReadinessPath)?;
+    validate_health_path(&readiness_path, AgentReleaseField::ReadinessPath)?;
+    let liveness_path = required_string(block, "liveness_path", AgentReleaseField::LivenessPath)?;
+    validate_health_path(&liveness_path, AgentReleaseField::LivenessPath)?;
+    if readiness_path == liveness_path {
+        return Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::LivenessPath,
+        ));
+    }
+    let shutdown_grace_seconds = required_integer(
+        block,
+        "shutdown_grace_seconds",
+        AgentReleaseField::ShutdownGraceSeconds,
+        MAX_SHUTDOWN_GRACE_SECONDS,
+    )?;
+    Ok(AgentReleaseHealth {
+        transport,
+        port,
+        readiness_path,
+        liveness_path,
+        shutdown_grace_seconds,
+    })
+}
+
+pub(crate) fn parse_storage(block: &Block) -> Result<AgentReleaseStorage, AgentReleaseError> {
+    let workspace =
+        match required_string(block, "workspace", AgentReleaseField::WorkspaceMode)?.as_str() {
+            "read_only" => AgentReleaseWorkspaceMode::ReadOnly,
+            "ephemeral" => AgentReleaseWorkspaceMode::Ephemeral,
+            _ => {
+                return Err(AgentReleaseError::InvalidField(
+                    AgentReleaseField::WorkspaceMode,
+                ))
+            }
+        };
+    let cache = match required_string(block, "cache", AgentReleaseField::CacheMode)?.as_str() {
+        "none" => AgentReleaseCacheMode::None,
+        "ephemeral" => AgentReleaseCacheMode::Ephemeral,
+        _ => {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::CacheMode,
+            ))
+        }
+    };
+    let persistent_data = match required_string(
+        block,
+        "persistent_data",
+        AgentReleaseField::PersistentDataMode,
+    )?
+    .as_str()
+    {
+        "none" => AgentReleasePersistentDataMode::None,
+        "external" => AgentReleasePersistentDataMode::External,
+        _ => {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::PersistentDataMode,
+            ))
+        }
+    };
+    Ok(AgentReleaseStorage {
+        workspace,
+        cache,
+        persistent_data,
+    })
+}
+
+pub(crate) fn parse_capability(block: &Block) -> Result<AgentReleaseCapability, AgentReleaseError> {
+    let name = block
+        .labels
+        .first()
+        .cloned()
+        .ok_or(AgentReleaseError::InvalidField(
+            AgentReleaseField::CapabilityName,
+        ))?;
+    let level = required_integer(
+        block,
+        "level",
+        AgentReleaseField::CapabilityLevel,
+        MAX_CAPABILITY_LEVEL,
+    )?;
+    AgentReleaseCapability::new(name, level)
+}
+
+pub(crate) fn parse_secret(
+    block: &Block,
+) -> Result<AgentReleaseSecretRequirement, AgentReleaseError> {
+    let name = block
+        .labels
+        .first()
+        .cloned()
+        .ok_or(AgentReleaseError::InvalidField(
+            AgentReleaseField::SecretName,
+        ))?;
+    validate_dotted_name(&name, AgentReleaseField::SecretName)?;
+    let target = match required_string(block, "target", AgentReleaseField::SecretTarget)?.as_str() {
+        "environment" => AgentReleaseSecretTarget::Environment,
+        "file" => AgentReleaseSecretTarget::File,
+        _ => {
+            return Err(AgentReleaseError::InvalidField(
+                AgentReleaseField::SecretTarget,
+            ))
+        }
+    };
+    let destination = required_string(block, "destination", AgentReleaseField::SecretDestination)?;
+    match target {
+        AgentReleaseSecretTarget::Environment => validate_environment_name(&destination)?,
+        AgentReleaseSecretTarget::File => validate_secret_path(&destination)?,
+    }
+    Ok(AgentReleaseSecretRequirement {
+        name,
+        target,
+        destination,
+    })
+}
+
+pub(crate) fn parse_provenance(block: &Block) -> Result<AgentReleaseProvenance, AgentReleaseError> {
+    let kind = block
+        .labels
+        .first()
+        .cloned()
+        .ok_or(AgentReleaseError::InvalidField(
+            AgentReleaseField::ProvenanceKind,
+        ))?;
+    validate_dotted_name(&kind, AgentReleaseField::ProvenanceKind)?;
+    let uri = required_string(block, "uri", AgentReleaseField::ProvenanceUri)?;
+    validate_provenance_uri(&uri)?;
+    let digest = required_string(block, "digest", AgentReleaseField::ProvenanceDigest)?;
+    validate_digest(&digest, AgentReleaseField::ProvenanceDigest)?;
+    Ok(AgentReleaseProvenance { kind, uri, digest })
+}
+
+pub(crate) fn unique_capabilities(
+    capabilities: impl IntoIterator<Item = AgentReleaseCapability>,
+) -> Result<Vec<AgentReleaseCapability>, AgentReleaseError> {
+    let mut unique = BTreeMap::new();
+    for capability in capabilities {
+        if unique.insert(capability.name.clone(), capability).is_some() {
+            return Err(AgentReleaseError::DuplicateCapability);
+        }
+    }
+    Ok(unique.into_values().collect())
+}
+
+pub(crate) fn unique_provenance(
+    provenance: impl IntoIterator<Item = AgentReleaseProvenance>,
+) -> Result<Vec<AgentReleaseProvenance>, AgentReleaseError> {
+    let mut unique = BTreeMap::new();
+    for reference in provenance {
+        if unique.insert(reference.kind.clone(), reference).is_some() {
+            return Err(AgentReleaseError::DuplicateProvenance);
+        }
+    }
+    Ok(unique.into_values().collect())
+}
+
+pub(crate) fn unique_secrets(
+    secrets: impl IntoIterator<Item = AgentReleaseSecretRequirement>,
+) -> Result<Vec<AgentReleaseSecretRequirement>, AgentReleaseError> {
+    let mut names = BTreeMap::new();
+    let mut destinations = BTreeSet::new();
+    for secret in secrets {
+        let destination = (secret.target.as_str(), secret.destination.clone());
+        if names.insert(secret.name.clone(), secret).is_some() || !destinations.insert(destination)
+        {
+            return Err(AgentReleaseError::DuplicateSecret);
+        }
+    }
+    Ok(names.into_values().collect())
+}
+
+pub(crate) fn required_block<'a>(
+    blocks: &'a [Block],
+    name: &str,
+    field: AgentReleaseField,
+) -> Result<&'a Block, AgentReleaseError> {
+    blocks
+        .iter()
+        .find(|block| block.name == name)
+        .ok_or(AgentReleaseError::InvalidField(field))
+}
+
+pub(crate) fn validate_dotted_name(
+    name: &str,
+    field: AgentReleaseField,
+) -> Result<(), AgentReleaseError> {
+    let valid = !name.is_empty()
+        && name.len() <= MAX_NAME_BYTES
+        && name.split('.').all(|segment| {
+            let mut bytes = segment.bytes();
+            bytes.next().is_some_and(|byte| byte.is_ascii_lowercase())
+                && bytes
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(field))
+    }
+}
+
+pub(crate) fn validate_protocol(protocol: &str) -> Result<(), AgentReleaseError> {
+    let valid = protocol
+        .strip_prefix("a3s.code.agent.v")
+        .and_then(|value| value.parse::<u32>().ok().map(|version| (value, version)))
+        .is_some_and(|(source, version)| {
+            version > 0 && version <= MAX_CAPABILITY_LEVEL && source == version.to_string()
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(AgentReleaseField::Protocol))
+    }
+}
+
+pub(crate) fn required_string(
+    block: &Block,
+    name: &str,
+    field: AgentReleaseField,
+) -> Result<String, AgentReleaseError> {
+    match block.attributes.get(name) {
+        Some(Value::String(value)) => Ok(value.clone()),
+        _ => Err(AgentReleaseError::InvalidField(field)),
+    }
+}
+
+fn required_integer(
+    block: &Block,
+    name: &str,
+    field: AgentReleaseField,
+    max: u32,
+) -> Result<u32, AgentReleaseError> {
+    match block.attributes.get(name) {
+        Some(Value::Number(value))
+            if value.is_finite()
+                && value.fract() == 0.0
+                && *value >= 1.0
+                && *value <= max as f64 =>
+        {
+            Ok(*value as u32)
+        }
+        _ => Err(AgentReleaseError::InvalidField(field)),
+    }
+}
+
+fn validate_digest(digest: &str, field: AgentReleaseField) -> Result<(), AgentReleaseError> {
+    let valid = digest.strip_prefix("sha256:").is_some_and(|value| {
+        value.len() == 64
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(field))
+    }
+}
+
+fn validate_health_path(path: &str, field: AgentReleaseField) -> Result<(), AgentReleaseError> {
+    let valid = path.strip_prefix('/').is_some_and(|relative| {
+        !relative.is_empty()
+            && relative.split('/').all(|segment| {
+                !segment.is_empty()
+                    && segment != "."
+                    && segment != ".."
+                    && segment.bytes().all(|byte| {
+                        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~')
+                    })
+            })
+    }) && path.len() <= MAX_HEALTH_PATH_BYTES;
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(field))
+    }
+}
+
+fn validate_environment_name(name: &str) -> Result<(), AgentReleaseError> {
+    let mut bytes = name.bytes();
+    let valid = name.len() <= MAX_NAME_BYTES
+        && bytes
+            .next()
+            .is_some_and(|byte| byte.is_ascii_uppercase() || byte == b'_')
+        && bytes.all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_');
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::SecretDestination,
+        ))
+    }
+}
+
+fn validate_secret_path(path: &str) -> Result<(), AgentReleaseError> {
+    let valid = path
+        .strip_prefix(SECRET_FILE_PREFIX)
+        .is_some_and(|relative| {
+            !relative.is_empty()
+                && relative.split('/').all(|segment| {
+                    !segment.is_empty()
+                        && segment != "."
+                        && segment != ".."
+                        && segment.bytes().all(|byte| {
+                            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_')
+                        })
+                })
+        })
+        && path.len() <= MAX_SECRET_DESTINATION_BYTES;
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::SecretDestination,
+        ))
+    }
+}
+
+fn validate_provenance_uri(uri: &str) -> Result<(), AgentReleaseError> {
+    let parsed = Url::parse(uri)
+        .map_err(|_| AgentReleaseError::InvalidField(AgentReleaseField::ProvenanceUri))?;
+    let scheme_valid = match parsed.scheme() {
+        "https" => parsed.host_str().is_some(),
+        "urn" => !parsed.path().is_empty(),
+        _ => false,
+    };
+    let valid = uri.len() <= MAX_PROVENANCE_URI_BYTES
+        && uri.is_ascii()
+        && !uri
+            .bytes()
+            .any(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+        && scheme_valid
+        && parsed.username().is_empty()
+        && parsed.password().is_none()
+        && parsed.query().is_none()
+        && parsed.fragment().is_none();
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentReleaseError::InvalidField(
+            AgentReleaseField::ProvenanceUri,
+        ))
+    }
+}

--- a/core/tests/agent_release_manifest.rs
+++ b/core/tests/agent_release_manifest.rs
@@ -1,0 +1,456 @@
+use a3s_code_core::release::{
+    AgentReleaseArtifact, AgentReleaseCacheMode, AgentReleaseCapability, AgentReleaseCompatibility,
+    AgentReleaseEntrypoint, AgentReleaseError, AgentReleaseField, AgentReleaseHealth,
+    AgentReleaseManifest, AgentReleasePersistentDataMode, AgentReleaseProvenance,
+    AgentReleaseSecretRequirement, AgentReleaseSecretTarget, AgentReleaseStorage,
+    AgentReleaseWorkspaceMode, AGENT_PROTOCOL_V1, AGENT_RELEASE_CONTRACT_V1, AGENT_RELEASE_LIMITS,
+};
+use std::path::Path;
+
+const FIXTURE: &str = include_str!("../../fixtures/agent-release-contract/.a3s/asset.acl");
+
+fn compatibility() -> AgentReleaseCompatibility {
+    AgentReleaseCompatibility::new(
+        AGENT_PROTOCOL_V1,
+        [
+            AgentReleaseCapability::new("runtime.service", 1).unwrap(),
+            AgentReleaseCapability::new("secrets.external", 1).unwrap(),
+            AgentReleaseCapability::new("workspace.local", 2).unwrap(),
+        ],
+    )
+    .unwrap()
+}
+
+#[test]
+fn fixture_is_typed_canonical_and_digest_bound() {
+    let manifest = AgentReleaseManifest::parse(FIXTURE).expect("fixture should be admitted");
+
+    assert_eq!(manifest.contract(), AGENT_RELEASE_CONTRACT_V1);
+    assert_eq!(manifest.protocol(), AGENT_PROTOCOL_V1);
+    assert_eq!(
+        manifest.artifact().digest(),
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    assert_eq!(
+        manifest.artifact().media_type(),
+        "application/vnd.oci.image.manifest.v1+json"
+    );
+    assert_eq!(manifest.entrypoint().command(), "/usr/bin/a3s-code-agent");
+    assert_eq!(
+        manifest.entrypoint().args(),
+        ["serve", "--manifest", "/app/.a3s/asset.acl"]
+    );
+    assert_eq!(manifest.health().transport(), "http");
+    assert_eq!(manifest.health().port(), 8080);
+    assert_eq!(manifest.health().readiness_path(), "/health/ready");
+    assert_eq!(manifest.health().liveness_path(), "/health/live");
+    assert_eq!(manifest.health().shutdown_grace_seconds(), 30);
+    assert_eq!(
+        manifest
+            .required_capabilities()
+            .iter()
+            .map(|capability| (capability.name(), capability.level()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("runtime.service", 1),
+            ("secrets.external", 1),
+            ("workspace.local", 1)
+        ]
+    );
+    assert_eq!(
+        manifest.storage().workspace(),
+        AgentReleaseWorkspaceMode::Ephemeral
+    );
+    assert_eq!(manifest.storage().cache(), AgentReleaseCacheMode::Ephemeral);
+    assert_eq!(
+        manifest.storage().persistent_data(),
+        AgentReleasePersistentDataMode::None
+    );
+    assert_eq!(manifest.required_secrets().len(), 2);
+    assert_eq!(manifest.required_secrets()[0].name(), "provider-api-key");
+    assert_eq!(
+        manifest.required_secrets()[0].target(),
+        AgentReleaseSecretTarget::Environment
+    );
+    assert_eq!(
+        manifest.required_secrets()[0].destination(),
+        "PROVIDER_API_KEY"
+    );
+    assert_eq!(manifest.required_secrets()[1].name(), "signing-key");
+    assert_eq!(
+        manifest.required_secrets()[1].target(),
+        AgentReleaseSecretTarget::File
+    );
+    assert_eq!(manifest.provenance().len(), 2);
+    assert_eq!(manifest.provenance()[0].kind(), "builder");
+    assert_eq!(
+        manifest.provenance()[0].uri(),
+        "urn:a3s:builder:github-actions"
+    );
+    assert_eq!(manifest.provenance()[1].kind(), "source");
+    assert_eq!(
+        manifest.provenance()[1].uri(),
+        "https://github.com/A3S-Lab/Code"
+    );
+    assert!(manifest.identity().starts_with("sha256:"));
+    assert_eq!(manifest.identity().len(), 71);
+    assert_eq!(
+        manifest.identity(),
+        "sha256:18a6f165a9dce546db0cc61402f9a55d9be138e5f4e52a7649e0935c51bd504b"
+    );
+    assert!(manifest.canonical_acl().ends_with('\n'));
+
+    let round_trip = AgentReleaseManifest::parse(manifest.canonical_acl())
+        .expect("canonical bytes should parse");
+    assert_eq!(round_trip.identity(), manifest.identity());
+    assert_eq!(round_trip.canonical_acl(), manifest.canonical_acl());
+    let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../fixtures/agent-release-contract/.a3s/asset.acl");
+    assert_eq!(
+        AgentReleaseManifest::from_file(fixture_path)
+            .expect("the conventional asset path should load")
+            .identity(),
+        manifest.identity()
+    );
+    manifest
+        .verify_compatibility(&compatibility())
+        .expect("fixture requirements should be available");
+
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<AgentReleaseManifest>();
+    assert_send_sync::<AgentReleaseError>();
+}
+
+#[test]
+fn identity_ignores_formatting_and_set_like_block_order_only() {
+    let first = AgentReleaseManifest::parse(FIXTURE).unwrap();
+    let equivalent = FIXTURE
+        .replace(
+            "  capability \"runtime.service\" {\n    level = 1\n  }\n\n  capability \"secrets.external\" {\n    level = 1\n  }\n\n  capability \"workspace.local\" {\n    level = 1\n  }",
+            "  # Capability requirements are a set.\n  capability \"workspace.local\" { level = 1 }\n  capability \"runtime.service\" { level = 1 }\n  capability \"secrets.external\" { level = 1 }",
+        )
+        .replace(
+            "  schema = \"a3s.code.agent-release.v1\"\n  protocol = \"a3s.code.agent.v1\"",
+            "  protocol = \"a3s.code.agent.v1\"\n  schema = \"a3s.code.agent-release.v1\"",
+        )
+        .replace(
+            "  provenance \"source\" {\n    uri = \"https://github.com/A3S-Lab/Code\"\n    digest = \"sha256:2222222222222222222222222222222222222222222222222222222222222222\"\n  }\n\n  provenance \"builder\" {\n    uri = \"urn:a3s:builder:github-actions\"\n    digest = \"sha256:4444444444444444444444444444444444444444444444444444444444444444\"\n  }",
+            "  provenance \"builder\" { uri = \"urn:a3s:builder:github-actions\" digest = \"sha256:4444444444444444444444444444444444444444444444444444444444444444\" }\n  provenance \"source\" { uri = \"https://github.com/A3S-Lab/Code\" digest = \"sha256:2222222222222222222222222222222222222222222222222222222222222222\" }",
+        )
+        .replace(
+            "  secret \"provider-api-key\" {\n    target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"\n  }\n\n  secret \"signing-key\" {\n    target = \"file\"\n    destination = \"/run/secrets/signing-key\"\n  }",
+            "  secret \"signing-key\" { target = \"file\" destination = \"/run/secrets/signing-key\" }\n  secret \"provider-api-key\" { target = \"environment\" destination = \"PROVIDER_API_KEY\" }",
+        );
+    let second = AgentReleaseManifest::parse(&equivalent).unwrap();
+
+    assert_eq!(second.identity(), first.identity());
+    assert_eq!(second.canonical_acl(), first.canonical_acl());
+
+    let changed = FIXTURE.replace(
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    );
+    assert_ne!(
+        AgentReleaseManifest::parse(&changed).unwrap().identity(),
+        first.identity()
+    );
+
+    let reordered_args = FIXTURE.replace(
+        "args = [\"serve\", \"--manifest\", \"/app/.a3s/asset.acl\"]",
+        "args = [\"--manifest\", \"serve\", \"/app/.a3s/asset.acl\"]",
+    );
+    assert_ne!(
+        AgentReleaseManifest::parse(&reordered_args)
+            .unwrap()
+            .identity(),
+        first.identity(),
+        "ordered entrypoint arguments must retain their semantics"
+    );
+}
+
+#[test]
+fn admission_is_bounded_closed_and_value_redacting() {
+    let unknown = FIXTURE.replace(
+        "  protocol = \"a3s.code.agent.v1\"",
+        "  protocol = \"a3s.code.agent.v1\"\n  secret = \"TOP_SECRET\"",
+    );
+    let error = AgentReleaseManifest::parse(&unknown).expect_err("unknown field must fail");
+    assert_eq!(error.code(), "a3s.code.agent_release.schema");
+    assert!(!error.to_string().contains("TOP_SECRET"));
+
+    let call = FIXTURE.replace(
+        "digest = \"sha256:1111111111111111111111111111111111111111111111111111111111111111\"",
+        "digest = env(\"TOP_SECRET\")",
+    );
+    let error = AgentReleaseManifest::parse(&call).expect_err("function calls must fail");
+    assert_eq!(error.code(), "a3s.code.agent_release.schema");
+    assert!(!error.to_string().contains("TOP_SECRET"));
+
+    let uppercase_digest = FIXTURE.replace(
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    let error =
+        AgentReleaseManifest::parse(&uppercase_digest).expect_err("digest must be lowercase");
+    assert_eq!(error.code(), "a3s.code.agent_release.invalid_field");
+    assert!(!error.to_string().contains("AAAA"));
+
+    let duplicate = FIXTURE.replace(
+        "  capability \"runtime.service\" {\n    level = 1\n  }",
+        "  capability \"runtime.service\" {\n    level = 1\n  }\n  capability \"runtime.service\" { level = 2 }",
+    );
+    let error =
+        AgentReleaseManifest::parse(&duplicate).expect_err("duplicate requirement must fail");
+    assert_eq!(error.code(), "a3s.code.agent_release.duplicate_capability");
+
+    let duplicate_provenance = FIXTURE.replace("provenance \"source\"", "provenance \"builder\"");
+    let error = AgentReleaseManifest::parse(&duplicate_provenance)
+        .expect_err("provenance kinds must be unique");
+    assert_eq!(error.code(), "a3s.code.agent_release.duplicate_provenance");
+
+    let plaintext_secret = FIXTURE.replace(
+        "target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"",
+        "target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"\n    value = \"TOP_SECRET\"",
+    );
+    let error = AgentReleaseManifest::parse(&plaintext_secret)
+        .expect_err("secret plaintext fields must be closed");
+    assert_eq!(error.code(), "a3s.code.agent_release.schema");
+    assert!(!error.to_string().contains("TOP_SECRET"));
+
+    let duplicate_secret = FIXTURE.replace(
+        "  secret \"provider-api-key\" {\n    target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"\n  }",
+        "  secret \"provider-api-key\" {\n    target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"\n  }\n  secret \"provider-api-key\" { target = \"file\" destination = \"/run/secrets/other\" }",
+    );
+    let error =
+        AgentReleaseManifest::parse(&duplicate_secret).expect_err("secret slots must be unique");
+    assert_eq!(error.code(), "a3s.code.agent_release.duplicate_secret");
+
+    let missing_secret_capability = FIXTURE.replace(
+        "  capability \"secrets.external\" {\n    level = 1\n  }\n\n",
+        "",
+    );
+    let error = AgentReleaseManifest::parse(&missing_secret_capability)
+        .expect_err("secret slots require the external-secret capability");
+    assert_eq!(error.code(), "a3s.code.agent_release.invalid_field");
+
+    let oversized = "x".repeat(AGENT_RELEASE_LIMITS.max_document_bytes + 1);
+    let error = AgentReleaseManifest::parse(&oversized).expect_err("input must be bounded");
+    assert_eq!(error.code(), "a3s.code.agent_release.parse");
+
+    let attacker_named_field = FIXTURE.replace(
+        "  protocol = \"a3s.code.agent.v1\"",
+        "  protocol = \"a3s.code.agent.v1\"\n  TOP_SECRET_VALUE = true",
+    );
+    let error = AgentReleaseManifest::parse(&attacker_named_field)
+        .expect_err("unknown attacker-controlled field must fail");
+    assert!(!error.to_string().contains("TOP_SECRET_VALUE"));
+    assert!(!format!("{error:?}").contains("TOP_SECRET_VALUE"));
+}
+
+#[test]
+fn compatibility_fails_before_activation_with_typed_reasons() {
+    let manifest = AgentReleaseManifest::parse(FIXTURE).unwrap();
+
+    let wrong_protocol = AgentReleaseCompatibility::new(
+        "a3s.code.agent.v2",
+        [
+            AgentReleaseCapability::new("runtime.service", 1).unwrap(),
+            AgentReleaseCapability::new("secrets.external", 1).unwrap(),
+            AgentReleaseCapability::new("workspace.local", 1).unwrap(),
+        ],
+    )
+    .unwrap();
+    let error = manifest
+        .verify_compatibility(&wrong_protocol)
+        .expect_err("protocol mismatch must fail");
+    assert_eq!(error.code(), "a3s.code.agent_release.incompatible_protocol");
+
+    let future_source = FIXTURE.replace(AGENT_PROTOCOL_V1, "a3s.code.agent.v2");
+    let future_manifest =
+        AgentReleaseManifest::parse(&future_source).expect("schema and protocol are independent");
+    let error = future_manifest
+        .verify_compatibility(&compatibility())
+        .expect_err("a valid but unavailable protocol must fail before activation");
+    assert_eq!(error.code(), "a3s.code.agent_release.incompatible_protocol");
+
+    let missing = AgentReleaseCompatibility::new(
+        AGENT_PROTOCOL_V1,
+        [
+            AgentReleaseCapability::new("runtime.service", 1).unwrap(),
+            AgentReleaseCapability::new("secrets.external", 1).unwrap(),
+        ],
+    )
+    .unwrap();
+    let error = manifest
+        .verify_compatibility(&missing)
+        .expect_err("missing capability must fail");
+    assert_eq!(
+        error.code(),
+        "a3s.code.agent_release.unsupported_capability"
+    );
+    assert!(matches!(
+        error,
+        AgentReleaseError::UnsupportedCapability { required_index: 2 }
+    ));
+
+    let invalid_level = AgentReleaseCapability::new("workspace.local", 0)
+        .expect_err("zero capability level must fail");
+    assert_eq!(invalid_level.code(), "a3s.code.agent_release.invalid_field");
+
+    let demanding_source = FIXTURE.replacen(
+        "capability \"workspace.local\" {\n    level = 1",
+        "capability \"workspace.local\" {\n    level = 2",
+        1,
+    );
+    let demanding = AgentReleaseManifest::parse(&demanding_source).unwrap();
+    let too_low = AgentReleaseCompatibility::new(
+        AGENT_PROTOCOL_V1,
+        [
+            AgentReleaseCapability::new("runtime.service", 1).unwrap(),
+            AgentReleaseCapability::new("secrets.external", 1).unwrap(),
+            AgentReleaseCapability::new("workspace.local", 1).unwrap(),
+        ],
+    )
+    .unwrap();
+    let error = demanding
+        .verify_compatibility(&too_low)
+        .expect_err("capability level mismatch must fail");
+    assert_eq!(
+        error.code(),
+        "a3s.code.agent_release.unsupported_capability"
+    );
+}
+
+#[test]
+fn storage_and_secret_destinations_are_closed_and_collision_free() {
+    for (source, replacement, field) in [
+        (
+            "workspace = \"ephemeral\"",
+            "workspace = \"persistent\"",
+            AgentReleaseField::WorkspaceMode,
+        ),
+        (
+            "cache = \"ephemeral\"",
+            "cache = \"external\"",
+            AgentReleaseField::CacheMode,
+        ),
+        (
+            "persistent_data = \"none\"",
+            "persistent_data = \"ephemeral\"",
+            AgentReleaseField::PersistentDataMode,
+        ),
+    ] {
+        let invalid = FIXTURE.replace(source, replacement);
+        let error = AgentReleaseManifest::parse(&invalid)
+            .expect_err("unknown storage mode must fail admission");
+        assert_eq!(error.field(), Some(field));
+    }
+
+    for invalid_destination in [
+        "provider_api_key",
+        "/run/secrets/../signing-key",
+        "/run/secrets//signing-key",
+        "/run/secrets/signing-key/",
+        "/tmp/signing-key",
+    ] {
+        let (source, replacement) = if invalid_destination == "provider_api_key" {
+            (
+                "destination = \"PROVIDER_API_KEY\"",
+                format!("destination = \"{invalid_destination}\""),
+            )
+        } else {
+            (
+                "destination = \"/run/secrets/signing-key\"",
+                format!("destination = \"{invalid_destination}\""),
+            )
+        };
+        let invalid = FIXTURE.replace(source, &replacement);
+        let error = AgentReleaseManifest::parse(&invalid)
+            .expect_err("non-canonical secret destination must fail admission");
+        assert_eq!(error.field(), Some(AgentReleaseField::SecretDestination));
+        assert!(!error.to_string().contains(invalid_destination));
+    }
+
+    let nested_file = FIXTURE.replace(
+        "destination = \"/run/secrets/signing-key\"",
+        "destination = \"/run/secrets/signing/key.pem\"",
+    );
+    AgentReleaseManifest::parse(&nested_file)
+        .expect("a canonical nested /run/secrets path should be admitted");
+
+    let duplicate_destination = FIXTURE.replace(
+        "target = \"file\"\n    destination = \"/run/secrets/signing-key\"",
+        "target = \"environment\"\n    destination = \"PROVIDER_API_KEY\"",
+    );
+    let error = AgentReleaseManifest::parse(&duplicate_destination)
+        .expect_err("two slots must not inject into the same target");
+    assert_eq!(error.code(), "a3s.code.agent_release.duplicate_secret");
+}
+
+#[test]
+fn compatibility_inputs_are_canonical_unique_and_value_redacting() {
+    let duplicate = AgentReleaseCompatibility::new(
+        AGENT_PROTOCOL_V1,
+        [
+            AgentReleaseCapability::new("runtime.service", 1).unwrap(),
+            AgentReleaseCapability::new("runtime.service", 2).unwrap(),
+        ],
+    )
+    .expect_err("available capabilities must be unique");
+    assert_eq!(
+        duplicate.code(),
+        "a3s.code.agent_release.duplicate_capability"
+    );
+
+    for protocol in ["a3s.code.agent.v0", "a3s.code.agent.v01", "agent.v1"] {
+        let error = AgentReleaseCompatibility::new(protocol, [])
+            .expect_err("non-canonical protocol versions must fail");
+        assert_eq!(error.field(), Some(AgentReleaseField::Protocol));
+    }
+
+    let secret_looking_name = "top-secret-token";
+    let source = FIXTURE.replace("workspace.local", secret_looking_name);
+    let manifest = AgentReleaseManifest::parse(&source).unwrap();
+    let error = manifest
+        .verify_compatibility(&compatibility())
+        .expect_err("missing requirement must fail before activation");
+    assert!(!error.to_string().contains(secret_looking_name));
+    assert!(!format!("{error:?}").contains(secret_looking_name));
+}
+
+#[test]
+fn file_admission_applies_encoding_and_size_budgets_before_parsing() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(
+        file.path(),
+        vec![b'x'; AGENT_RELEASE_LIMITS.max_document_bytes + 1],
+    )
+    .unwrap();
+    let error = AgentReleaseManifest::from_file(file.path()).expect_err("oversized file must fail");
+    assert!(matches!(error, AgentReleaseError::InputTooLarge));
+
+    std::fs::write(file.path(), [0xff]).unwrap();
+    let error = AgentReleaseManifest::from_file(file.path()).expect_err("invalid UTF-8 must fail");
+    assert!(matches!(error, AgentReleaseError::InvalidEncoding));
+}
+
+#[test]
+fn public_release_types_are_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    assert_send_sync::<AgentReleaseArtifact>();
+    assert_send_sync::<AgentReleaseCacheMode>();
+    assert_send_sync::<AgentReleaseCapability>();
+    assert_send_sync::<AgentReleaseCompatibility>();
+    assert_send_sync::<AgentReleaseEntrypoint>();
+    assert_send_sync::<AgentReleaseError>();
+    assert_send_sync::<AgentReleaseField>();
+    assert_send_sync::<AgentReleaseHealth>();
+    assert_send_sync::<AgentReleaseManifest>();
+    assert_send_sync::<AgentReleasePersistentDataMode>();
+    assert_send_sync::<AgentReleaseProvenance>();
+    assert_send_sync::<AgentReleaseSecretRequirement>();
+    assert_send_sync::<AgentReleaseSecretTarget>();
+    assert_send_sync::<AgentReleaseStorage>();
+    assert_send_sync::<AgentReleaseWorkspaceMode>();
+}

--- a/fixtures/agent-release-contract/.a3s/asset.acl
+++ b/fixtures/agent-release-contract/.a3s/asset.acl
@@ -1,0 +1,60 @@
+agent_release {
+  schema = "a3s.code.agent-release.v1"
+  protocol = "a3s.code.agent.v1"
+
+  artifact {
+    digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    media_type = "application/vnd.oci.image.manifest.v1+json"
+  }
+
+  entrypoint {
+    command = "/usr/bin/a3s-code-agent"
+    args = ["serve", "--manifest", "/app/.a3s/asset.acl"]
+  }
+
+  health {
+    transport = "http"
+    port = 8080
+    readiness_path = "/health/ready"
+    liveness_path = "/health/live"
+    shutdown_grace_seconds = 30
+  }
+
+  storage {
+    workspace = "ephemeral"
+    cache = "ephemeral"
+    persistent_data = "none"
+  }
+
+  capability "runtime.service" {
+    level = 1
+  }
+
+  capability "secrets.external" {
+    level = 1
+  }
+
+  capability "workspace.local" {
+    level = 1
+  }
+
+  secret "provider-api-key" {
+    target = "environment"
+    destination = "PROVIDER_API_KEY"
+  }
+
+  secret "signing-key" {
+    target = "file"
+    destination = "/run/secrets/signing-key"
+  }
+
+  provenance "source" {
+    uri = "https://github.com/A3S-Lab/Code"
+    digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  }
+
+  provenance "builder" {
+    uri = "urn:a3s:builder:github-actions"
+    digest = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+  }
+}

--- a/manual/AGENT_RELEASE_CONTRACT.md
+++ b/manual/AGENT_RELEASE_CONTRACT.md
@@ -1,0 +1,299 @@
+# Agent Release Contract
+
+## Status and boundary
+
+`a3s-code-core` defines a closed, bounded admission contract for an immutable
+Agent release manifest at `.a3s/asset.acl`. The current schema identifier is
+`a3s.code.agent-release.v1`.
+
+The `release` module owns:
+
+- parsing untrusted manifest bytes with explicit limits;
+- validating the closed v1 schema and semantic constraints;
+- deriving a schema-aware canonical ACL document and release identity; and
+- checking the declared protocol and capability requirements before activation.
+
+It does not build an OCI image, start an Agent daemon, implement the declared
+health endpoints, enforce the shutdown deadline, or certify a deployment as a
+Runtime Service. Those runtime pieces must be implemented and tested before an
+Agent release is considered deployable.
+
+The repository fixture at
+[`fixtures/agent-release-contract/.a3s/asset.acl`](../fixtures/agent-release-contract/.a3s/asset.acl)
+is a parser and identity contract fixture. Its repeated hexadecimal digests are
+test values, not published OCI or provenance digests, so the fixture is not a
+deployable release.
+
+Its expected schema-aware identity is
+`sha256:18a6f165a9dce546db0cc61402f9a55d9be138e5f4e52a7649e0935c51bd504b`.
+Cross-repository parser tests may use that value to detect canonicalization
+drift, but must not treat it as an artifact digest or deployment certification.
+
+## File and schema
+
+A release producer places exactly one `agent_release` block in
+`.a3s/asset.acl`:
+
+```acl
+agent_release {
+  schema = "a3s.code.agent-release.v1"
+  protocol = "a3s.code.agent.v1"
+
+  artifact {
+    digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    media_type = "application/vnd.oci.image.manifest.v1+json"
+  }
+
+  entrypoint {
+    command = "/usr/bin/a3s-code-agent"
+    args = ["serve", "--manifest", "/app/.a3s/asset.acl"]
+  }
+
+  health {
+    transport = "http"
+    port = 8080
+    readiness_path = "/health/ready"
+    liveness_path = "/health/live"
+    shutdown_grace_seconds = 30
+  }
+
+  storage {
+    workspace = "ephemeral"
+    cache = "ephemeral"
+    persistent_data = "none"
+  }
+
+  capability "runtime.service" {
+    level = 1
+  }
+
+  provenance "source" {
+    uri = "https://github.com/A3S-Lab/Code"
+    digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  }
+}
+```
+
+Unknown attributes, blocks, calls, and value shapes fail admission. All strings
+below are measured in UTF-8 bytes.
+
+`schema` must be exactly `a3s.code.agent-release.v1`. `protocol` is independently
+versioned and uses the canonical form `a3s.code.agent.v<N>`, where `N` is an
+integer from 1 through 65,535 with no leading zero. Admission understands that
+version syntax; activation still requires an exact match with a protocol the
+runtime supplies.
+
+### Artifact and entrypoint
+
+| Field | v1 requirement |
+| --- | --- |
+| `artifact.digest` | Lowercase `sha256:` plus exactly 64 hexadecimal characters |
+| `artifact.media_type` | Exactly `application/vnd.oci.image.manifest.v1+json` |
+| `entrypoint.command` | Absolute container path, at most 1,024 bytes, with no whitespace or control characters |
+| `entrypoint.args` | Ordered list of at most 64 strings; each is at most 4,096 bytes and contains no control characters |
+
+The artifact digest is immutable input to the declared release identity. A tag,
+branch, mutable workspace, or registry label is not accepted as an artifact
+reference.
+
+### Health and shutdown declaration
+
+| Field | v1 requirement |
+| --- | --- |
+| `health.transport` | Exactly `http` |
+| `health.port` | Integer from 1 through 65,535 |
+| `health.readiness_path` | Canonical absolute path of non-empty ASCII unreserved segments |
+| `health.liveness_path` | Same path rules as readiness and different from the readiness path |
+| `health.shutdown_grace_seconds` | Integer from 1 through 3,600 |
+
+Path segments may contain ASCII letters, digits, `-`, `.`, `_`, or `~`.
+Empty, `.` and `..` segments are rejected.
+
+These fields are declarations consumed by a future headless runtime and its
+controller. Admission does not make either endpoint observable. A conforming
+runtime must keep readiness false until it can accept work, report liveness
+without exposing release secrets, stop accepting new work during shutdown, and
+reach a terminal state within the declared grace period.
+
+### Writable storage boundaries
+
+The v1 modes are deliberately finite:
+
+| Boundary | Accepted values | Meaning |
+| --- | --- | --- |
+| `storage.workspace` | `read_only`, `ephemeral` | The release may receive a read-only workspace or a release-scoped writable workspace that is discarded |
+| `storage.cache` | `none`, `ephemeral` | No cache is mounted, or cache data is disposable |
+| `storage.persistent_data` | `none`, `external` | The release owns no durable data, or durable data is supplied and governed outside the image |
+
+The manifest cannot name host paths, volume identifiers, buckets, tenants, or
+mutable workspace snapshots. A runtime must reject a deployment it cannot
+isolate according to these modes.
+
+### Capabilities
+
+At least one `capability "<name>"` block is required. Names are unique and at
+most 128 bytes. Each dot-separated segment starts with a lowercase ASCII letter
+and continues with lowercase ASCII letters, digits, or `-`. `level` is an
+integer from 1 through 65,535.
+
+Capability blocks form a schema-declared unordered set. Reordering them does
+not change canonical bytes or identity. A duplicate name fails admission
+instead of choosing one occurrence.
+
+### Secret injection slots
+
+A secret block declares a typed injection slot:
+
+```acl
+secret "provider-api-key" {
+  target = "environment"
+  destination = "PROVIDER_API_KEY"
+}
+
+secret "signing-key" {
+  target = "file"
+  destination = "/run/secrets/signing/key.pem"
+}
+```
+
+Secret names use the same bounded dotted-name grammar as capabilities. The
+accepted targets are:
+
+| Target | Destination |
+| --- | --- |
+| `environment` | POSIX-style uppercase environment name: `[A-Z_][A-Z0-9_]*`, at most 128 bytes |
+| `file` | Canonical path below `/run/secrets/`, at most 256 bytes; each non-empty segment contains only ASCII letters, digits, `-`, `.`, or `_` |
+
+Names and `(target, destination)` pairs must both be unique. Any secret block
+also requires a `secrets.external` capability declaration.
+
+The release manifest contains only the slot name and injection destination. It
+must never contain a plaintext value, ciphertext, external secret identifier,
+vault path, provider resource name, or tenant reference. A deployment
+controller resolves an external secret outside the manifest and injects only
+runtime material into the declared environment variable or file. The value
+must not be copied into artifact metadata, logs, diagnostics, provenance, or
+health responses.
+
+The schema is closed, so an attempted `value`, `reference`, or other extra
+field fails before canonicalization. Admission errors expose stable codes and
+structural fields or indexes without echoing manifest values.
+
+### Provenance
+
+At least one `provenance "<kind>"` block is required. Kinds use the bounded
+dotted-name grammar and must be unique. Each reference contains:
+
+- an ASCII `https` URI with a host, or a non-empty ASCII `urn` URI;
+- no credentials, query, or fragment; and
+- a lowercase SHA-256 digest in the same form as the artifact digest.
+
+The URI is a locator or subject name; the digest binds the immutable provenance
+object. Provenance blocks form a schema-declared unordered set.
+
+## Admission budgets
+
+`AgentReleaseManifest::parse` and `AgentReleaseManifest::from_file` apply the
+same ACL limits:
+
+| Budget | Limit |
+| --- | ---: |
+| Document | 64 KiB |
+| Nesting depth | 8 |
+| Collection items | 256 |
+| Token | 8 KiB |
+| Diagnostics | 20 |
+
+`from_file` reads at most 64 KiB plus one byte before rejecting an oversized
+file. Invalid UTF-8 fails before ACL parsing.
+
+## Canonical identity
+
+After schema and semantic admission, Core computes:
+
+```text
+canonical_acl = canonical_bytes_with_schema(document, v1_schema)
+identity      = "sha256:" + sha256(canonical_acl)
+```
+
+The schema declares `capability`, `secret`, and `provenance` occurrences as
+unordered sets. Their source order, comments, whitespace, and ordinary ACL
+formatting therefore do not affect identity. Ordered values such as
+`entrypoint.args` retain their order. Duplicate set keys are rejected before
+identity is returned.
+
+Because `artifact.digest` and all provenance digests are canonical manifest
+fields, the identity binds them. The same admitted manifest and artifact digest
+produce the same declared identity. Changing the artifact digest, entrypoint,
+health declaration, storage boundary, capability, secret slot, or provenance
+changes the identity.
+
+Callers should persist and compare `AgentReleaseManifest::identity()`, not a
+digest of the original source formatting.
+
+## Pre-activation compatibility
+
+The runtime supplies an `AgentReleaseCompatibility` containing its exact
+protocol and unique available capability levels:
+
+```rust,no_run
+use a3s_code_core::release::{
+    AgentReleaseCapability, AgentReleaseCompatibility, AgentReleaseManifest,
+    AGENT_PROTOCOL_V1,
+};
+
+# fn admit(source: &str) -> Result<(), Box<dyn std::error::Error>> {
+let release = AgentReleaseManifest::parse(source)?;
+let runtime = AgentReleaseCompatibility::new(
+    AGENT_PROTOCOL_V1,
+    [
+        AgentReleaseCapability::new("runtime.service", 1)?,
+        AgentReleaseCapability::new("secrets.external", 1)?,
+    ],
+)?;
+release.verify_compatibility(&runtime)?;
+# Ok(())
+# }
+```
+
+Activation fails when the protocol is not an exact match, a required
+capability is absent, or the available level is below the required level.
+Errors expose stable machine codes:
+
+| Condition | Code |
+| --- | --- |
+| Protocol mismatch | `a3s.code.agent_release.incompatible_protocol` |
+| Missing or insufficient capability | `a3s.code.agent_release.unsupported_capability` |
+| Invalid semantic field | `a3s.code.agent_release.invalid_field` |
+| Closed-schema rejection | `a3s.code.agent_release.schema` |
+
+Compatibility verification is an admission gate only. A successful result
+does not prove artifact availability, secret resolution, storage isolation,
+process readiness, or Runtime Service health.
+
+## Versioning and breaking changes
+
+The schema and protocol are versioned independently:
+
+- `schema` governs manifest syntax, admission rules, canonicalization, and
+  release identity.
+- `protocol` governs the headless Agent request and lifecycle behavior expected
+  from the artifact.
+
+Version-one readers never reinterpret a v1 document with new semantics.
+Changing any accepted field, mode, limit, required block, set-order rule,
+canonical byte rule, or identity meaning requires a new release schema
+identifier. This includes adding an otherwise optional field, because old
+closed-schema readers would reject it. A new secret target or destination
+grammar also requires a new schema version.
+
+A breaking headless request, readiness, liveness, shutdown, or exit-semantics
+change requires a new protocol identifier. Runtimes may support multiple
+schema or protocol versions explicitly, but they must select by the exact
+identifier and fail closed when no supported version matches.
+
+Implementation changes that preserve the complete v1 admission set, typed
+meaning, canonical bytes, identity, and protocol behavior do not require a new
+identifier. New runtime capability names and higher available capability
+levels are also compatible because each release declares and verifies its own
+requirements.

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -10,14 +10,19 @@ checksum = "35b83be97f61abdd33096446eae063f9d65d98e84c446560b59d3c744194287e"
 
 [[package]]
 name = "a3s-acl"
-version = "0.2.1"
-source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22#6e2a6469edc0f4c61b1e588d0ace873aaf15ce22"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add06e627b80ea0d3f6de5ecfb2708cfcf4c6d022806ae33aec0905aeffde3ce"
+dependencies = [
+ "ryu-js",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "a3s-code-core"
 version = "6.0.0"
 dependencies = [
- "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
+ "a3s-acl 0.3.0",
  "a3s-common",
  "a3s-flow",
  "a3s-lane",
@@ -45,7 +50,6 @@ dependencies = [
  "ignore",
  "jsonschema",
  "libc",
- "lopdf",
  "lsp-types",
  "notify",
  "pdf-extract",
@@ -159,7 +163,7 @@ dependencies = [
 name = "a3s-search"
 version = "1.4.3"
 dependencies = [
- "a3s-acl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "a3s-acl 0.2.1",
  "a3s-updater",
  "a3s-use-browser",
  "anyhow",
@@ -242,6 +246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
 dependencies = [
  "pom",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -984,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1123,12 @@ dependencies = [
  "uuid",
  "web-time",
 ]
+
+[[package]]
+name = "cff-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
 
 [[package]]
 name = "cfg-if"
@@ -1194,6 +1233,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -1672,6 +1721,15 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ego-tree"
@@ -2620,6 +2678,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,21 +2851,28 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
- "chrono",
+ "aes",
+ "bitflags 2.13.0",
+ "cbc",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.3",
  "indexmap",
  "itoa",
  "log",
  "md-5 0.10.6",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.2",
  "rangemap",
- "rayon",
- "time",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "weezl",
 ]
 
@@ -3292,13 +3367,15 @@ dependencies = [
 
 [[package]]
 name = "pdf-extract"
-version = "0.7.12"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
+ "cff-parser",
  "encoding_rs",
  "euclid",
+ "log",
  "lopdf",
  "postscript",
  "type1-encoding-parser",
@@ -3652,26 +3729,6 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -4038,6 +4095,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -4450,6 +4513,17 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -4926,6 +5000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4959,6 +5039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4978,6 +5064,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -10,14 +10,19 @@ checksum = "35b83be97f61abdd33096446eae063f9d65d98e84c446560b59d3c744194287e"
 
 [[package]]
 name = "a3s-acl"
-version = "0.2.1"
-source = "git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22#6e2a6469edc0f4c61b1e588d0ace873aaf15ce22"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add06e627b80ea0d3f6de5ecfb2708cfcf4c6d022806ae33aec0905aeffde3ce"
+dependencies = [
+ "ryu-js",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "a3s-code-core"
 version = "6.0.0"
 dependencies = [
- "a3s-acl 0.2.1 (git+https://github.com/A3S-Lab/ACL.git?rev=6e2a6469edc0f4c61b1e588d0ace873aaf15ce22)",
+ "a3s-acl 0.3.0",
  "a3s-common",
  "a3s-flow",
  "a3s-lane",
@@ -45,7 +50,6 @@ dependencies = [
  "ignore",
  "jsonschema",
  "libc",
- "lopdf",
  "lsp-types",
  "notify",
  "pdf-extract",
@@ -158,7 +162,7 @@ dependencies = [
 name = "a3s-search"
 version = "1.4.3"
 dependencies = [
- "a3s-acl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "a3s-acl 0.2.1",
  "a3s-updater",
  "a3s-use-browser",
  "anyhow",
@@ -241,6 +245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
 dependencies = [
  "pom",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -983,6 +998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1094,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cff-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5810ca1a2b5870df2aab1c03e11c40c361ba51d6e3e361e56310f1cb3b4e087"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1140,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chromiumoxide"
@@ -1182,6 +1232,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -1646,6 +1706,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ego-tree"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,10 +2106,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2626,6 +2698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,21 +2876,28 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
-version = "0.34.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
- "chrono",
+ "aes",
+ "bitflags 2.11.1",
+ "cbc",
+ "ecb",
  "encoding_rs",
  "flate2",
+ "getrandom 0.4.2",
  "indexmap",
  "itoa",
  "log",
  "md-5 0.10.6",
- "nom 7.1.3",
+ "nom 8.0.0",
+ "rand 0.10.2",
  "rangemap",
- "rayon",
- "time",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "weezl",
 ]
 
@@ -3252,13 +3341,15 @@ dependencies = [
 
 [[package]]
 name = "pdf-extract"
-version = "0.7.12"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+checksum = "417e8fdc940f1d5bc62c5f89864c3a2255f74f69aa353c98509213d67df61e73"
 dependencies = [
  "adobe-cmap-parser",
+ "cff-parser",
  "encoding_rs",
  "euclid",
+ "log",
  "lopdf",
  "postscript",
  "type1-encoding-parser",
@@ -3652,6 +3743,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,30 +3792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -4080,6 +4168,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -4495,6 +4589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4682,7 +4787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4976,6 +5080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5009,6 +5119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5028,6 +5144,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"


### PR DESCRIPTION
## Summary

- add a closed, bounded `.a3s/asset.acl` v1 admission API backed by `a3s-acl` 0.3.0
- bind canonical release identity to an immutable OCI digest, static entrypoint, health declaration, storage modes, capability requirements, typed secret slots, and digest-bound provenance
- verify exact protocol and minimum capability levels before activation with stable, value-redacting diagnostics
- publish a schema/identity contract fixture with a pinned canonical identity and document the compatibility and breaking-change policy

## Contract boundaries

This is the manifest/admission slice of #10. It deliberately does **not** claim that the current daemon implements the declared HTTP readiness/liveness endpoints, bounded graceful shutdown, or headless request protocol. The checked-in fixture uses placeholder artifact/provenance digests and is not a deployable Runtime Service fixture.

Secret blocks contain only a slot name plus an environment or canonical `/run/secrets/` destination. Plaintext, ciphertext, external secret identifiers, provider resource names, and tenant references are rejected by the closed schema or excluded from the type model.

`capability`, `secret`, and `provenance` blocks are schema-declared unordered sets; ordered values such as entrypoint arguments retain their order. The fixture identity is pinned to catch canonicalization drift across repositories.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo test --workspace` (2,453 core tests passed, 10 ignored; integration and doc tests passed)
- `cargo test --workspace --all-features --lib` (2,499 passed, 10 ignored)
- `cargo test -p a3s-code-core --test agent_release_manifest` (8 passed)
- `node scripts/generate_event_protocol_artifacts.mjs --check`
- `node scripts/sdk_api_alignment_check.mjs`
- `cargo check --locked --manifest-path sdk/node/Cargo.toml`
- `cargo check --locked --manifest-path sdk/python/Cargo.toml`
- `bash scripts/check_semver.sh 5.3.5`
- `cargo package -p a3s-code-core --allow-dirty --no-verify --locked`
- `cargo doc --workspace --no-deps --locked` (passes with one pre-existing private intra-doc-link warning in `core/src/mcp/result.rs`)

The SDK lock refresh also reconciles their previously stale `pdf-extract`/`lopdf` entries with the versions already declared by Core.

## Follow-up for #10

Keep #10 open for observable daemon preparation, actual readiness/liveness and request serving, bounded joined shutdown, a real immutable image build, Runtime Service deployment evidence, and cross-repository A0 certification.
