### PR TITLE
feat(sandbox): ship SRT process isolation in v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-07-22
+
+### Added
+
+- Added a fail-closed SRT-backed `BashSandbox` with bounded execution,
+  separated output streams, protected workspace control metadata, credential
+  read boundaries, and verified exact-path npm and Node runtime constructors.
+
 ### Fixed
 
 - Forwarded delegated child confirmation-required, confirmation-received, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,6 +81,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
  "wiremock",
  "zip 0.6.6",
 ]

--- a/README.md
+++ b/README.md
@@ -302,6 +302,53 @@ directories, `AgentDir`, inline host input, or live registration. The
 model-visible `program` tool executes JavaScript in QuickJS, not arbitrary
 Python or a shell-script catalog.
 
+### Process sandbox contract
+
+Hosts can attach a `BashSandbox` through `SessionOptions::with_sandbox_handle`.
+The extended execution request preserves the command, guest workspace, timeout,
+stream observer, and explicit command environment; existing implementations
+remain compatible through `exec_command`.
+
+`SrtBashSandbox` is the fail-closed local adapter. It denies command network
+egress, local binding, and Unix sockets; limits writes to the active workspace
+and a private per-run scratch directory; protects repository and agent-control
+metadata; blocks common credential reads; and scrubs ambient secrets and
+language/bootstrap injection variables. It keeps stdout and stderr distinct
+under one global capture limit. Its deadline covers output draining and the
+child's complete lifetime, including a process that closes both streams before
+it exits; timeout or cancellation terminates the Unix process group. It never
+searches `PATH` for a sandbox runtime and never falls back to the host runner
+when its explicitly provisioned runtime is missing or fails. The embedding host
+remains responsible for choosing whether an unavailable sandbox causes an
+interactive escalation or a deterministic denial.
+
+Shell isolation does not automatically govern in-process workspace tools.
+Interactive hosts should construct `LocalWorkspaceBackend` or
+`ManifestWorkspaceBackend` with
+`LocalWorkspaceAccessPolicy::CredentialBoundary`. That opt-in applies the
+credential boundary to direct reads, range reads, writes, and both indexed and
+fallback grep. Directory grep omits denied candidates, explicit sensitive
+targets fail closed, source-tree multi-link files are rejected, and ordinary
+package-store hardlinks remain usable unless they alias a discovered
+credential inode. Guarded local Git diff enumerates changed paths with Git's
+NUL-delimited format and regenerates output only for allowed paths; option-like
+revision input cannot become a Git flag, and displayed remote URLs omit
+embedded HTTP credentials and query tokens.
+
+Hosts use `from_verified_npm_with_node` when a lifecycle owner supplies exact
+SRT and Node paths. The verified constructor requires the expected npm package
+identity and a tested SRT version; `new` likewise requires an explicit path for
+an intentionally supplied custom adapter. The A3S CLI uses the verified
+exact-path form after validating and, when policy allows, preparing its
+user-wide managed installation; Core does not install host software.
+
+This adapter is a low-latency local enforcement provider, not the stack-wide
+workload contract. Code owns agent permission and escalation policy, A3S
+Runtime owns provider-neutral Task and Service lifecycle and placement, and A3S
+Box owns OCI and stronger-isolation workloads. Replacing the CLI's transitional
+npm bootstrap with an A3S-signed sandbox artifact does not change the
+`BashSandbox` contract.
+
 Long-running hosts can call `AgentSession::add_skill`, `remove_skill`, and
 `skill_names` without rebuilding the session. The model-visible Skill catalog
 reads the same live registry, so a successful mutation is visible on the next

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -121,6 +121,9 @@ aws-smithy-runtime-api = { version = "1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [features]
 default = []

--- a/core/src/sandbox.rs
+++ b/core/src/sandbox.rs
@@ -11,6 +11,63 @@
 //! user installs `a3s-box`). This crate defines only the trait contract.
 
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::workspace::CommandOutputObserver;
+
+pub mod srt;
+
+/// Workspace-relative directories whose contents can change the agent,
+/// repository, editor, or tool control plane.
+///
+/// Ordinary sandboxed commands and quiet workspace file mutations must not
+/// write these paths. An interactive host may expose an explicit, auditable
+/// escalation path instead.
+pub const PROTECTED_WORKSPACE_DIRECTORIES: &[&str] = &[
+    ".git", ".a3s", ".agents", ".codex", ".claude", ".vscode", ".idea",
+];
+
+/// Workspace-relative files that can change command discovery or repository
+/// behavior even though they are not contained in a protected directory.
+pub const PROTECTED_WORKSPACE_FILES: &[&str] = &[
+    ".gitmodules",
+    ".mcp.json",
+    ".ripgreprc",
+    ".bashrc",
+    ".bash_profile",
+    ".zshrc",
+    ".zprofile",
+    ".profile",
+];
+
+/// Return whether a workspace-relative path targets protected control
+/// metadata.
+///
+/// Both separators are recognized so policy decisions are stable before a
+/// platform-specific workspace resolver consumes the path. Boundary traversal
+/// is handled separately by the workspace guardrail and is never treated as a
+/// protected-path approval request.
+pub fn is_protected_workspace_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    let mut components = normalized
+        .split('/')
+        .filter(|component| !component.is_empty() && *component != ".");
+    let Some(first) = components.next() else {
+        return false;
+    };
+    if first == ".." || components.clone().any(|component| component == "..") {
+        return false;
+    }
+
+    PROTECTED_WORKSPACE_DIRECTORIES
+        .iter()
+        .any(|protected| first.eq_ignore_ascii_case(protected))
+        || PROTECTED_WORKSPACE_FILES
+            .iter()
+            .any(|protected| first.eq_ignore_ascii_case(protected))
+}
+
 /// Output from running a command inside a sandbox.
 pub struct SandboxOutput {
     /// Standard output bytes decoded as UTF-8.
@@ -19,6 +76,53 @@ pub struct SandboxOutput {
     pub stderr: String,
     /// Process exit code (0 = success).
     pub exit_code: i32,
+}
+
+/// Complete request passed to sandbox implementations that support the
+/// execution controls used by the built-in `bash` tool.
+///
+/// The legacy [`BashSandbox::exec_command`] method remains the minimum
+/// compatibility contract. New implementations should override
+/// [`BashSandbox::exec`] so command timeouts, streaming output, and explicit
+/// host-provided environment values are preserved inside the sandbox.
+#[derive(Clone)]
+pub struct SandboxCommandRequest {
+    pub command: String,
+    pub guest_workspace: String,
+    pub timeout_ms: u64,
+    pub output_observer: Option<Arc<dyn CommandOutputObserver>>,
+    pub env: Option<Arc<HashMap<String, String>>>,
+}
+
+impl std::fmt::Debug for SandboxCommandRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxCommandRequest")
+            .field("command", &self.command)
+            .field("guest_workspace", &self.guest_workspace)
+            .field("timeout_ms", &self.timeout_ms)
+            .field("output_observer", &self.output_observer.is_some())
+            .field("env", &self.env.as_ref().map(|env| env.len()))
+            .finish()
+    }
+}
+
+/// Output from the extended sandbox execution contract.
+pub struct SandboxExecutionOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub timed_out: bool,
+}
+
+impl From<SandboxOutput> for SandboxExecutionOutput {
+    fn from(output: SandboxOutput) -> Self {
+        Self {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.exit_code,
+            timed_out: false,
+        }
+    }
 }
 
 // ============================================================================
@@ -42,6 +146,18 @@ pub trait BashSandbox: Send + Sync {
         command: &str,
         guest_workspace: &str,
     ) -> anyhow::Result<SandboxOutput>;
+
+    /// Execute a command with the complete host tool contract.
+    ///
+    /// Existing implementations inherit a compatibility adapter that delegates
+    /// to [`Self::exec_command`]. Sandboxes that spawn a real process should
+    /// override this method so timeout and output-stream semantics are not
+    /// silently lost.
+    async fn exec(&self, request: SandboxCommandRequest) -> anyhow::Result<SandboxExecutionOutput> {
+        self.exec_command(&request.command, &request.guest_workspace)
+            .await
+            .map(Into::into)
+    }
 
     /// Shut down the sandbox (best-effort, infallible from caller's perspective).
     async fn shutdown(&self);
@@ -114,5 +230,36 @@ mod tests {
         });
         let result = sandbox.exec_command("true", "/workspace").await.unwrap();
         assert_eq!(result.exit_code, 0);
+    }
+
+    #[test]
+    fn protected_workspace_paths_cover_control_metadata_cross_platform() {
+        for path in [
+            ".git/config",
+            "./.a3s/permissions.acl",
+            ".AGENTS/worker.acl",
+            ".codex\\config",
+            ".Claude/settings.json",
+            ".vscode/tasks.json",
+            ".idea/workspace.xml",
+            ".gitmodules",
+            ".MCP.JSON",
+        ] {
+            assert!(
+                is_protected_workspace_path(path),
+                "{path} should require explicit host authorization"
+            );
+        }
+        for path in [
+            "src/lib.rs",
+            "nested/.git/config",
+            "AGENTS.md",
+            "../.git/config",
+        ] {
+            assert!(
+                !is_protected_workspace_path(path),
+                "{path} should be handled by another boundary or remain ordinary"
+            );
+        }
     }
 }

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -627,6 +627,7 @@ fn compose_srt_process_env(
     }
 }
 
+#[cfg(not(windows))]
 fn compose_wrapper_env(workspace: &Path) -> HashMap<OsString, OsString> {
     const SAFE_KEYS: &[&str] = &[
         "HOME",
@@ -707,6 +708,7 @@ fn remove_bootstrap_injection_variables(environment: &mut HashMap<OsString, OsSt
     });
 }
 
+#[cfg(not(windows))]
 fn environment_assignment(key: &OsStr, value: &OsStr) -> OsString {
     let mut assignment = key.to_os_string();
     assignment.push("=");
@@ -927,7 +929,7 @@ pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>>
                 pending.push((path, depth + 1));
                 continue;
             }
-            if metadata.is_file() && hard_link_count(&metadata) > 1 {
+            if metadata.is_file() && hard_link_count(&path, &metadata) > 1 {
                 hardlinks.push(path);
                 if hardlinks.len() > MAX_WORKSPACE_HARDLINK_DENIES {
                     bail!(
@@ -972,19 +974,32 @@ pub(crate) fn should_skip_workspace_scan_directory(name: &OsStr) -> bool {
 }
 
 #[cfg(unix)]
-pub(crate) fn hard_link_count(metadata: &std::fs::Metadata) -> u64 {
+pub(crate) fn hard_link_count(_path: &Path, metadata: &std::fs::Metadata) -> u64 {
     use std::os::unix::fs::MetadataExt;
     metadata.nlink()
 }
 
 #[cfg(windows)]
-pub(crate) fn hard_link_count(metadata: &std::fs::Metadata) -> u64 {
-    use std::os::windows::fs::MetadataExt;
-    u64::from(metadata.number_of_links().unwrap_or(1))
+pub(crate) fn hard_link_count(path: &Path, _metadata: &std::fs::Metadata) -> u64 {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return u64::MAX;
+    };
+    let mut information = unsafe { std::mem::zeroed::<BY_HANDLE_FILE_INFORMATION>() };
+    // SAFETY: `file` owns a valid handle for the duration of this call and
+    // `information` points to writable storage of the required type.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) } == 0 {
+        return u64::MAX;
+    }
+    u64::from(information.nNumberOfLinks.max(1))
 }
 
 #[cfg(not(any(unix, windows)))]
-pub(crate) fn hard_link_count(_metadata: &std::fs::Metadata) -> u64 {
+pub(crate) fn hard_link_count(_path: &Path, _metadata: &std::fs::Metadata) -> u64 {
     1
 }
 

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -21,7 +21,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_WORKSPACE_SCAN_ENTRIES: usize = 1_000_000;
 const MAX_WORKSPACE_SCAN_DEPTH: usize = 64;
 const MAX_WORKSPACE_HARDLINK_DENIES: usize = 4_096;
-/// npm package accepted by the verified SRT discovery path.
+/// npm package accepted by the verified SRT constructor.
 pub const SRT_NPM_PACKAGE_NAME: &str = "@anthropic-ai/sandbox-runtime";
 /// Exact SRT version provisioned by the current A3S CLI managed-runtime path.
 ///
@@ -47,6 +47,10 @@ pub struct SrtBashSandbox {
 impl SrtBashSandbox {
     /// Build an adapter from an explicit `srt` executable.
     pub fn new(binary: impl Into<PathBuf>, workspace: impl Into<PathBuf>) -> Result<Self> {
+        let binary = binary.into();
+        if binary.components().count() == 1 {
+            bail!("an explicit SRT executable path is required; PATH discovery is unsupported");
+        }
         let workspace = workspace
             .into()
             .canonicalize()
@@ -54,7 +58,7 @@ impl SrtBashSandbox {
         if !workspace.is_dir() {
             bail!("SRT workspace is not a directory: {}", workspace.display());
         }
-        let binary = resolve_executable(binary.into(), Some(&workspace))?;
+        let binary = resolve_executable(binary, Some(&workspace))?;
         if binary.starts_with(&workspace) {
             bail!(
                 "refusing to trust an SRT executable from inside the active workspace: {}",
@@ -66,24 +70,6 @@ impl SrtBashSandbox {
             .transpose()
             .context("failed to resolve a trusted Node.js launcher for SRT")?;
         Self::from_resolved(binary, node, workspace)
-    }
-
-    /// Discover a compatible npm-distributed `srt` on `PATH`.
-    ///
-    /// Missing executables return `Ok(None)` so the host can retain its
-    /// approval boundary without silently running on the host. A discovered
-    /// executable must resolve to the expected package and a tested pre-1.0
-    /// version; embedders that intentionally supply another implementation can
-    /// construct it explicitly with [`Self::new`].
-    pub fn discover(workspace: impl Into<PathBuf>) -> Result<Option<Self>> {
-        let workspace = workspace.into();
-        let canonical_workspace = workspace
-            .canonicalize()
-            .context("failed to canonicalize the SRT workspace")?;
-        let Some(binary) = find_executable_on_path("srt", Some(&canonical_workspace)) else {
-            return Ok(None);
-        };
-        Self::from_verified_npm(binary, canonical_workspace).map(Some)
     }
 
     /// Build an adapter from a compatible npm installation at an exact path.
@@ -437,19 +423,23 @@ fn node_script(path: &Path) -> bool {
 
 fn resolve_executable(binary: PathBuf, excluded_root: Option<&Path>) -> Result<PathBuf> {
     let candidate = if binary.components().count() == 1 {
-        find_executable_on_path(&binary, excluded_root)
-            .ok_or_else(|| anyhow!("SRT executable was not found on PATH: {}", binary.display()))?
+        find_executable_on_path(&binary, excluded_root).ok_or_else(|| {
+            anyhow!(
+                "required executable was not found on PATH: {}",
+                binary.display()
+            )
+        })?
     } else {
         binary
     };
     let candidate = candidate
         .canonicalize()
-        .with_context(|| format!("failed to resolve SRT executable {}", candidate.display()))?;
+        .with_context(|| format!("failed to resolve executable {}", candidate.display()))?;
     if !candidate.is_file() {
-        bail!("SRT executable is not a file: {}", candidate.display());
+        bail!("executable is not a file: {}", candidate.display());
     }
     if !is_executable(&candidate) {
-        bail!("SRT executable is not executable: {}", candidate.display());
+        bail!("executable is not executable: {}", candidate.display());
     }
     if excluded_root.is_some_and(|root| candidate.starts_with(root)) {
         bail!(

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -1,0 +1,1053 @@
+//! Local command sandbox backed by the `srt` process wrapper.
+//!
+//! The adapter deliberately has no unsandboxed fallback. Hosts decide whether
+//! an unavailable sandbox should require approval or fail closed before a tool
+//! reaches this implementation.
+
+use super::{
+    BashSandbox, SandboxCommandRequest, SandboxExecutionOutput, SandboxOutput,
+    PROTECTED_WORKSPACE_DIRECTORIES, PROTECTED_WORKSPACE_FILES,
+};
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use serde_json::json;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use tokio::process::Command;
+
+const DEFAULT_TIMEOUT_MS: u64 = 120_000;
+const MAX_WORKSPACE_SCAN_ENTRIES: usize = 1_000_000;
+const MAX_WORKSPACE_SCAN_DEPTH: usize = 64;
+const MAX_WORKSPACE_HARDLINK_DENIES: usize = 4_096;
+/// npm package accepted by the verified SRT discovery path.
+pub const SRT_NPM_PACKAGE_NAME: &str = "@anthropic-ai/sandbox-runtime";
+/// Exact SRT version provisioned by the current A3S CLI managed-runtime path.
+///
+/// Core accepts the tested compatibility range below so a host can roll a
+/// compatible patch independently. The CLI deliberately installs one exact
+/// version until an A3S-signed component artifact replaces registry bootstrap.
+pub const MANAGED_SRT_VERSION: &str = "0.0.66";
+const MINIMUM_SRT_VERSION: (u64, u64, u64) = (0, 0, 66);
+const MAXIMUM_SRT_VERSION_EXCLUSIVE: (u64, u64, u64) = (0, 1, 0);
+
+/// An `srt`-backed local command sandbox rooted at one workspace.
+#[derive(Debug)]
+pub struct SrtBashSandbox {
+    binary: PathBuf,
+    node: Option<PathBuf>,
+    shell: PathBuf,
+    #[cfg(not(windows))]
+    env_binary: PathBuf,
+    workspace: PathBuf,
+    workspace_hardlink_paths: Vec<PathBuf>,
+}
+
+impl SrtBashSandbox {
+    /// Build an adapter from an explicit `srt` executable.
+    pub fn new(binary: impl Into<PathBuf>, workspace: impl Into<PathBuf>) -> Result<Self> {
+        let workspace = workspace
+            .into()
+            .canonicalize()
+            .context("failed to canonicalize the SRT workspace")?;
+        if !workspace.is_dir() {
+            bail!("SRT workspace is not a directory: {}", workspace.display());
+        }
+        let binary = resolve_executable(binary.into(), Some(&workspace))?;
+        if binary.starts_with(&workspace) {
+            bail!(
+                "refusing to trust an SRT executable from inside the active workspace: {}",
+                binary.display()
+            );
+        }
+        let node = node_script(&binary)
+            .then(|| resolve_executable(PathBuf::from("node"), Some(&workspace)))
+            .transpose()
+            .context("failed to resolve a trusted Node.js launcher for SRT")?;
+        Self::from_resolved(binary, node, workspace)
+    }
+
+    /// Discover a compatible npm-distributed `srt` on `PATH`.
+    ///
+    /// Missing executables return `Ok(None)` so the host can retain its
+    /// approval boundary without silently running on the host. A discovered
+    /// executable must resolve to the expected package and a tested pre-1.0
+    /// version; embedders that intentionally supply another implementation can
+    /// construct it explicitly with [`Self::new`].
+    pub fn discover(workspace: impl Into<PathBuf>) -> Result<Option<Self>> {
+        let workspace = workspace.into();
+        let canonical_workspace = workspace
+            .canonicalize()
+            .context("failed to canonicalize the SRT workspace")?;
+        let Some(binary) = find_executable_on_path("srt", Some(&canonical_workspace)) else {
+            return Ok(None);
+        };
+        Self::from_verified_npm(binary, canonical_workspace).map(Some)
+    }
+
+    /// Build an adapter from a compatible npm installation at an exact path.
+    ///
+    /// Unlike [`Self::new`], this path verifies the package identity and tested
+    /// version before accepting its CLI. It is intended for embedding hosts
+    /// that provision SRT outside `PATH`.
+    pub fn from_verified_npm(
+        binary: impl Into<PathBuf>,
+        workspace: impl Into<PathBuf>,
+    ) -> Result<Self> {
+        let binary = binary.into();
+        let installation = inspect_srt_installation(&binary)?;
+        ensure_supported_srt_version(&installation.version)?;
+        Self::new(installation.cli, workspace)
+    }
+
+    /// Build from a verified npm installation and an explicitly selected Node
+    /// executable.
+    ///
+    /// Managed hosts use this form so command startup cannot select a different
+    /// `node` from a later `PATH` entry after provisioning has completed.
+    pub fn from_verified_npm_with_node(
+        binary: impl Into<PathBuf>,
+        node: impl Into<PathBuf>,
+        workspace: impl Into<PathBuf>,
+    ) -> Result<Self> {
+        let workspace = workspace
+            .into()
+            .canonicalize()
+            .context("failed to canonicalize the SRT workspace")?;
+        if !workspace.is_dir() {
+            bail!("SRT workspace is not a directory: {}", workspace.display());
+        }
+        let installation = inspect_srt_installation(&binary.into())?;
+        ensure_supported_srt_version(&installation.version)?;
+        let binary = resolve_executable(installation.cli, Some(&workspace))?;
+        let node = resolve_executable(node.into(), Some(&workspace))
+            .context("failed to resolve the managed Node.js launcher for SRT")?;
+        Self::from_resolved(binary, Some(node), workspace)
+    }
+
+    pub fn binary(&self) -> &Path {
+        &self.binary
+    }
+
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    fn settings(&self, scratch: &Path) -> Result<serde_json::Value> {
+        let mut deny_write = protected_workspace_paths(&self.workspace);
+        if let Some(git_dir) = resolved_git_dir(&self.workspace) {
+            deny_write.push(git_dir);
+        }
+        let mut sensitive_paths = sensitive_paths();
+        sensitive_paths.extend(workspace_sensitive_paths(&self.workspace)?);
+        sensitive_paths.extend(self.workspace_hardlink_paths.iter().cloned());
+        let mut deny_read = sensitive_paths.clone();
+        deny_read.extend(read_denied_roots());
+        let mut allow_read = readable_tool_paths(&self.workspace, scratch);
+        deny_write.extend(sensitive_paths.iter().cloned());
+        deduplicate_paths(&mut deny_write);
+        deduplicate_paths(&mut sensitive_paths);
+        deduplicate_paths(&mut deny_read);
+        deduplicate_paths(&mut allow_read);
+
+        Ok(json!({
+            "network": {
+                "allowedDomains": [],
+                "deniedDomains": [],
+                "allowUnixSockets": [],
+                "allowAllUnixSockets": false,
+                "allowLocalBinding": false
+            },
+            "filesystem": {
+                "allowWrite": path_strings([self.workspace.as_path(), scratch]),
+                "denyWrite": path_strings(deny_write.iter().map(PathBuf::as_path)),
+                "denyRead": path_strings(deny_read.iter().map(PathBuf::as_path)),
+                // User and temporary roots are hidden, then the workspace,
+                // private scratch directory, and explicit toolchain roots are
+                // re-exposed. The tested SRT range preserves more-specific
+                // literal credential denies inside an allowed workspace.
+                "allowRead": path_strings(allow_read.iter().map(PathBuf::as_path))
+            },
+            "mandatoryDenySearchDepth": 10,
+            "enableWeakerNestedSandbox": false,
+            "enableWeakerNetworkIsolation": false,
+            "allowAppleEvents": false
+        }))
+    }
+
+    fn from_resolved(binary: PathBuf, node: Option<PathBuf>, workspace: PathBuf) -> Result<Self> {
+        #[cfg(not(windows))]
+        let shell = resolve_executable(PathBuf::from("bash"), Some(&workspace))
+            .context("failed to resolve a trusted bash executable for SRT")?;
+        #[cfg(windows)]
+        let shell = resolve_executable(PathBuf::from("powershell.exe"), Some(&workspace))
+            .context("failed to resolve a trusted PowerShell executable for SRT")?;
+        #[cfg(not(windows))]
+        let env_binary = resolve_executable(PathBuf::from("env"), Some(&workspace))
+            .context("failed to resolve a trusted env executable for SRT")?;
+        let workspace_hardlink_paths = workspace_hardlink_paths(&workspace)?;
+        Ok(Self {
+            binary,
+            node,
+            shell,
+            #[cfg(not(windows))]
+            env_binary,
+            workspace,
+            workspace_hardlink_paths,
+        })
+    }
+
+    async fn execute_request(
+        &self,
+        request: SandboxCommandRequest,
+    ) -> Result<SandboxExecutionOutput> {
+        let scratch = tempfile::Builder::new()
+            .prefix("a3s-code-srt-")
+            .tempdir()
+            .context("failed to create SRT scratch directory")?;
+        let settings_path = scratch.path().join("settings.json");
+        let settings = serde_json::to_vec(&self.settings(scratch.path())?)
+            .context("failed to serialize SRT settings")?;
+        tokio::fs::write(&settings_path, settings)
+            .await
+            .context("failed to write SRT settings")?;
+
+        let mut command = if let Some(node) = &self.node {
+            let mut command = Command::new(node);
+            command.arg(&self.binary);
+            command
+        } else {
+            Command::new(&self.binary)
+        };
+        command
+            .arg("--settings")
+            .arg(&settings_path)
+            // Stop the SRT CLI parser before the wrapped executable's flags.
+            // Without this delimiter, flags such as `env -i` or PowerShell's
+            // `-NoProfile` are consumed as SRT options before the sandbox
+            // command is constructed.
+            .arg("--");
+        #[cfg(not(windows))]
+        {
+            command.arg(&self.env_binary).arg("-i");
+            for (key, value) in compose_child_env(request.env.as_deref(), scratch.path())? {
+                command.arg(environment_assignment(&key, &value));
+            }
+            command.arg(&self.shell).arg("-c").arg(&request.command);
+        }
+        #[cfg(windows)]
+        {
+            let wrapped = crate::tools::builtin::bash::build_powershell_command(&request.command);
+            let encoded = crate::tools::builtin::bash::encode_powershell_command(&wrapped);
+            command
+                .arg(&self.shell)
+                .args([
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-EncodedCommand",
+                    &encoded,
+                ])
+                .creation_flags(crate::tools::builtin::bash::CREATE_NO_WINDOW);
+        }
+        command
+            .current_dir(&self.workspace)
+            .env_clear()
+            .envs(compose_srt_process_env(
+                request.env.as_deref(),
+                scratch.path(),
+                &self.workspace,
+            )?)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        crate::tools::process::configure_process_group(&mut command);
+
+        let mut child = command
+            .spawn()
+            .with_context(|| format!("failed to start SRT executable {}", self.binary.display()))?;
+        let process = crate::tools::process::read_process_output(
+            &mut child,
+            request.timeout_ms,
+            request.output_observer.as_deref(),
+        )
+        .await
+        .context("failed to wait for SRT command")?;
+        if process.timed_out {
+            return Ok(SandboxExecutionOutput {
+                stdout: process.stdout,
+                stderr: process.stderr,
+                exit_code: -1,
+                timed_out: true,
+            });
+        }
+
+        Ok(SandboxExecutionOutput {
+            stdout: process.stdout,
+            stderr: process.stderr,
+            exit_code: process
+                .status
+                .and_then(|status| status.code())
+                .unwrap_or(-1),
+            timed_out: false,
+        })
+    }
+}
+
+#[async_trait]
+impl BashSandbox for SrtBashSandbox {
+    async fn exec_command(&self, command: &str, guest_workspace: &str) -> Result<SandboxOutput> {
+        let output = self
+            .execute_request(SandboxCommandRequest {
+                command: command.to_string(),
+                guest_workspace: guest_workspace.to_string(),
+                timeout_ms: DEFAULT_TIMEOUT_MS,
+                output_observer: None,
+                env: None,
+            })
+            .await?;
+        Ok(SandboxOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.exit_code,
+        })
+    }
+
+    async fn exec(&self, request: SandboxCommandRequest) -> Result<SandboxExecutionOutput> {
+        self.execute_request(request).await
+    }
+
+    async fn shutdown(&self) {}
+}
+
+#[derive(Debug)]
+struct SrtInstallation {
+    cli: PathBuf,
+    version: String,
+}
+
+fn inspect_srt_installation(binary: &Path) -> Result<SrtInstallation> {
+    let canonical = binary
+        .canonicalize()
+        .with_context(|| format!("failed to resolve SRT executable {}", binary.display()))?;
+    let mut roots = canonical
+        .ancestors()
+        .take(5)
+        .map(Path::to_path_buf)
+        .collect::<Vec<_>>();
+    if binary
+        .parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name.eq_ignore_ascii_case(".bin"))
+    {
+        if let Some(node_modules) = binary.parent().and_then(Path::parent) {
+            roots.push(node_modules.join("@anthropic-ai").join("sandbox-runtime"));
+        }
+    }
+    deduplicate_paths(&mut roots);
+
+    for root in roots {
+        let manifest_path = root.join("package.json");
+        let Ok(source) = std::fs::read(&manifest_path) else {
+            continue;
+        };
+        let manifest: serde_json::Value = serde_json::from_slice(&source)
+            .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
+        if manifest.get("name").and_then(serde_json::Value::as_str) != Some(SRT_NPM_PACKAGE_NAME) {
+            continue;
+        }
+        let version = manifest
+            .get("version")
+            .and_then(serde_json::Value::as_str)
+            .filter(|version| !version.trim().is_empty())
+            .ok_or_else(|| anyhow!("SRT package manifest has no version"))?
+            .to_string();
+        let cli = root
+            .join("dist")
+            .join("cli.js")
+            .canonicalize()
+            .context("failed to resolve the SRT package CLI")?;
+        if !cli.is_file() {
+            bail!("SRT package CLI is not a file: {}", cli.display());
+        }
+        return Ok(SrtInstallation { cli, version });
+    }
+
+    bail!(
+        "refusing unverified `srt` from {}: expected package {}",
+        binary.display(),
+        SRT_NPM_PACKAGE_NAME
+    )
+}
+
+fn ensure_supported_srt_version(version: &str) -> Result<()> {
+    let parsed = parse_semver_triplet(version)
+        .ok_or_else(|| anyhow!("unsupported SRT version format: {version}"))?;
+    if parsed < MINIMUM_SRT_VERSION || parsed >= MAXIMUM_SRT_VERSION_EXCLUSIVE {
+        bail!(
+            "unsupported SRT version {version}; expected >= {}.{}.{} and < {}.{}.{}",
+            MINIMUM_SRT_VERSION.0,
+            MINIMUM_SRT_VERSION.1,
+            MINIMUM_SRT_VERSION.2,
+            MAXIMUM_SRT_VERSION_EXCLUSIVE.0,
+            MAXIMUM_SRT_VERSION_EXCLUSIVE.1,
+            MAXIMUM_SRT_VERSION_EXCLUSIVE.2,
+        );
+    }
+    Ok(())
+}
+
+fn parse_semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
+    let core = version
+        .trim()
+        .strip_prefix('v')
+        .unwrap_or(version.trim())
+        .split(['-', '+'])
+        .next()?;
+    let mut components = core.split('.');
+    let parsed = (
+        components.next()?.parse().ok()?,
+        components.next()?.parse().ok()?,
+        components.next()?.parse().ok()?,
+    );
+    components.next().is_none().then_some(parsed)
+}
+
+fn node_script(path: &Path) -> bool {
+    if path
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("js"))
+    {
+        return true;
+    }
+    std::fs::read(path)
+        .ok()
+        .and_then(|source| source.get(..source.len().min(128)).map(Vec::from))
+        .and_then(|prefix| String::from_utf8(prefix).ok())
+        .is_some_and(|prefix| {
+            prefix
+                .lines()
+                .next()
+                .is_some_and(|line| line.starts_with("#!") && line.contains("node"))
+        })
+}
+
+fn resolve_executable(binary: PathBuf, excluded_root: Option<&Path>) -> Result<PathBuf> {
+    let candidate = if binary.components().count() == 1 {
+        find_executable_on_path(&binary, excluded_root)
+            .ok_or_else(|| anyhow!("SRT executable was not found on PATH: {}", binary.display()))?
+    } else {
+        binary
+    };
+    let candidate = candidate
+        .canonicalize()
+        .with_context(|| format!("failed to resolve SRT executable {}", candidate.display()))?;
+    if !candidate.is_file() {
+        bail!("SRT executable is not a file: {}", candidate.display());
+    }
+    if !is_executable(&candidate) {
+        bail!("SRT executable is not executable: {}", candidate.display());
+    }
+    if excluded_root.is_some_and(|root| candidate.starts_with(root)) {
+        bail!(
+            "refusing executable from inside the active workspace: {}",
+            candidate.display()
+        );
+    }
+    Ok(candidate)
+}
+
+fn find_executable_on_path(
+    binary: impl AsRef<OsStr>,
+    excluded_root: Option<&Path>,
+) -> Option<PathBuf> {
+    let binary = binary.as_ref();
+    let path = std::env::var_os("PATH")?;
+    for directory in std::env::split_paths(&path) {
+        let candidate = directory.join(binary);
+        if executable_is_trusted(&candidate, excluded_root) {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            for extension in executable_extensions() {
+                let candidate = directory.join(format!(
+                    "{}{}",
+                    binary.to_string_lossy(),
+                    extension.to_string_lossy()
+                ));
+                if executable_is_trusted(&candidate, excluded_root) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn executable_is_trusted(candidate: &Path, excluded_root: Option<&Path>) -> bool {
+    if !candidate.is_file() || !is_executable(candidate) {
+        return false;
+    }
+    let Ok(canonical) = candidate.canonicalize() else {
+        return false;
+    };
+    !excluded_root.is_some_and(|root| canonical.starts_with(root))
+}
+
+#[cfg(windows)]
+fn executable_extensions() -> Vec<OsString> {
+    std::env::var_os("PATHEXT")
+        .map(|value| {
+            value
+                .to_string_lossy()
+                .split(';')
+                .filter(|value| !value.is_empty())
+                .map(OsString::from)
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            [".COM", ".EXE", ".BAT", ".CMD"]
+                .into_iter()
+                .map(OsString::from)
+                .collect()
+        })
+}
+
+fn is_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+fn compose_child_env(
+    explicit: Option<&HashMap<String, String>>,
+    scratch: &Path,
+) -> Result<HashMap<OsString, OsString>> {
+    const SAFE_KEYS: &[&str] = &[
+        "PATH",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TZ",
+        "TERM",
+        "COLORTERM",
+        "NO_COLOR",
+        "CI",
+        "CARGO_HOME",
+        "RUSTUP_HOME",
+        "RUSTC_WRAPPER",
+        "GOPATH",
+        "GOROOT",
+        "GOMODCACHE",
+        "NVM_DIR",
+        "FNM_DIR",
+        "VOLTA_HOME",
+        "BUN_INSTALL",
+        "DENO_DIR",
+        "PNPM_HOME",
+        "JAVA_HOME",
+        "GRADLE_USER_HOME",
+        "MAVEN_HOME",
+        "SDKROOT",
+        "DEVELOPER_DIR",
+        "PKG_CONFIG_PATH",
+        "LIBRARY_PATH",
+        "CPATH",
+        "CC",
+        "CXX",
+        "AR",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+    ];
+
+    let mut environment = HashMap::new();
+    for key in SAFE_KEYS {
+        if let Some(value) = std::env::var_os(key) {
+            environment.insert(OsString::from(key), value);
+        }
+    }
+    for (key, value) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("LC_") {
+            environment.insert(key, value);
+        }
+    }
+    if let Some(explicit) = explicit {
+        for (key, value) in explicit {
+            if key.is_empty() || key.contains('=') || key.contains('\0') || value.contains('\0') {
+                bail!("invalid explicit command environment entry: {key:?}");
+            }
+            environment.insert(OsString::from(key), OsString::from(value));
+        }
+    }
+    // Explicit command variables may add ordinary data, but they must not
+    // re-enable shell, language-runtime, or dynamic-loader bootstrap hooks.
+    // Apply this after explicit values so callers cannot override the denylist.
+    remove_bootstrap_injection_variables(&mut environment);
+
+    let scratch = scratch.as_os_str().to_os_string();
+    environment.insert(OsString::from("HOME"), scratch.clone());
+    environment.insert(OsString::from("TMPDIR"), scratch.clone());
+    environment.insert(OsString::from("TMP"), scratch.clone());
+    environment.insert(OsString::from("TEMP"), scratch.clone());
+    environment.insert(OsString::from("XDG_CACHE_HOME"), scratch.clone());
+    environment.insert(OsString::from("XDG_CONFIG_HOME"), scratch.clone());
+    environment.insert(OsString::from("XDG_DATA_HOME"), scratch.clone());
+    environment.insert(OsString::from("XDG_STATE_HOME"), scratch);
+    Ok(environment)
+}
+
+fn compose_srt_process_env(
+    explicit: Option<&HashMap<String, String>>,
+    scratch: &Path,
+    workspace: &Path,
+) -> Result<HashMap<OsString, OsString>> {
+    #[cfg(not(windows))]
+    {
+        let _ = explicit;
+        let _ = scratch;
+        Ok(compose_wrapper_env(workspace))
+    }
+    #[cfg(windows)]
+    {
+        let mut environment = compose_child_env(explicit, scratch)?;
+        remove_bootstrap_injection_variables(&mut environment);
+        if let Some(path) = trusted_wrapper_path(workspace) {
+            environment.insert(OsString::from("PATH"), path);
+        } else {
+            environment.remove(OsStr::new("PATH"));
+        }
+        Ok(environment)
+    }
+}
+
+fn compose_wrapper_env(workspace: &Path) -> HashMap<OsString, OsString> {
+    const SAFE_KEYS: &[&str] = &[
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TZ",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+    ];
+    let mut environment = HashMap::new();
+    for key in SAFE_KEYS {
+        if let Some(value) = std::env::var_os(key) {
+            environment.insert(OsString::from(key), value);
+        }
+    }
+    for (key, value) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("LC_") {
+            environment.insert(key, value);
+        }
+    }
+    if let Some(path) = trusted_wrapper_path(workspace) {
+        environment.insert(OsString::from("PATH"), path);
+    }
+    remove_bootstrap_injection_variables(&mut environment);
+    environment
+}
+
+fn trusted_wrapper_path(workspace: &Path) -> Option<OsString> {
+    let path = std::env::var_os("PATH")?;
+    let directories = std::env::split_paths(&path)
+        .filter_map(|directory| {
+            let absolute = if directory.is_absolute() {
+                directory
+            } else {
+                std::env::current_dir().ok()?.join(directory)
+            };
+            let canonical = absolute.canonicalize().ok()?;
+            (canonical.is_dir() && !canonical.starts_with(workspace)).then_some(canonical)
+        })
+        .collect::<Vec<_>>();
+    std::env::join_paths(directories).ok()
+}
+
+fn remove_bootstrap_injection_variables(environment: &mut HashMap<OsString, OsString>) {
+    const BLOCKED: &[&str] = &[
+        "BASH_ENV",
+        "ENV",
+        "NODE_OPTIONS",
+        "NODE_PATH",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "PYTHONINSPECT",
+        "RUBYOPT",
+        "RUBYLIB",
+        "PERL5OPT",
+        "PERL5LIB",
+        "LUA_INIT",
+        "JAVA_TOOL_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "_JAVA_OPTIONS",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+    ];
+    environment.retain(|key, _| {
+        let key = key.to_string_lossy();
+        !BLOCKED
+            .iter()
+            .any(|blocked| key.eq_ignore_ascii_case(blocked))
+            && !key.to_ascii_uppercase().starts_with("LUA_INIT_")
+    });
+}
+
+fn environment_assignment(key: &OsStr, value: &OsStr) -> OsString {
+    let mut assignment = key.to_os_string();
+    assignment.push("=");
+    assignment.push(value);
+    assignment
+}
+
+pub(crate) fn sensitive_paths() -> Vec<PathBuf> {
+    let mut paths = dirs::home_dir()
+        .map(|home| default_sensitive_paths(&home))
+        .unwrap_or_default();
+
+    extend_configured_secret(&mut paths, "CODEX_HOME", Some("auth.json"));
+    extend_configured_secret(&mut paths, "CLAUDE_CONFIG_DIR", Some(".credentials.json"));
+    extend_configured_secret(&mut paths, "CARGO_HOME", Some("credentials"));
+    extend_configured_secret(&mut paths, "CARGO_HOME", Some("credentials.toml"));
+    for variable in ["A3S_KIMI_HOME", "KIMI_CODE_HOME", "KIMI_SHARE_DIR"] {
+        extend_configured_secret(&mut paths, variable, Some("credentials/kimi-code.json"));
+    }
+    for variable in [
+        "A3S_KIMI_DESKTOP_HOME",
+        "KIMI_DESKTOP_HOME",
+        "WORKBUDDY_CONFIG_DIR",
+        "CODEBUDDY_CONFIG_DIR",
+    ] {
+        extend_configured_secret(&mut paths, variable, None);
+    }
+    paths
+}
+
+fn read_denied_roots() -> Vec<PathBuf> {
+    #[cfg(windows)]
+    {
+        // The Windows provider runs commands under its dedicated sandbox user.
+        // Broad parent-directory DENY ACEs would override the narrower
+        // workspace grant, so rely on that account boundary plus the explicit
+        // credential denies above.
+        Vec::new()
+    }
+    #[cfg(not(windows))]
+    {
+        let mut roots = Vec::new();
+        if let Some(home) = dirs::home_dir() {
+            roots.push(home);
+        }
+        let temp = std::env::temp_dir();
+        roots.push(temp.canonicalize().unwrap_or(temp));
+        roots
+    }
+}
+
+fn readable_tool_paths(workspace: &Path, scratch: &Path) -> Vec<PathBuf> {
+    const TOOLCHAIN_ROOTS: &[&str] = &[
+        "CARGO_HOME",
+        "RUSTUP_HOME",
+        "GOPATH",
+        "GOROOT",
+        "GOMODCACHE",
+        "NVM_DIR",
+        "FNM_DIR",
+        "VOLTA_HOME",
+        "BUN_INSTALL",
+        "DENO_DIR",
+        "PNPM_HOME",
+        "JAVA_HOME",
+        "GRADLE_USER_HOME",
+        "MAVEN_HOME",
+        "SDKROOT",
+        "DEVELOPER_DIR",
+    ];
+
+    let mut paths = vec![workspace.to_path_buf(), scratch.to_path_buf()];
+    for variable in TOOLCHAIN_ROOTS {
+        let Some(path) = std::env::var_os(variable).filter(|value| !value.is_empty()) else {
+            continue;
+        };
+        let path = PathBuf::from(path);
+        if path.is_absolute() && path.exists() {
+            paths.push(path.canonicalize().unwrap_or(path));
+        }
+    }
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path).filter_map(|path| {
+            if !path.is_absolute() || !path.exists() {
+                return None;
+            }
+            path.canonicalize().ok()
+        }));
+    }
+    paths
+}
+
+fn default_sensitive_paths(home: &Path) -> Vec<PathBuf> {
+    [
+        ".ssh",
+        ".gnupg",
+        ".aws",
+        ".azure",
+        ".kube",
+        ".docker",
+        ".config/gcloud",
+        ".config/gh",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".cargo/credentials",
+        ".cargo/credentials.toml",
+        ".codex/auth.json",
+        ".claude/.credentials.json",
+        ".claude.json",
+        ".git-credentials",
+        ".config/git/credentials",
+        ".workbuddy",
+        "credentials/kimi-code.json",
+        ".kimi-code/credentials/kimi-code.json",
+        ".kimi/credentials/kimi-code.json",
+        ".config/kimi-desktop/daimon-share",
+        "Library/Application Support/kimi-desktop/daimon-share",
+        ".config/opencode/auth.json",
+        ".local/share/opencode/auth.json",
+        ".gemini/oauth_creds.json",
+        ".terraform.d/credentials.tfrc.json",
+        ".local/share/keyrings",
+        ".password-store",
+        ".a3s/os-auth.json",
+        "Library/Keychains",
+    ]
+    .into_iter()
+    .map(|path| home.join(path))
+    .collect()
+}
+
+pub(crate) fn workspace_sensitive_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let mut paths = [
+        ".env",
+        ".env.local",
+        ".env.development",
+        ".env.production",
+        ".env.test",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        ".git-credentials",
+        ".a3s/os-auth.json",
+        ".codex/auth.json",
+        ".claude/.credentials.json",
+        ".claude.json",
+    ]
+    .into_iter()
+    .map(|path| workspace.join(path))
+    .collect::<Vec<_>>();
+    paths.extend(workspace_nested_env_paths(workspace)?);
+    Ok(paths)
+}
+
+fn workspace_nested_env_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let mut pending = vec![(workspace.to_path_buf(), 0usize)];
+    let mut scanned = 0usize;
+    let mut paths = Vec::new();
+
+    while let Some((directory, depth)) = pending.pop() {
+        let entries = std::fs::read_dir(&directory)
+            .with_context(|| format!("failed to scan SRT workspace {}", directory.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!("failed to enumerate SRT workspace {}", directory.display())
+            })?;
+            scanned = next_workspace_scan_entry(scanned)?;
+            let path = entry.path();
+            let file_type = entry.file_type().with_context(|| {
+                format!("failed to inspect SRT workspace path {}", path.display())
+            })?;
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(".env"))
+            {
+                paths.push(path);
+            } else if file_type.is_dir() {
+                if should_skip_workspace_scan_directory(&entry.file_name()) {
+                    continue;
+                }
+                ensure_workspace_scan_depth(depth, &path)?;
+                pending.push((path, depth + 1));
+            }
+        }
+    }
+
+    Ok(paths)
+}
+
+pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let mut pending = vec![(workspace.to_path_buf(), 0usize)];
+    let mut scanned = 0usize;
+    let mut hardlinks = Vec::new();
+
+    while let Some((directory, depth)) = pending.pop() {
+        let entries = std::fs::read_dir(&directory)
+            .with_context(|| format!("failed to scan SRT workspace {}", directory.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| {
+                format!("failed to enumerate SRT workspace {}", directory.display())
+            })?;
+            scanned = next_workspace_scan_entry(scanned)?;
+
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path).with_context(|| {
+                format!("failed to inspect SRT workspace path {}", path.display())
+            })?;
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                if should_skip_workspace_scan_directory(&entry.file_name()) {
+                    continue;
+                }
+                ensure_workspace_scan_depth(depth, &path)?;
+                pending.push((path, depth + 1));
+                continue;
+            }
+            if metadata.is_file() && hard_link_count(&metadata) > 1 {
+                hardlinks.push(path);
+                if hardlinks.len() > MAX_WORKSPACE_HARDLINK_DENIES {
+                    bail!(
+                        "SRT workspace contains more than {MAX_WORKSPACE_HARDLINK_DENIES} multi-link files"
+                    );
+                }
+            }
+        }
+    }
+
+    hardlinks.sort();
+    hardlinks.dedup();
+    Ok(hardlinks)
+}
+
+fn next_workspace_scan_entry(scanned: usize) -> Result<usize> {
+    let scanned = scanned
+        .checked_add(1)
+        .context("SRT workspace scan entry count overflowed")?;
+    if scanned > MAX_WORKSPACE_SCAN_ENTRIES {
+        bail!("SRT workspace exceeds the {MAX_WORKSPACE_SCAN_ENTRIES} entry scan limit");
+    }
+    Ok(scanned)
+}
+
+fn ensure_workspace_scan_depth(depth: usize, path: &Path) -> Result<()> {
+    if depth >= MAX_WORKSPACE_SCAN_DEPTH {
+        bail!(
+            "SRT workspace exceeds the {MAX_WORKSPACE_SCAN_DEPTH}-level scan depth at {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn should_skip_workspace_scan_directory(name: &OsStr) -> bool {
+    // Control metadata is already write-protected, while dependency and build
+    // trees commonly contain legitimate package-store hardlinks and can be
+    // extremely large. The local boundary governs source-tree work; hostile
+    // dependency/build execution belongs in the stronger Box/Runtime boundary.
+    matches!(name.to_str(), Some(".git" | "node_modules" | "target"))
+}
+
+#[cfg(unix)]
+pub(crate) fn hard_link_count(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    metadata.nlink()
+}
+
+#[cfg(windows)]
+pub(crate) fn hard_link_count(metadata: &std::fs::Metadata) -> u64 {
+    use std::os::windows::fs::MetadataExt;
+    u64::from(metadata.number_of_links().unwrap_or(1))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn hard_link_count(_metadata: &std::fs::Metadata) -> u64 {
+    1
+}
+
+fn extend_configured_secret(paths: &mut Vec<PathBuf>, variable: &str, suffix: Option<&str>) {
+    let Some(root) = std::env::var_os(variable).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    if !root.is_absolute() {
+        return;
+    }
+    paths.push(match suffix {
+        Some(suffix) => root.join(suffix),
+        None => root,
+    });
+}
+
+fn protected_workspace_paths(workspace: &Path) -> Vec<PathBuf> {
+    PROTECTED_WORKSPACE_DIRECTORIES
+        .iter()
+        .chain(PROTECTED_WORKSPACE_FILES)
+        .copied()
+        .map(|path| workspace.join(path))
+        .collect()
+}
+
+fn resolved_git_dir(workspace: &Path) -> Option<PathBuf> {
+    let dot_git = workspace.join(".git");
+    if dot_git.is_dir() {
+        return dot_git.canonicalize().ok();
+    }
+    let source = std::fs::read_to_string(dot_git).ok()?;
+    let relative = source.trim().strip_prefix("gitdir:")?.trim();
+    let path = Path::new(relative);
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        workspace.join(path)
+    };
+    path.canonicalize().ok()
+}
+
+fn deduplicate_paths(paths: &mut Vec<PathBuf>) {
+    paths.sort();
+    paths.dedup();
+}
+
+fn path_strings<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Vec<String> {
+    paths
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -1,0 +1,568 @@
+use super::*;
+use crate::sandbox::BashSandbox;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+fn fake_srt(capture_path: &Path) -> (TempDir, PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let directory = tempfile::tempdir().unwrap();
+    let binary = directory.path().join("srt");
+    std::fs::write(
+        &binary,
+        format!(
+            "#!/bin/sh\n\
+             if [ \"$1\" = \"--settings\" ]; then\n\
+               cp \"$2\" '{}'\n\
+               shift 2\n\
+             fi\n\
+             if [ \"$1\" = \"--\" ]; then\n\
+               shift\n\
+             fi\n\
+             exec \"$@\"\n",
+            capture_path.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&binary, permissions).unwrap();
+    (directory, binary)
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn adapter_passes_argv_workspace_timeout_env_and_settings() {
+    let workspace = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(workspace.path().join("services/api")).unwrap();
+    std::fs::write(workspace.path().join("services/api/.env"), "SECRET=hidden").unwrap();
+    let capture = workspace.path().join("captured-settings.json");
+    let (_binary_dir, binary) = fake_srt(&capture);
+    let sandbox = SrtBashSandbox::new(binary, workspace.path()).unwrap();
+    let output = sandbox
+        .exec(SandboxCommandRequest {
+            command: "printf '%s|%s' \"$PWD\" \"$EXPLICIT_VALUE\"".to_string(),
+            guest_workspace: "/workspace".to_string(),
+            timeout_ms: 5_000,
+            output_observer: None,
+            env: Some(Arc::new(HashMap::from([(
+                "EXPLICIT_VALUE".to_string(),
+                "kept".to_string(),
+            )]))),
+        })
+        .await
+        .unwrap();
+
+    assert!(!output.timed_out);
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(
+        output.stdout,
+        format!(
+            "{}|kept",
+            workspace.path().canonicalize().unwrap().display()
+        )
+    );
+    let settings: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+    assert_eq!(settings["network"]["allowedDomains"], json!([]));
+    assert_eq!(settings["network"]["allowLocalBinding"], false);
+    assert!(settings["filesystem"]["allowWrite"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path == &json!(workspace.path().canonicalize().unwrap())));
+    assert!(settings["filesystem"]["denyWrite"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("/.a3s")));
+    assert!(settings["filesystem"]["denyWrite"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("/.claude")));
+    assert!(settings["filesystem"]["denyWrite"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("/.mcp.json")));
+    assert!(settings["filesystem"]["allowRead"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path == &json!(workspace.path().canonicalize().unwrap())));
+    assert!(settings["filesystem"]["denyRead"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("/.codex/auth.json")));
+    assert!(settings["filesystem"]["denyRead"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path == &json!(workspace.path().canonicalize().unwrap().join(".env"))));
+    assert!(settings["filesystem"]["denyRead"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path
+            == &json!(workspace
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join("services/api/.env"))));
+    assert!(settings["filesystem"]["denyWrite"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path.as_str().unwrap().ends_with("/.codex/auth.json")));
+    assert_eq!(settings["enableWeakerNestedSandbox"], false);
+    assert_eq!(settings["allowAppleEvents"], false);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn adapter_denies_every_preexisting_workspace_hardlink_alias() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    std::fs::create_dir_all(workspace.join("nested")).unwrap();
+    let outside = root.path().join("outside-secret");
+    let alias = workspace.join("nested").join("apparently-safe.txt");
+    std::fs::write(&outside, "outside-secret").unwrap();
+    std::fs::hard_link(&outside, &alias).unwrap();
+    let canonical_alias = alias.canonicalize().unwrap();
+
+    let capture = root.path().join("captured-settings.json");
+    let (_binary_dir, binary) = fake_srt(&capture);
+    let sandbox = SrtBashSandbox::new(binary, &workspace).unwrap();
+    sandbox
+        .exec_command("printf ready", "/workspace")
+        .await
+        .unwrap();
+
+    let settings: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(capture).unwrap()).unwrap();
+    for boundary in ["denyRead", "denyWrite"] {
+        assert!(
+            settings["filesystem"][boundary]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|path| path == &json!(canonical_alias)),
+            "{boundary} omitted a multi-link workspace alias"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn adapter_preserves_stdout_and_stderr_as_separate_streams() {
+    let workspace = tempfile::tempdir().unwrap();
+    let capture = workspace.path().join("captured-settings.json");
+    let (_binary_dir, binary) = fake_srt(&capture);
+    let sandbox = SrtBashSandbox::new(binary, workspace.path()).unwrap();
+
+    let output = sandbox
+        .exec(SandboxCommandRequest {
+            command: "printf stdout-value; printf stderr-value >&2".to_string(),
+            guest_workspace: "/workspace".to_string(),
+            timeout_ms: 5_000,
+            output_observer: None,
+            env: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(!output.timed_out);
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(output.stdout, "stdout-value");
+    assert_eq!(output.stderr, "stderr-value");
+}
+
+#[test]
+fn child_environment_drops_ambient_secrets_and_pins_scratch_paths() {
+    let scratch = tempfile::tempdir().unwrap();
+    let environment = compose_child_env(None, scratch.path()).unwrap();
+
+    assert!(!environment.contains_key(OsStr::new("OPENAI_API_KEY")));
+    assert!(!environment.contains_key(OsStr::new("ANTHROPIC_API_KEY")));
+    assert!(!environment.contains_key(OsStr::new("SSH_AUTH_SOCK")));
+    assert_eq!(
+        environment.get(OsStr::new("HOME")),
+        Some(&scratch.path().as_os_str().to_os_string())
+    );
+    assert_eq!(
+        environment.get(OsStr::new("TMPDIR")),
+        Some(&scratch.path().as_os_str().to_os_string())
+    );
+    assert_eq!(
+        environment.get(OsStr::new("XDG_CONFIG_HOME")),
+        Some(&scratch.path().as_os_str().to_os_string())
+    );
+}
+
+#[test]
+fn child_environment_rejects_explicit_bootstrap_injection_variables() {
+    let scratch = tempfile::tempdir().unwrap();
+    let explicit = HashMap::from([
+        ("SAFE_VALUE".to_string(), "kept".to_string()),
+        ("BASH_ENV".to_string(), "/tmp/bash-hook".to_string()),
+        (
+            "node_options".to_string(),
+            "--require=/tmp/hook.js".to_string(),
+        ),
+        ("NODE_PATH".to_string(), "/tmp/node-modules".to_string()),
+        ("PYTHONPATH".to_string(), "/tmp/python".to_string()),
+        ("RUBYOPT".to_string(), "-r/tmp/hook.rb".to_string()),
+        ("PERL5OPT".to_string(), "-M/tmp/hook.pm".to_string()),
+        ("LUA_INIT_5_4".to_string(), "@/tmp/hook.lua".to_string()),
+        ("LD_PRELOAD".to_string(), "/tmp/hook.so".to_string()),
+        (
+            "DYLD_INSERT_LIBRARIES".to_string(),
+            "/tmp/hook.dylib".to_string(),
+        ),
+        (
+            "JAVA_TOOL_OPTIONS".to_string(),
+            "-javaagent:/tmp/hook.jar".to_string(),
+        ),
+    ]);
+
+    let environment = compose_child_env(Some(&explicit), scratch.path()).unwrap();
+
+    assert_eq!(
+        environment.get(OsStr::new("SAFE_VALUE")),
+        Some(&OsString::from("kept"))
+    );
+    for key in explicit.keys().filter(|key| key.as_str() != "SAFE_VALUE") {
+        assert!(
+            !environment
+                .keys()
+                .any(|candidate| candidate.to_string_lossy().eq_ignore_ascii_case(key)),
+            "{key} must not reach the sandbox child"
+        );
+    }
+}
+
+#[test]
+fn supported_srt_version_range_is_explicit() {
+    for version in ["0.0.66", "v0.0.66", "0.0.99-beta.1"] {
+        ensure_supported_srt_version(version).unwrap();
+    }
+    for version in ["0.0.65", "0.1.0", "1.0.0", "unknown"] {
+        assert!(
+            ensure_supported_srt_version(version).is_err(),
+            "{version} must not enter the trusted discovery path"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn discovered_installation_uses_the_expected_package_manifest_and_cli() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().unwrap();
+    let package = root
+        .path()
+        .join("node_modules/@anthropic-ai/sandbox-runtime");
+    let cli = package.join("dist/cli.js");
+    std::fs::create_dir_all(cli.parent().unwrap()).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        serde_json::json!({
+            "name": SRT_NPM_PACKAGE_NAME,
+            "version": "0.0.66"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(&cli, "#!/usr/bin/env node\n").unwrap();
+    let mut permissions = std::fs::metadata(&cli).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&cli, permissions).unwrap();
+
+    let installation = inspect_srt_installation(&cli).unwrap();
+    assert_eq!(installation.cli, cli.canonicalize().unwrap());
+    assert_eq!(installation.version, "0.0.66");
+}
+
+#[cfg(unix)]
+#[test]
+fn workspace_cannot_supply_the_sandbox_executable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = tempfile::tempdir().unwrap();
+    let binary = workspace.path().join("srt");
+    std::fs::write(&binary, "#!/bin/sh\nexec \"$@\"\n").unwrap();
+    let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&binary, permissions).unwrap();
+
+    let error = SrtBashSandbox::new(&binary, workspace.path()).unwrap_err();
+    assert!(error.to_string().contains("inside the active workspace"));
+}
+
+#[test]
+fn sensitive_paths_cover_agent_cloud_and_package_credentials() {
+    let paths = default_sensitive_paths(Path::new("/home/a3s-test"));
+    for suffix in [
+        ".ssh",
+        ".aws",
+        ".kube",
+        ".docker",
+        ".codex/auth.json",
+        ".claude/.credentials.json",
+        ".git-credentials",
+        "credentials/kimi-code.json",
+        ".a3s/os-auth.json",
+        ".cargo/credentials.toml",
+    ] {
+        assert!(
+            paths.iter().any(|path| path.ends_with(suffix)),
+            "missing sensitive path {suffix}"
+        );
+    }
+}
+
+/// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/srt` to verify
+/// the real OS boundary rather than the fake argv adapter above.
+#[tokio::test]
+#[ignore = "requires an installed srt runtime"]
+async fn real_srt_allows_workspace_writes_and_blocks_outside_writes() {
+    let binary = std::env::var_os("A3S_TEST_SRT_BIN")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_BIN");
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let outside = root.path().join("outside");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    let sandbox = SrtBashSandbox::new(binary, &workspace).unwrap();
+
+    let allowed = sandbox
+        .exec_command("printf ok > inside.txt", "/workspace")
+        .await
+        .unwrap();
+    assert_eq!(allowed.exit_code, 0, "{}", allowed.stderr);
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("inside.txt")).unwrap(),
+        "ok"
+    );
+
+    let denied = sandbox
+        .exec_command(
+            &format!("printf escaped > {}/escaped.txt", outside.display()),
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_ne!(denied.exit_code, 0);
+    assert!(!outside.join("escaped.txt").exists());
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&outside, workspace.join("outside-link")).unwrap();
+        let denied = sandbox
+            .exec_command(
+                "printf escaped > outside-link/symlink-escaped.txt",
+                "/workspace",
+            )
+            .await
+            .unwrap();
+        assert_ne!(denied.exit_code, 0);
+        assert!(!outside.join("symlink-escaped.txt").exists());
+    }
+}
+
+/// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/srt`.
+#[tokio::test]
+#[ignore = "requires an installed srt runtime"]
+async fn real_srt_denies_network_and_protected_workspace_metadata() {
+    let binary = std::env::var_os("A3S_TEST_SRT_BIN")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_BIN");
+    let workspace = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(workspace.path().join(".git")).unwrap();
+    std::fs::create_dir_all(workspace.path().join(".a3s")).unwrap();
+    std::fs::create_dir_all(workspace.path().join(".claude")).unwrap();
+    std::fs::write(workspace.path().join(".git/config"), "original-git").unwrap();
+    std::fs::write(workspace.path().join(".a3s/policy.acl"), "original-policy").unwrap();
+    std::fs::write(
+        workspace.path().join(".claude/settings.json"),
+        "original-agent-settings",
+    )
+    .unwrap();
+    let sandbox = SrtBashSandbox::new(binary, workspace.path()).unwrap();
+
+    let network = sandbox
+        .exec_command(
+            "curl --connect-timeout 2 --max-time 5 -fsS https://example.com >/dev/null",
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        network.exit_code, 0,
+        "network egress unexpectedly succeeded: {}{}",
+        network.stdout, network.stderr
+    );
+
+    let local_binding = sandbox
+        .exec_command(
+            "python3 -c 'import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0))'",
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        local_binding.exit_code, 0,
+        "local binding unexpectedly succeeded: {}{}",
+        local_binding.stdout, local_binding.stderr
+    );
+
+    let unix_socket = sandbox
+        .exec_command(
+            "python3 -c 'import socket; s=socket.socket(socket.AF_UNIX); s.bind(\"blocked.sock\")'",
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        unix_socket.exit_code, 0,
+        "Unix socket binding unexpectedly succeeded: {}{}",
+        unix_socket.stdout, unix_socket.stderr
+    );
+    assert!(!workspace.path().join("blocked.sock").exists());
+
+    for (command, path, original) in [
+        (
+            "printf changed > .git/config",
+            ".git/config",
+            "original-git",
+        ),
+        (
+            "printf changed > .a3s/policy.acl",
+            ".a3s/policy.acl",
+            "original-policy",
+        ),
+        (
+            "printf changed > .claude/settings.json",
+            ".claude/settings.json",
+            "original-agent-settings",
+        ),
+    ] {
+        let denied = sandbox.exec_command(command, "/workspace").await.unwrap();
+        assert_ne!(denied.exit_code, 0, "{command} unexpectedly succeeded");
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join(path)).unwrap(),
+            original
+        );
+    }
+
+    let create_protected = sandbox
+        .exec_command(
+            "mkdir -p .codex && printf changed > .codex/config",
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        create_protected.exit_code, 0,
+        "creating protected metadata unexpectedly succeeded"
+    );
+    assert!(!workspace.path().join(".codex/config").exists());
+
+    let create_protected_file = sandbox
+        .exec_command("printf changed > .mcp.json", "/workspace")
+        .await
+        .unwrap();
+    assert_ne!(
+        create_protected_file.exit_code, 0,
+        "creating a protected control file unexpectedly succeeded"
+    );
+    assert!(!workspace.path().join(".mcp.json").exists());
+}
+
+/// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/srt`.
+#[tokio::test]
+#[ignore = "requires an installed srt runtime"]
+async fn real_srt_limits_user_reads_and_hides_workspace_credentials() {
+    let binary = std::env::var_os("A3S_TEST_SRT_BIN")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_BIN");
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let outside = root.path().join("outside-secret.txt");
+    std::fs::create_dir_all(workspace.join(".codex")).unwrap();
+    std::fs::create_dir_all(workspace.join("services/api")).unwrap();
+    std::fs::write(workspace.join("visible.txt"), "workspace-visible").unwrap();
+    std::fs::write(workspace.join(".env"), "WORKSPACE_SECRET=hidden").unwrap();
+    std::fs::write(
+        workspace.join("services/api/.env"),
+        "NESTED_WORKSPACE_SECRET=hidden",
+    )
+    .unwrap();
+    std::fs::write(workspace.join(".codex/auth.json"), "workspace-auth").unwrap();
+    std::fs::write(&outside, "outside-hidden").unwrap();
+    std::fs::hard_link(&outside, workspace.join("outside-hardlink")).unwrap();
+    let sandbox = SrtBashSandbox::new(binary, &workspace).unwrap();
+
+    let visible = sandbox
+        .exec_command("cat visible.txt", "/workspace")
+        .await
+        .unwrap();
+    assert_eq!(visible.exit_code, 0, "{}{}", visible.stdout, visible.stderr);
+    assert_eq!(visible.stdout, "workspace-visible");
+
+    for command in [
+        format!("cat {}", outside.display()),
+        "cat .env".to_string(),
+        "cat services/api/.env".to_string(),
+        "cat .codex/auth.json".to_string(),
+        "cat outside-hardlink".to_string(),
+    ] {
+        let denied = sandbox.exec_command(&command, "/workspace").await.unwrap();
+        assert_ne!(
+            denied.exit_code, 0,
+            "{command} unexpectedly exposed protected data: {}{}",
+            denied.stdout, denied.stderr
+        );
+        assert!(!denied.stdout.contains("hidden"));
+        assert!(!denied.stdout.contains("workspace-auth"));
+    }
+
+    let home = sandbox
+        .exec_command("printf %s \"$HOME\"", "/workspace")
+        .await
+        .unwrap();
+    assert_eq!(home.exit_code, 0, "{}{}", home.stdout, home.stderr);
+    assert_ne!(
+        Path::new(home.stdout.trim()),
+        dirs::home_dir().as_deref().unwrap_or_else(|| Path::new(""))
+    );
+}
+
+/// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/srt`.
+#[tokio::test]
+#[ignore = "requires an installed srt runtime"]
+async fn real_srt_keeps_the_local_rust_toolchain_usable_offline() {
+    let binary = std::env::var_os("A3S_TEST_SRT_BIN")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_BIN");
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let sandbox = SrtBashSandbox::new(binary, workspace).unwrap();
+
+    let output = sandbox
+        .exec_command(
+            "cargo metadata --offline --no-deps --format-version 1 >/dev/null",
+            "/workspace",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        output.exit_code, 0,
+        "sandboxed Cargo metadata failed: {}{}",
+        output.stdout, output.stderr
+    );
+}

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -259,7 +259,7 @@ fn supported_srt_version_range_is_explicit() {
 
 #[cfg(unix)]
 #[test]
-fn discovered_installation_uses_the_expected_package_manifest_and_cli() {
+fn verified_installation_uses_the_expected_package_manifest_and_cli() {
     use std::os::unix::fs::PermissionsExt;
 
     let root = tempfile::tempdir().unwrap();
@@ -301,6 +301,16 @@ fn workspace_cannot_supply_the_sandbox_executable() {
 
     let error = SrtBashSandbox::new(&binary, workspace.path()).unwrap_err();
     assert!(error.to_string().contains("inside the active workspace"));
+}
+
+#[test]
+fn sandbox_runtime_requires_an_explicit_path() {
+    let workspace = tempfile::tempdir().unwrap();
+    let error = SrtBashSandbox::new("srt", workspace.path()).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "an explicit SRT executable path is required; PATH discovery is unsupported"
+    );
 }
 
 #[test]

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::sandbox::BashSandbox;
+#[cfg(not(windows))]
 use std::sync::Arc;
+#[cfg(not(windows))]
 use tempfile::TempDir;
 
 #[cfg(unix)]

--- a/core/src/tools/builtin/bash.rs
+++ b/core/src/tools/builtin/bash.rs
@@ -12,11 +12,11 @@ use std::sync::{Arc, Mutex};
 use tokio::process::Command;
 
 #[cfg(windows)]
-mod windows;
+pub(crate) mod windows;
 #[cfg(windows)]
 pub(crate) use windows::maybe_execute_simple_windows_http_command;
 #[cfg(windows)]
-use windows::{build_powershell_command, encode_powershell_command, CREATE_NO_WINDOW};
+pub(crate) use windows::{build_powershell_command, encode_powershell_command, CREATE_NO_WINDOW};
 #[cfg(all(test, windows))]
 use windows::{
     normalize_json_like_literal, parse_simple_windows_http_command, preprocess_windows_command,
@@ -150,6 +150,16 @@ impl Tool for BashTool {
                 "timeout": {
                     "type": "integer",
                     "description": "Optional. Timeout in milliseconds. Default: 120000. Values below 1000 are clamped to 1000 to avoid accidental immediate timeouts."
+                },
+                "sandbox_permissions": {
+                    "type": "string",
+                    "enum": ["use_default", "require_escalated"],
+                    "default": "use_default",
+                    "description": "Execution boundary. Omit or use 'use_default' for the configured workspace sandbox. Use 'require_escalated' only after a sandbox denial when host execution is necessary; interactive hosts must authorize that request."
+                },
+                "justification": {
+                    "type": "string",
+                    "description": "Required with sandbox_permissions='require_escalated'. Briefly explain why the command cannot run inside the workspace sandbox."
                 }
             },
             "required": ["command"],
@@ -165,40 +175,41 @@ impl Tool for BashTool {
         })
     }
 
+    fn requires_confirmation(&self, args: &serde_json::Value) -> bool {
+        args.get("sandbox_permissions")
+            .and_then(serde_json::Value::as_str)
+            == Some("require_escalated")
+    }
+
     async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext) -> Result<ToolOutput> {
         let command = match args.get("command").and_then(|v| v.as_str()) {
             Some(c) => c,
             None => return Ok(ToolOutput::error("command parameter is required")),
         };
-
-        // If a sandbox is configured, route execution through it.
-        if let Some(ref sandbox) = ctx.sandbox {
-            let result = sandbox
-                .exec_command(command, "/workspace")
-                .await
-                .map_err(|e| anyhow::anyhow!("Sandbox bash execution failed: {}", e))?;
-
-            // Combine stdout and stderr the same way the local path does.
-            let mut output = result.stdout;
-            if !result.stderr.is_empty() {
-                output.push_str(&result.stderr);
+        let require_escalated = match args
+            .get("sandbox_permissions")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("use_default")
+        {
+            "use_default" => false,
+            "require_escalated" => true,
+            value => {
+                return Ok(ToolOutput::error(format!(
+                    "unsupported sandbox_permissions value: {value}"
+                )))
             }
-
-            return Ok(ToolOutput {
-                content: output,
-                success: result.exit_code == 0,
-                metadata: Some(serde_json::json!({ "exit_code": result.exit_code })),
-                images: vec![],
-                error_kind: None,
-            });
+        };
+        if require_escalated
+            && !args
+                .get("justification")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.trim().is_empty())
+        {
+            return Ok(ToolOutput::error(
+                "justification is required when sandbox_permissions is require_escalated",
+            ));
         }
 
-        // Capability gating guarantees that `bash` is only registered when the
-        // workspace backend provides a command runner, so this unwrap is sound.
-        let runner = ctx
-            .workspace_services
-            .command_runner()
-            .expect("bash registered without workspace command runner");
         let requested_timeout_ms = args
             .get("timeout")
             .and_then(|v| v.as_u64())
@@ -209,6 +220,76 @@ impl Tool for BashTool {
             summary: Mutex::new(None),
         });
         let output_observer = Some(Arc::clone(&event_observer) as Arc<dyn CommandOutputObserver>);
+
+        // The normal path uses the configured workspace sandbox. An explicit
+        // escalation is intentionally routed to the host runner only after the
+        // session permission layer authorizes the exact invocation.
+        if !require_escalated {
+            if let Some(ref sandbox) = ctx.sandbox {
+                let result = sandbox
+                    .exec(crate::sandbox::SandboxCommandRequest {
+                        command: command.to_string(),
+                        guest_workspace: "/workspace".to_string(),
+                        timeout_ms,
+                        output_observer: output_observer.clone(),
+                        env: ctx.command_env.clone(),
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Sandbox bash execution failed: {}", e))?;
+
+                // Combine stdout and stderr the same way the local path does.
+                let mut output = result.stdout;
+                if !result.stderr.is_empty() {
+                    output.push_str(&result.stderr);
+                }
+
+                let capture_summary = *event_observer.summary.lock().unwrap();
+                let capture_metadata = capture_summary.map(|summary| {
+                    serde_json::json!({
+                        "total_bytes": summary.total_bytes,
+                        "captured_bytes": summary.captured_bytes,
+                        "truncated": summary.truncated,
+                        "timed_out": summary.timed_out,
+                    })
+                });
+                if result.timed_out {
+                    let mut timed_out = ToolOutput::error(format!(
+                        "{}\n\n[Command timed out after {}ms]",
+                        output, timeout_ms
+                    ));
+                    timed_out.metadata = Some(serde_json::json!({
+                        "exit_code": result.exit_code,
+                        "timeout_ms": timeout_ms,
+                        "sandboxed": true,
+                        "output": capture_metadata,
+                    }));
+                    timed_out.error_kind = Some(ToolErrorKind::Timeout {
+                        op: "bash".to_string(),
+                        duration_ms: timeout_ms,
+                    });
+                    return Ok(timed_out);
+                }
+
+                return Ok(ToolOutput {
+                    content: output,
+                    success: result.exit_code == 0,
+                    metadata: Some(serde_json::json!({
+                        "exit_code": result.exit_code,
+                        "sandboxed": true,
+                        "output": capture_metadata,
+                    })),
+                    images: vec![],
+                    error_kind: None,
+                });
+            }
+        }
+
+        // Capability gating guarantees that `bash` is only registered when the
+        // workspace backend provides a command runner, so this unwrap is sound.
+        let runner = ctx
+            .workspace_services
+            .command_runner()
+            .expect("bash registered without workspace command runner");
         let result = runner
             .exec(CommandRequest {
                 command: command.to_string(),
@@ -237,6 +318,7 @@ impl Tool for BashTool {
             output.metadata = Some(serde_json::json!({
                 "exit_code": result.exit_code,
                 "timeout_ms": timeout_ms,
+                "sandboxed": false,
                 "output": capture_metadata,
             }));
             output.error_kind = Some(ToolErrorKind::Timeout {
@@ -251,6 +333,7 @@ impl Tool for BashTool {
             success: result.exit_code == 0,
             metadata: Some(serde_json::json!({
                 "exit_code": result.exit_code,
+                "sandboxed": false,
                 "output": capture_metadata,
             })),
             images: vec![],

--- a/core/src/tools/builtin/bash/tests.rs
+++ b/core/src/tools/builtin/bash/tests.rs
@@ -1,7 +1,10 @@
 use super::*;
-use crate::sandbox::{BashSandbox, SandboxOutput};
+use crate::sandbox::{BashSandbox, SandboxCommandRequest, SandboxExecutionOutput, SandboxOutput};
+use crate::workspace::CommandOutputSummary;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 // ------------------------------------------------------------------
@@ -31,6 +34,56 @@ impl BashSandbox for MockSandbox {
     async fn shutdown(&self) {}
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct RecordedSandboxRequest {
+    command: String,
+    guest_workspace: String,
+    timeout_ms: u64,
+    env: Option<HashMap<String, String>>,
+    had_output_observer: bool,
+}
+
+struct RecordingExtendedSandbox {
+    called: Arc<AtomicBool>,
+    request: Arc<std::sync::Mutex<Option<RecordedSandboxRequest>>>,
+    output: SandboxExecutionOutput,
+    summary: CommandOutputSummary,
+}
+
+#[async_trait]
+impl BashSandbox for RecordingExtendedSandbox {
+    async fn exec_command(
+        &self,
+        _command: &str,
+        _guest_workspace: &str,
+    ) -> anyhow::Result<SandboxOutput> {
+        anyhow::bail!("the bash tool must use the extended sandbox contract")
+    }
+
+    async fn exec(&self, request: SandboxCommandRequest) -> anyhow::Result<SandboxExecutionOutput> {
+        self.called.store(true, Ordering::SeqCst);
+        *self.request.lock().unwrap() = Some(RecordedSandboxRequest {
+            command: request.command,
+            guest_workspace: request.guest_workspace,
+            timeout_ms: request.timeout_ms,
+            env: request.env.as_deref().cloned(),
+            had_output_observer: request.output_observer.is_some(),
+        });
+        if let Some(observer) = request.output_observer {
+            observer.on_output_delta("streamed sandbox output").await;
+            observer.on_output_complete(&self.summary).await;
+        }
+        Ok(SandboxExecutionOutput {
+            stdout: self.output.stdout.clone(),
+            stderr: self.output.stderr.clone(),
+            exit_code: self.output.exit_code,
+            timed_out: self.output.timed_out,
+        })
+    }
+
+    async fn shutdown(&self) {}
+}
+
 #[tokio::test]
 async fn test_bash_delegates_to_sandbox() {
     let tool = BashTool;
@@ -48,7 +101,186 @@ async fn test_bash_delegates_to_sandbox() {
 
     assert!(result.success);
     assert!(result.content.contains("sandbox output"));
-    assert_eq!(result.metadata.unwrap()["exit_code"], 0);
+    let metadata = result.metadata.unwrap();
+    assert_eq!(metadata["exit_code"], 0);
+    assert_eq!(metadata["sandboxed"], true);
+}
+
+#[tokio::test]
+async fn default_sandbox_execution_preserves_timeout_env_and_streaming_contract() {
+    let tool = BashTool;
+    let called = Arc::new(AtomicBool::new(false));
+    let request = Arc::new(std::sync::Mutex::new(None));
+    let sandbox = Arc::new(RecordingExtendedSandbox {
+        called: Arc::clone(&called),
+        request: Arc::clone(&request),
+        output: SandboxExecutionOutput {
+            stdout: "sandbox result".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+        },
+        summary: CommandOutputSummary {
+            total_bytes: 23,
+            captured_bytes: 23,
+            truncated: false,
+            timed_out: false,
+        },
+    });
+    let temp = tempfile::tempdir().unwrap();
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(4);
+    let ctx = ToolContext::new(temp.path().to_path_buf())
+        .with_sandbox(sandbox)
+        .with_command_env(Arc::new(HashMap::from([(
+            "A3S_TEST_ENV".to_string(),
+            "visible".to_string(),
+        )])))
+        .with_event_tx(event_tx);
+
+    let result = tool
+        .execute(
+            &serde_json::json!({
+                "command": "printf result",
+                "timeout": 42,
+                "sandbox_permissions": "use_default"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(result.success, "{}", result.content);
+    assert!(called.load(Ordering::SeqCst));
+    assert_eq!(
+        request.lock().unwrap().as_ref(),
+        Some(&RecordedSandboxRequest {
+            command: "printf result".to_string(),
+            guest_workspace: "/workspace".to_string(),
+            timeout_ms: MIN_TIMEOUT_MS,
+            env: Some(HashMap::from([(
+                "A3S_TEST_ENV".to_string(),
+                "visible".to_string(),
+            )])),
+            had_output_observer: true,
+        })
+    );
+    assert!(matches!(
+        event_rx.recv().await,
+        Some(ToolStreamEvent::OutputDelta(delta))
+            if delta == "streamed sandbox output"
+    ));
+    let metadata = result.metadata.unwrap();
+    assert_eq!(metadata["sandboxed"], true);
+    assert_eq!(metadata["output"]["total_bytes"], 23);
+}
+
+#[tokio::test]
+async fn escalated_execution_requires_a_justification() {
+    let tool = BashTool;
+    let temp = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf());
+
+    let result = tool
+        .execute(
+            &serde_json::json!({
+                "command": "printf host",
+                "sandbox_permissions": "require_escalated"
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.success);
+    assert!(result.content.contains("justification is required"));
+}
+
+#[tokio::test]
+#[cfg(not(windows))]
+async fn escalated_execution_skips_the_configured_sandbox() {
+    let tool = BashTool;
+    let called = Arc::new(AtomicBool::new(false));
+    let request = Arc::new(std::sync::Mutex::new(None));
+    let sandbox = Arc::new(RecordingExtendedSandbox {
+        called: Arc::clone(&called),
+        request,
+        output: SandboxExecutionOutput {
+            stdout: "wrong boundary".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+        },
+        summary: CommandOutputSummary {
+            total_bytes: 0,
+            captured_bytes: 0,
+            truncated: false,
+            timed_out: false,
+        },
+    });
+    let temp = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf()).with_sandbox(sandbox);
+
+    let result = tool
+        .execute(
+            &serde_json::json!({
+                "command": "printf host",
+                "sandbox_permissions": "require_escalated",
+                "justification": "The exact command needs an approved host capability."
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(result.success, "{}", result.content);
+    assert_eq!(result.content, "host");
+    assert!(!called.load(Ordering::SeqCst));
+    assert_eq!(result.metadata.unwrap()["sandboxed"], false);
+}
+
+#[tokio::test]
+async fn sandbox_timeout_uses_the_sandbox_result_and_metadata() {
+    let tool = BashTool;
+    let sandbox = Arc::new(RecordingExtendedSandbox {
+        called: Arc::new(AtomicBool::new(false)),
+        request: Arc::new(std::sync::Mutex::new(None)),
+        output: SandboxExecutionOutput {
+            stdout: "partial".to_string(),
+            stderr: String::new(),
+            exit_code: -1,
+            timed_out: true,
+        },
+        summary: CommandOutputSummary {
+            total_bytes: 7,
+            captured_bytes: 7,
+            truncated: false,
+            timed_out: true,
+        },
+    });
+    let temp = tempfile::tempdir().unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf()).with_sandbox(sandbox);
+
+    let result = tool
+        .execute(
+            &serde_json::json!({"command": "slow", "timeout": 1_500}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.success);
+    assert!(result.content.contains("timed out after 1500ms"));
+    assert!(matches!(
+        result.error_kind,
+        Some(ToolErrorKind::Timeout {
+            ref op,
+            duration_ms: 1_500
+        }) if op == "bash"
+    ));
+    let metadata = result.metadata.unwrap();
+    assert_eq!(metadata["sandboxed"], true);
+    assert_eq!(metadata["timeout_ms"], 1_500);
+    assert_eq!(metadata["output"]["timed_out"], true);
 }
 
 #[tokio::test]
@@ -406,6 +638,15 @@ fn test_bash_schema_is_canonical() {
         "cargo test -p a3s-code-core skill::"
     );
     assert!(examples[0].get("cmd").is_none());
+    assert!(!tool.requires_confirmation(&serde_json::json!({
+        "command": "cargo test",
+        "sandbox_permissions": "use_default"
+    })));
+    assert!(tool.requires_confirmation(&serde_json::json!({
+        "command": "cargo test",
+        "sandbox_permissions": "require_escalated",
+        "justification": "Needs an approved host capability."
+    })));
 }
 
 #[test]

--- a/core/src/tools/builtin/bash/windows.rs
+++ b/core/src/tools/builtin/bash/windows.rs
@@ -3,7 +3,7 @@ use crate::tools::types::ToolOutput;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 
 #[cfg(windows)]
-pub(super) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 #[cfg(windows)]
 const WINDOWS_POWERSHELL_COMPAT_SHIM: &str = r#"
@@ -372,7 +372,7 @@ function which {
 "#;
 
 #[cfg(windows)]
-pub(super) fn build_powershell_command(command: &str) -> String {
+pub(crate) fn build_powershell_command(command: &str) -> String {
     format!(
         "{WINDOWS_POWERSHELL_COMPAT_SHIM}\n{}",
         preprocess_windows_command(command)
@@ -380,7 +380,7 @@ pub(super) fn build_powershell_command(command: &str) -> String {
 }
 
 #[cfg(windows)]
-pub(super) fn encode_powershell_command(command: &str) -> String {
+pub(crate) fn encode_powershell_command(command: &str) -> String {
     let utf16_le: Vec<u8> = command
         .encode_utf16()
         .flat_map(|unit| unit.to_le_bytes())

--- a/core/src/tools/process.rs
+++ b/core/src/tools/process.rs
@@ -3,6 +3,8 @@
 use super::MAX_OUTPUT_SIZE;
 use crate::workspace::{CommandOutputObserver, CommandOutputSummary};
 use std::collections::VecDeque;
+use std::io;
+use std::process::ExitStatus;
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
 
@@ -10,10 +12,24 @@ const READ_CHUNK_BYTES: usize = 8 * 1024;
 const OUTPUT_HEAD_BYTES: usize = 64 * 1024;
 const PROCESS_SETTLEMENT_MS: u64 = 500;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Clone, Copy)]
+struct CapturedByte {
+    stream: OutputStream,
+    byte: u8,
+}
+
 struct BoundedCapture {
-    head: Vec<u8>,
-    tail: VecDeque<u8>,
+    head: Vec<CapturedByte>,
+    tail: VecDeque<CapturedByte>,
     total_bytes: usize,
+    stdout_bytes: usize,
+    stderr_bytes: usize,
 }
 
 impl BoundedCapture {
@@ -22,17 +38,35 @@ impl BoundedCapture {
             head: Vec::with_capacity(OUTPUT_HEAD_BYTES),
             tail: VecDeque::with_capacity(MAX_OUTPUT_SIZE - OUTPUT_HEAD_BYTES),
             total_bytes: 0,
+            stdout_bytes: 0,
+            stderr_bytes: 0,
         }
     }
 
-    fn push(&mut self, bytes: &[u8]) {
+    fn push(&mut self, stream: OutputStream, bytes: &[u8]) {
         self.total_bytes = self.total_bytes.saturating_add(bytes.len());
+        match stream {
+            OutputStream::Stdout => {
+                self.stdout_bytes = self.stdout_bytes.saturating_add(bytes.len());
+            }
+            OutputStream::Stderr => {
+                self.stderr_bytes = self.stderr_bytes.saturating_add(bytes.len());
+            }
+        }
         let head_remaining = OUTPUT_HEAD_BYTES.saturating_sub(self.head.len());
         let head_bytes = head_remaining.min(bytes.len());
-        self.head.extend_from_slice(&bytes[..head_bytes]);
+        self.head
+            .extend(bytes[..head_bytes].iter().map(|byte| CapturedByte {
+                stream,
+                byte: *byte,
+            }));
 
         let tail_limit = MAX_OUTPUT_SIZE - OUTPUT_HEAD_BYTES;
-        self.tail.extend(bytes[head_bytes..].iter().copied());
+        self.tail
+            .extend(bytes[head_bytes..].iter().map(|byte| CapturedByte {
+                stream,
+                byte: *byte,
+            }));
         while self.tail.len() > tail_limit {
             self.tail.pop_front();
         }
@@ -47,9 +81,9 @@ impl BoundedCapture {
         }
     }
 
-    fn render(&self) -> String {
+    fn render_combined(&self) -> String {
         let mut rendered = String::new();
-        rendered.push_str(&String::from_utf8_lossy(&self.head));
+        append_captured_bytes(&mut rendered, self.head.iter().copied());
         if self.total_bytes > MAX_OUTPUT_SIZE {
             rendered.push_str(&format!(
                 "\n\n[command output truncated: retained the first {} and last {} of {} bytes]\n\n",
@@ -58,10 +92,63 @@ impl BoundedCapture {
                 self.total_bytes
             ));
         }
-        let tail = self.tail.iter().copied().collect::<Vec<_>>();
-        rendered.push_str(&String::from_utf8_lossy(&tail));
+        append_captured_bytes(&mut rendered, self.tail.iter().copied());
         rendered
     }
+
+    fn render_stream(&self, stream: OutputStream) -> String {
+        let head = self
+            .head
+            .iter()
+            .copied()
+            .filter(|captured| captured.stream == stream)
+            .collect::<Vec<_>>();
+        let tail = self
+            .tail
+            .iter()
+            .copied()
+            .filter(|captured| captured.stream == stream)
+            .collect::<Vec<_>>();
+        let total_bytes = match stream {
+            OutputStream::Stdout => self.stdout_bytes,
+            OutputStream::Stderr => self.stderr_bytes,
+        };
+
+        let mut rendered = String::new();
+        append_captured_bytes(&mut rendered, head.iter().copied());
+        if total_bytes > head.len() + tail.len() {
+            let label = match stream {
+                OutputStream::Stdout => "stdout",
+                OutputStream::Stderr => "stderr",
+            };
+            rendered.push_str(&format!(
+                "\n\n[command {label} truncated by the global output limit: retained the first {} \
+                 and last {} of {} bytes]\n\n",
+                head.len(),
+                tail.len(),
+                total_bytes
+            ));
+        }
+        append_captured_bytes(&mut rendered, tail.iter().copied());
+        rendered
+    }
+}
+
+fn append_captured_bytes(rendered: &mut String, captured: impl IntoIterator<Item = CapturedByte>) {
+    let bytes = captured
+        .into_iter()
+        .map(|captured| captured.byte)
+        .collect::<Vec<_>>();
+    rendered.push_str(&String::from_utf8_lossy(&bytes));
+}
+
+#[derive(Debug)]
+pub(crate) struct CapturedProcessOutput {
+    pub(crate) combined: String,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) status: Option<ExitStatus>,
+    pub(crate) timed_out: bool,
 }
 
 /// Configure a child as the leader of its own process group when supported.
@@ -138,17 +225,17 @@ pub(crate) async fn read_process_output(
     child: &mut Child,
     timeout_ms: u64,
     observer: Option<&dyn CommandOutputObserver>,
-) -> (String, bool) {
+) -> io::Result<CapturedProcessOutput> {
     let mut stdout = match child.stdout.take() {
         Some(stdout) => stdout,
         None => {
-            return ("Internal error: child stdout not piped".to_string(), false);
+            return Err(io::Error::other("child stdout was not piped"));
         }
     };
     let mut stderr = match child.stderr.take() {
         Some(stderr) => stderr,
         None => {
-            return ("Internal error: child stderr not piped".to_string(), false);
+            return Err(io::Error::other("child stderr was not piped"));
         }
     };
 
@@ -159,7 +246,7 @@ pub(crate) async fn read_process_output(
     let mut stdout_buffer = vec![0_u8; READ_CHUNK_BYTES];
     let mut stderr_buffer = vec![0_u8; READ_CHUNK_BYTES];
 
-    let timed_out = tokio::time::timeout(tokio::time::Duration::from_millis(timeout_ms), async {
+    let execution = tokio::time::timeout(tokio::time::Duration::from_millis(timeout_ms), async {
         while !stdout_done || !stderr_done {
             tokio::select! {
                 read = stdout.read(&mut stdout_buffer), if !stdout_done => {
@@ -167,14 +254,14 @@ pub(crate) async fn read_process_output(
                         Ok(0) => stdout_done = true,
                         Ok(count) => {
                             let bytes = &stdout_buffer[..count];
-                            capture.push(bytes);
+                            capture.push(OutputStream::Stdout, bytes);
                             if let Some(observer) = observer {
                                 observer.on_output_delta(&String::from_utf8_lossy(bytes)).await;
                             }
                         }
                         Err(error) => {
                             let message = format!("\n[failed to read command stdout: {error}]\n");
-                            capture.push(message.as_bytes());
+                            capture.push(OutputStream::Stderr, message.as_bytes());
                             stdout_done = true;
                         }
                     }
@@ -184,41 +271,61 @@ pub(crate) async fn read_process_output(
                         Ok(0) => stderr_done = true,
                         Ok(count) => {
                             let bytes = &stderr_buffer[..count];
-                            capture.push(bytes);
+                            capture.push(OutputStream::Stderr, bytes);
                             if let Some(observer) = observer {
                                 observer.on_output_delta(&String::from_utf8_lossy(bytes)).await;
                             }
                         }
                         Err(error) => {
                             let message = format!("\n[failed to read command stderr: {error}]\n");
-                            capture.push(message.as_bytes());
+                            capture.push(OutputStream::Stderr, message.as_bytes());
                             stderr_done = true;
                         }
                     }
                 }
             }
         }
-    })
-    .await
-    .is_err();
 
-    if timed_out {
-        process_group.kill();
-        child.start_kill().ok();
-        let _ = tokio::time::timeout(
-            tokio::time::Duration::from_millis(PROCESS_SETTLEMENT_MS),
-            child.wait(),
-        )
-        .await;
-    } else {
-        process_group.disarm();
-    }
+        child.wait().await
+    })
+    .await;
+
+    let (status, timed_out, wait_error) = match execution {
+        Ok(Ok(status)) => {
+            process_group.disarm();
+            (Some(status), false, None)
+        }
+        Ok(Err(error)) => (None, false, Some(error)),
+        Err(_) => {
+            process_group.kill();
+            child.start_kill().ok();
+            let status = match tokio::time::timeout(
+                tokio::time::Duration::from_millis(PROCESS_SETTLEMENT_MS),
+                child.wait(),
+            )
+            .await
+            {
+                Ok(Ok(status)) => Some(status),
+                Ok(Err(_)) | Err(_) => None,
+            };
+            (status, true, None)
+        }
+    };
 
     let summary = capture.summary(timed_out);
     if let Some(observer) = observer {
         observer.on_output_complete(&summary).await;
     }
-    (capture.render(), timed_out)
+    if let Some(error) = wait_error {
+        return Err(error);
+    }
+    Ok(CapturedProcessOutput {
+        combined: capture.render_combined(),
+        stdout: capture.render_stream(OutputStream::Stdout),
+        stderr: capture.render_stream(OutputStream::Stderr),
+        status,
+        timed_out,
+    })
 }
 
 #[cfg(test)]
@@ -231,18 +338,108 @@ mod tests {
         let input = (0..(MAX_OUTPUT_SIZE + 1234))
             .map(|index| b'a' + (index % 26) as u8)
             .collect::<Vec<_>>();
-        capture.push(&input);
+        capture.push(OutputStream::Stdout, &input);
 
         let summary = capture.summary(false);
         assert_eq!(summary.total_bytes, input.len());
         assert_eq!(summary.captured_bytes, MAX_OUTPUT_SIZE);
         assert!(summary.truncated);
-        let rendered = capture.render();
+        let rendered = capture.render_combined();
         assert!(rendered.contains("command output truncated"));
         let expected_head = String::from_utf8_lossy(&input[..OUTPUT_HEAD_BYTES]);
         let expected_tail =
             String::from_utf8_lossy(&input[input.len() - (MAX_OUTPUT_SIZE - OUTPUT_HEAD_BYTES)..]);
         assert!(rendered.starts_with(expected_head.as_ref()));
         assert!(rendered.ends_with(expected_tail.as_ref()));
+        let stdout = capture.render_stream(OutputStream::Stdout);
+        assert!(stdout.contains("command stdout truncated by the global output limit"));
+        assert!(stdout.starts_with(expected_head.as_ref()));
+        assert!(stdout.ends_with(expected_tail.as_ref()));
+        assert!(capture.render_stream(OutputStream::Stderr).is_empty());
+    }
+
+    #[test]
+    fn bounded_capture_preserves_stream_identity_under_one_global_limit() {
+        let mut capture = BoundedCapture::new();
+        let stdout = vec![b'o'; 70 * 1024];
+        let stderr = vec![b'e'; 70 * 1024];
+        capture.push(OutputStream::Stdout, &stdout);
+        capture.push(OutputStream::Stderr, &stderr);
+
+        let summary = capture.summary(false);
+        assert_eq!(summary.total_bytes, stdout.len() + stderr.len());
+        assert_eq!(summary.captured_bytes, MAX_OUTPUT_SIZE);
+        assert!(summary.truncated);
+
+        let rendered_stdout = capture.render_stream(OutputStream::Stdout);
+        let rendered_stderr = capture.render_stream(OutputStream::Stderr);
+        assert!(!rendered_stdout.contains("eeee"));
+        assert!(!rendered_stderr.contains("oooo"));
+        assert!(rendered_stdout.contains("stdout truncated"));
+        assert!(rendered_stderr.contains("stderr truncated"));
+    }
+
+    #[cfg(unix)]
+    fn spawn_test_shell(directory: &std::path::Path, script: &str) -> Child {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(script)
+            .current_dir(directory)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        configure_process_group(&mut command);
+        command.spawn().unwrap()
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_deadline_includes_wait_after_both_streams_close() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut child = spawn_test_shell(
+            directory.path(),
+            "exec 1>&- 2>&-; sleep 0.30; touch timeout-leak",
+        );
+        let started = std::time::Instant::now();
+
+        let output = read_process_output(&mut child, 50, None).await.unwrap();
+
+        assert!(output.timed_out);
+        assert!(started.elapsed() < std::time::Duration::from_millis(250));
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        assert!(
+            !directory.path().join("timeout-leak").exists(),
+            "a process that closes its streams must not outlive its command deadline"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropping_capture_kills_descendants_in_the_process_group() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut child = spawn_test_shell(
+            directory.path(),
+            "exec 1>&- 2>&-; \
+             (touch descendant-started; sleep 0.30; touch cancellation-leak) & wait",
+        );
+        let capture =
+            tokio::spawn(async move { read_process_output(&mut child, 5_000, None).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !directory.path().join("descendant-started").exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("test process did not start");
+        capture.abort();
+        assert!(capture.await.unwrap_err().is_cancelled());
+
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        assert!(
+            !directory.path().join("cancellation-leak").exists(),
+            "dropping process capture must kill every descendant"
+        );
     }
 }

--- a/core/src/workspace/local.rs
+++ b/core/src/workspace/local.rs
@@ -614,31 +614,19 @@ impl WorkspaceCommandRunner for LocalWorkspaceBackend {
         )
         .map_err(|e| anyhow!("Failed to spawn shell: {}", e))?;
 
-        let (output, timed_out) = crate::tools::process::read_process_output(
+        let output = crate::tools::process::read_process_output(
             &mut child,
             request.timeout_ms,
             request.output_observer.as_deref(),
         )
-        .await;
-
-        if timed_out {
-            return Ok(CommandOutput {
-                output,
-                exit_code: -1,
-                timed_out: true,
-            });
-        }
-
-        let status = child
-            .wait()
-            .await
-            .map_err(|e| anyhow!("Failed to wait for shell: {}", e))?;
-        let exit_code = status.code().unwrap_or(-1);
+        .await
+        .map_err(|error| anyhow!("Failed to capture shell output: {error}"))?;
+        let exit_code = output.status.and_then(|status| status.code()).unwrap_or(-1);
 
         Ok(CommandOutput {
-            output,
+            output: output.combined,
             exit_code,
-            timed_out: false,
+            timed_out: output.timed_out,
         })
     }
 }

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -75,12 +75,13 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
  "zip 0.6.6",
 ]
 
 [[package]]
 name = "a3s-code-node"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",
@@ -97,6 +98,8 @@ dependencies = [
 [[package]]
 name = "a3s-common"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cd6201d7bcccd75f7719d5f3054c275dc31d0f406eab40d591d2c907f4fc60"
 dependencies = [
  "async-trait",
  "bytes",
@@ -113,6 +116,8 @@ dependencies = [
 [[package]]
 name = "a3s-flow"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f3b680a1d4c5cb08e178ebab3d4b9c37fc3a31b9348ddb980ae9dceb48e10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -128,6 +133,8 @@ dependencies = [
 [[package]]
 name = "a3s-lane"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1893dcc53093f705a21a7b5160509af3ddf5c872391e65509b9c944129cb46"
 dependencies = [
  "async-trait",
  "chrono",
@@ -149,6 +156,8 @@ dependencies = [
 [[package]]
 name = "a3s-memory"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10288750681acd08de9a4d7daef80550d72017dc4aef00256c8aad44c55e35e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -162,6 +171,8 @@ dependencies = [
 [[package]]
 name = "a3s-search"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f942ff1a7f591b07c9a9af381148adc21df692eb1439b292fd7c4f7224e2232"
 dependencies = [
  "a3s-acl 0.2.1",
  "a3s-updater",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.1.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.2.0", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.1.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.1.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.1.0",
-        "@a3s-lab/code-linux-x64-musl": "6.1.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.1.0"
+        "@a3s-lab/code-darwin-arm64": "6.2.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.2.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.2.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.2.0",
+        "@a3s-lab/code-linux-x64-musl": "6.2.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.2.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.1.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.1.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.1.0",
-        "@a3s-lab/code-linux-x64-musl": "6.1.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.1.0"
+        "@a3s-lab/code-darwin-arm64": "6.2.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.2.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.2.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.2.0",
+        "@a3s-lab/code-linux-x64-musl": "6.2.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.2.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "6.1.0",
-    "@a3s-lab/code-linux-x64-gnu": "6.1.0",
-    "@a3s-lab/code-linux-x64-musl": "6.1.0",
-    "@a3s-lab/code-linux-arm64-gnu": "6.1.0",
-    "@a3s-lab/code-linux-arm64-musl": "6.1.0",
-    "@a3s-lab/code-win32-x64-msvc": "6.1.0"
+    "@a3s-lab/code-darwin-arm64": "6.2.0",
+    "@a3s-lab/code-linux-x64-gnu": "6.2.0",
+    "@a3s-lab/code-linux-x64-musl": "6.2.0",
+    "@a3s-lab/code-linux-arm64-gnu": "6.2.0",
+    "@a3s-lab/code-linux-arm64-musl": "6.2.0",
+    "@a3s-lab/code-win32-x64-msvc": "6.2.0"
   }
 }

--- a/sdk/python-bootstrap/README.md
+++ b/sdk/python-bootstrap/README.md
@@ -44,4 +44,4 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.1.0`.
+Replace `<VERSION>` with the release to install, for example `6.2.0`.

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "6.1.0"
+version = "6.2.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "6.1.0"
+__version__ = "6.2.0"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-07-22
+
+### Changed
+
+- Updated the bundled Core with the verified SRT process-sandbox contract and
+  the latest delegated confirmation propagation fixes.
+
 ## [6.1.0] - 2026-07-20
 
 ### Changed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -75,12 +75,13 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows-sys 0.61.2",
  "zip 0.6.6",
 ]
 
 [[package]]
 name = "a3s-code-py"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",
@@ -96,6 +97,8 @@ dependencies = [
 [[package]]
 name = "a3s-common"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40cd6201d7bcccd75f7719d5f3054c275dc31d0f406eab40d591d2c907f4fc60"
 dependencies = [
  "async-trait",
  "bytes",
@@ -112,6 +115,8 @@ dependencies = [
 [[package]]
 name = "a3s-flow"
 version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f3b680a1d4c5cb08e178ebab3d4b9c37fc3a31b9348ddb980ae9dceb48e10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -127,6 +132,8 @@ dependencies = [
 [[package]]
 name = "a3s-lane"
 version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d1893dcc53093f705a21a7b5160509af3ddf5c872391e65509b9c944129cb46"
 dependencies = [
  "async-trait",
  "chrono",
@@ -148,6 +155,8 @@ dependencies = [
 [[package]]
 name = "a3s-memory"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10288750681acd08de9a4d7daef80550d72017dc4aef00256c8aad44c55e35e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -161,6 +170,8 @@ dependencies = [
 [[package]]
 name = "a3s-search"
 version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f942ff1a7f591b07c9a9af381148adc21df692eb1439b292fd7c4f7224e2232"
 dependencies = [
  "a3s-acl 0.2.1",
  "a3s-updater",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.1.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.2.0", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -28,7 +28,7 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.1.0`.
+Replace `<VERSION>` with the release to install, for example `6.2.0`.
 
 ## Quick Start
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "6.1.0"
+version = "6.2.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- add the SRT-backed workspace process sandbox and managed-runtime validation
- adapt local workspace execution to the structured process-capture contract
- use stable Windows hard-link inspection with fail-closed behavior
- release the additive public API as 6.2.0 across Rust, Node, and Python packages

## Validation
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --lib --bins -- -D warnings`
- `cargo test -p a3s-code-core sandbox::srt --lib` (5 passed; 4 real-runtime tests ignored)
- `cargo fmt --all -- --check`
- `cargo check --manifest-path sdk/node/Cargo.toml`

Python SDK compilation was dependency-resolved and lock-updated locally, but native compilation requires a Python interpreter; CI supplies it.