### PR TITLE
feat(search): default to AnySearch 2.0

### DIFF
--- a/.github/setup-workspace.sh
+++ b/.github/setup-workspace.sh
@@ -15,6 +15,7 @@ sed -i.bak \
   -e 's|a3s-memory = { version = "0.1.1", path = "../../memory" }|a3s-memory = "0.1.1"|' \
   -e 's|a3s-lane = { version = "0.5", path = "../../lane" }|a3s-lane = "0.5"|' \
   -e 's|a3s-lane = { version = "0.4", path = "../../lane" }|a3s-lane = "0.4"|' \
+  -e 's|a3s-search = { version = "2.0.0", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "2.0.0", default-features = false, features = ["lightpanda"] }|' \
   -e 's|a3s-search = { version = "1.4.3", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "1.4.3", default-features = false, features = ["lightpanda"] }|' \
   -e 's|a3s-search = { version = "1.3.0", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "1.3.0", default-features = false, features = ["lightpanda"] }|' \
   -e 's|a3s-search = { version = "1.2.3", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "1.2.3", default-features = false, features = ["lightpanda"] }|' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-07-20
+
 ### Added
 
 - Added a closed, bounded `.a3s/asset.acl` Agent release contract with immutable
   OCI and provenance digests, static entrypoint and health declarations, typed
   storage boundaries, schema-aware canonical identity, and pre-activation
   protocol and capability checks.
+- Integrated `a3s-search` 2.0 native AnySearch and Tavily providers into the
+  built-in `web_search` engine catalog. Both providers support their documented
+  credential-free modes and optional environment-based authentication.
+
+### Changed
+
+- Made AnySearch the sole built-in default for `web_search` when neither the
+  request nor `SearchConfig` selects engines. Explicit request and ACL engine
+  selections continue to override the built-in default.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-search"
-version = "1.4.3"
+version = "2.0.0"
 dependencies = [
  "a3s-acl 0.2.1",
  "a3s-updater",
@@ -2620,7 +2620,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3885,7 +3885,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3922,7 +3922,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/README.md
+++ b/README.md
@@ -280,13 +280,18 @@ object-only backend that cannot execute it.
 | Workspace search | `glob`, `grep` | Bounded matching with explicit result metadata and continuation |
 | Code Intelligence | `code_symbols`, `code_navigation`, `code_diagnostics` | Saved-file semantic metadata and locations with bounded results; source retrieval and mutation stay in the existing file tools |
 | Commands and source control | `bash`, `git` | Bounded output, cancellation, process-group termination on Unix, and typed Git operations |
-| Web evidence | `web_search`, `web_fetch` | Ranked multi-engine search, normalized sources, SSRF protections, extraction, and bounded pages |
+| Web evidence | `web_search`, `web_fetch` | AnySearch by default, optional Tavily and conventional engines, normalized sources, SSRF protections, extraction, and bounded pages |
 | Structured output | `generate_object` | Schema-constrained model generation with validation and repair |
 | Composition | `batch`, `program` | Safe batch scheduling and sandboxed JavaScript programmatic tool calling |
 | Delegation | `task`, `parallel_task` | Foreground/background workers, bounded parallelism, partial results, and task tracking |
 | Skills | `Skill`, `search_skills` | Filesystem or inline skill discovery and execution with optional tool restrictions |
 | MCP | `mcp__<server>__<tool>` | Namespaced tools owned by their source manager |
 | Dynamic workflows | `dynamic_workflow` | Explicitly registered A3S Flow-backed, replayable per-turn workflows |
+
+Without an explicit request or `SearchConfig` engine selection, `web_search`
+uses AnySearch in its anonymous mode. Set `ANYSEARCH_API_KEY` to authenticate,
+or select `tavily`, `ddg`, `wiki`, and the other documented engines through
+the tool arguments or ACL configuration.
 
 Standalone greetings are conversational turns: the model receives no tool
 definitions and a friendly response is not converted into a synthetic

--- a/agent.example.acl
+++ b/agent.example.acl
@@ -81,7 +81,8 @@ search {
     suspend_seconds = 60
   }
 
-  # Engine configurations
+  # Engine configurations. Omit this block to use the built-in AnySearch
+  # default; any entries here explicitly replace that default selection.
   engine {
     google {
       enabled = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 a3s-common = { version = "0.1.1", path = "../../common" }
 a3s-memory = { version = "0.1.2", path = "../../memory" }
 a3s-lane = { version = "0.5", path = "../../lane" }
-a3s-search = { version = "1.4.3", path = "../../search", default-features = false, features = ["lightpanda"] }
+a3s-search = { version = "2.0.0", path = "../../search", default-features = false, features = ["lightpanda"] }
 a3s-flow = { version = "0.4.2", path = "../../flow" }
 
 # Async runtime

--- a/core/src/tools/builtin/web_search.rs
+++ b/core/src/tools/builtin/web_search.rs
@@ -7,6 +7,7 @@ use a3s_search::engines::{
     Baidu, BingChina, BingParser, BraveParser, DuckDuckGoParser, Google, So360Parser, SogouParser,
     Wikipedia,
 };
+use a3s_search::providers::BuiltinProvider;
 use a3s_search::proxy::{ProxyConfig, ProxyPool};
 use a3s_search::WaitStrategy;
 use a3s_search::{
@@ -285,6 +286,25 @@ fn add_http_engine(search: &mut Search, shortcut: &str, proxy_url: Option<&str>)
             search.add_engine(BingChina::new(Arc::new(fetcher())));
             true
         }
+        "anysearch" | "tavily" => {
+            let Some(provider) = BuiltinProvider::from_id(shortcut.trim()) else {
+                return false;
+            };
+            match provider.create_engine() {
+                Ok(engine) => {
+                    search.add_engine(engine);
+                    true
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        provider = shortcut.trim(),
+                        %error,
+                        "Could not initialize native search provider"
+                    );
+                    false
+                }
+            }
+        }
         _ => false,
     }
 }
@@ -302,7 +322,7 @@ fn default_engine_selection(
                 .collect(),
             "config",
         ),
-        _ => (vec!["ddg", "wiki"], "builtin_default"),
+        _ => (vec!["anysearch"], "builtin_default"),
     }
 }
 
@@ -336,9 +356,9 @@ impl Tool for WebSearchTool {
     }
 
     fn description(&self) -> &str {
-        "Search the web using multiple search engines. Aggregates results from multiple engines \
-         (DuckDuckGo, Wikipedia, Brave, Bing, Sogou, 360, Google, Baidu, Bing China, etc.). \
-         Supports proxy configuration for anti-crawler protection. Returns deduplicated and ranked results. \
+        "Search the web using AnySearch by default or an explicit set of native providers and \
+         search engines. Supports AnySearch, Tavily, DuckDuckGo, Wikipedia, Brave, Bing, Sogou, \
+         360, Google, Baidu, and Bing China. Returns normalized, deduplicated, and ranked results. \
          Google and Baidu use a headless browser; Bing China uses its HTTP RSS endpoint."
     }
 
@@ -356,7 +376,7 @@ impl Tool for WebSearchTool {
                     "items": {
                         "type": "string"
                     },
-                    "description": "Optional. List of search engines to use. Default: [\"ddg\",\"wiki\"]. Available: ddg (DuckDuckGo), brave (Brave Search), bing (Bing RSS), wiki (Wikipedia), sogou (Sogou), 360 / so360 (360 Search), bing_cn (Bing China RSS), g / google (Google, headless), baidu (Baidu, headless)."
+                    "description": "Optional. List of native providers or search engines to use. Default: [\"anysearch\"]. Available: anysearch (anonymous or authenticated native provider), tavily (keyless or authenticated native provider), ddg (DuckDuckGo), brave (Brave Search), bing (Bing RSS), wiki (Wikipedia), sogou (Sogou), 360 / so360 (360 Search), bing_cn (Bing China RSS), g / google (Google, headless), baidu (Baidu, headless)."
                 },
                 "limit": {
                     "type": "integer",

--- a/core/src/tools/builtin/web_search/tests.rs
+++ b/core/src/tools/builtin/web_search/tests.rs
@@ -61,14 +61,14 @@ fn search_config(engines: HashMap<String, SearchEngineConfig>) -> SearchConfig {
 }
 
 #[test]
-fn default_engine_selection_uses_builtin_defaults_without_engine_configuration() {
+fn default_engine_selection_uses_anysearch_without_engine_configuration() {
     let (engines, source) = default_engine_selection(None);
-    assert_eq!(engines, ["ddg", "wiki"]);
+    assert_eq!(engines, ["anysearch"]);
     assert_eq!(source, "builtin_default");
 
     let config = search_config(HashMap::new());
     let (engines, source) = default_engine_selection(Some(&config));
-    assert_eq!(engines, ["ddg", "wiki"]);
+    assert_eq!(engines, ["anysearch"]);
     assert_eq!(source, "builtin_default");
 }
 
@@ -382,7 +382,12 @@ fn test_web_search_schema_is_canonical() {
     assert_eq!(examples[1]["engines"].as_array().unwrap(), &["ddg", "wiki"]);
     assert!(params["properties"]["engines"]["description"]
         .as_str()
-        .is_some_and(|description| description.contains("bing (Bing RSS)")));
+        .is_some_and(|description| {
+            description.contains("Default: [\"anysearch\"]")
+                && description.contains("anysearch")
+                && description.contains("tavily")
+                && description.contains("bing (Bing RSS)")
+        }));
 }
 
 #[test]
@@ -426,6 +431,12 @@ fn test_add_http_engine_valid() {
 
     assert!(add_http_engine(&mut search, "bing_cn", None));
     assert_eq!(search.engine_count(), 5);
+
+    assert!(add_http_engine(&mut search, "anysearch", None));
+    assert_eq!(search.engine_count(), 6);
+
+    assert!(add_http_engine(&mut search, "tavily", None));
+    assert_eq!(search.engine_count(), 7);
 }
 
 #[test]

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-search"
-version = "1.4.3"
+version = "2.0.0"
 dependencies = [
  "a3s-acl 0.2.1",
  "a3s-updater",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.0.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.1.0", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.0.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.0.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.0.0",
-        "@a3s-lab/code-linux-x64-musl": "6.0.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.0.0"
+        "@a3s-lab/code-darwin-arm64": "6.1.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.1.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.1.0",
+        "@a3s-lab/code-linux-x64-musl": "6.1.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.1.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/examples/search/test_search_config.ts
+++ b/sdk/node/examples/search/test_search_config.ts
@@ -2,7 +2,7 @@
 /**
  * A3S Code Node.js SDK - Web Search Configuration Test
  *
- * Tests A3S Search v0.7.0 configurable web search with real LLM.
+ * Tests A3S Search v2.0.0 configurable web search with real LLM.
  *
  * Run with: npx ts-node examples/test_search_config.ts
  */
@@ -60,10 +60,10 @@ class SearchConfigTest {
     console.log("\nTest 1: Default Search Configuration");
     console.log("-".repeat(80));
 
-    // Use config from file (should have default search engines)
+    // Use config from file (uses AnySearch when no engines are configured)
     const session: Session = this.agent.session(".");
 
-    console.log("Testing: Web search with default engines (ddg, wiki)...");
+    console.log("Testing: Web search with the default AnySearch provider...");
     try {
       const result: AgentResult = await session.send("Search the web for 'Rust async programming' and give me the top 3 results");
       console.log("Default search works");

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.0.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.0.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.0.0",
-        "@a3s-lab/code-linux-x64-musl": "6.0.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.0.0"
+        "@a3s-lab/code-darwin-arm64": "6.1.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.1.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.1.0",
+        "@a3s-lab/code-linux-x64-musl": "6.1.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.1.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "6.0.0",
-    "@a3s-lab/code-linux-x64-gnu": "6.0.0",
-    "@a3s-lab/code-linux-x64-musl": "6.0.0",
-    "@a3s-lab/code-linux-arm64-gnu": "6.0.0",
-    "@a3s-lab/code-linux-arm64-musl": "6.0.0",
-    "@a3s-lab/code-win32-x64-msvc": "6.0.0"
+    "@a3s-lab/code-darwin-arm64": "6.1.0",
+    "@a3s-lab/code-linux-x64-gnu": "6.1.0",
+    "@a3s-lab/code-linux-x64-musl": "6.1.0",
+    "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
+    "@a3s-lab/code-linux-arm64-musl": "6.1.0",
+    "@a3s-lab/code-win32-x64-msvc": "6.1.0"
   }
 }

--- a/sdk/python-bootstrap/README.md
+++ b/sdk/python-bootstrap/README.md
@@ -44,4 +44,4 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.0.0`.
+Replace `<VERSION>` with the release to install, for example `6.1.0`.

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "6.0.0"
+version = "6.1.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "6.0.0"
+__version__ = "6.1.0"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-07-20
+
+### Changed
+
+- Updated the bundled Core to `a3s-search` 2.0, with AnySearch as the default
+  web-search provider and Tavily available as an explicit native provider.
+
 ## [6.0.0] - 2026-07-19
 
 ### Changed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-search"
-version = "1.4.3"
+version = "2.0.0"
 dependencies = [
  "a3s-acl 0.2.1",
  "a3s-updater",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.0.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.1.0", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -28,7 +28,7 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.0.0`.
+Replace `<VERSION>` with the release to install, for example `6.1.0`.
 
 ## Quick Start
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "6.0.0"
+version = "6.1.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- upgrade A3S Code Core to `a3s-search` 2.0.0
- register the native AnySearch and Tavily providers in `web_search`
- use AnySearch as the built-in default while preserving request and ACL engine overrides
- prepare aligned Core, Node, Python, and bootstrap 6.1.0 release metadata and docs

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `scripts/release_preflight.sh` (all 12 gates; real LLM smoke explicitly skipped)
- `cargo check` for Node and Python SDK crates
- `scripts/check_semver.sh 5.3.5`
- `cargo publish --manifest-path core/Cargo.toml --dry-run --allow-dirty`
- Node SDK runtime/type/helper tests and examples typecheck
- Python bootstrap unit tests, wheel/sdist build, and Twine check
- live credential-free AnySearch query returned results

Search 2.0.0 is published on crates.io and its release workflow completed successfully.