### PR TITLE
fix(sandbox): avoid nested deny mount failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-07-22
+
+### Fixed
+
+- Removed redundant nested SRT write-deny mounts when a protected workspace
+  ancestor already blocks writes, while retaining credential read denial and
+  standalone sensitive-file write protection.
+
 ## [6.3.0] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",

--- a/README.md
+++ b/README.md
@@ -317,10 +317,12 @@ language/bootstrap injection variables. It keeps stdout and stderr distinct
 under one global capture limit. Its deadline covers output draining and the
 child's complete lifetime, including a process that closes both streams before
 it exits; timeout or cancellation terminates the Unix process group. It never
- searches `PATH` for a sandbox runtime and never falls back to the host runner
- when its explicitly provisioned runtime is missing or fails. The embedding host
- remains responsible for choosing whether an unavailable sandbox causes an
- interactive escalation or a deterministic denial.
+searches `PATH` for a sandbox runtime and never falls back to the host runner
+when its explicitly provisioned runtime is missing or fails. Write-deny paths
+already covered by a protected ancestor are collapsed before SRT startup,
+while more-specific credential read denies remain intact. The embedding host
+remains responsible for choosing whether an unavailable sandbox causes an
+interactive escalation or a deterministic denial.
 
 Shell isolation does not automatically govern in-process workspace tools.
 Interactive hosts should construct `LocalWorkspaceBackend` or

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "6.3.0"
+version = "6.3.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -132,7 +132,7 @@ impl SrtBashSandbox {
         deny_read.extend(read_denied_roots());
         let mut allow_read = readable_tool_paths(&self.workspace, scratch);
         deny_write.extend(sensitive_paths.iter().cloned());
-        deduplicate_paths(&mut deny_write);
+        remove_redundant_deny_write_descendants(&mut deny_write);
         deduplicate_paths(&mut sensitive_paths);
         deduplicate_paths(&mut deny_read);
         deduplicate_paths(&mut allow_read);
@@ -1045,6 +1045,16 @@ fn resolved_git_dir(workspace: &Path) -> Option<PathBuf> {
 fn deduplicate_paths(paths: &mut Vec<PathBuf>) {
     paths.sort();
     paths.dedup();
+}
+
+fn remove_redundant_deny_write_descendants(paths: &mut Vec<PathBuf>) {
+    deduplicate_paths(paths);
+    let candidates = paths.clone();
+    paths.retain(|path| {
+        !candidates
+            .iter()
+            .any(|ancestor| ancestor != path && path.starts_with(ancestor))
+    });
 }
 
 fn path_strings<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Vec<String> {

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -98,7 +98,22 @@ async fn adapter_passes_argv_workspace_timeout_env_and_settings() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|path| path.as_str().unwrap().ends_with("/.codex/auth.json")));
+        .any(|path| path
+            == &json!(workspace
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join(".codex/auth.json"))));
+    assert!(settings["filesystem"]["denyRead"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|path| path
+            == &json!(workspace
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join(".a3s/os-auth.json"))));
     assert!(settings["filesystem"]["denyRead"]
         .as_array()
         .unwrap()
@@ -114,11 +129,29 @@ async fn adapter_passes_argv_workspace_timeout_env_and_settings() {
                 .canonicalize()
                 .unwrap()
                 .join("services/api/.env"))));
+    assert!(
+        !settings["filesystem"]["denyWrite"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|path| path
+                == &json!(workspace
+                    .path()
+                    .canonicalize()
+                    .unwrap()
+                    .join(".a3s/os-auth.json"))),
+        "a protected parent directory must cover sensitive descendants without a nested mount"
+    );
     assert!(settings["filesystem"]["denyWrite"]
         .as_array()
         .unwrap()
         .iter()
-        .any(|path| path.as_str().unwrap().ends_with("/.codex/auth.json")));
+        .any(|path| path
+            == &json!(workspace
+                .path()
+                .canonicalize()
+                .unwrap()
+                .join("services/api/.env"))));
     assert_eq!(settings["enableWeakerNestedSandbox"], false);
     assert_eq!(settings["allowAppleEvents"], false);
 }

--- a/core/src/tools/builtin/bash.rs
+++ b/core/src/tools/builtin/bash.rs
@@ -200,10 +200,10 @@ impl Tool for BashTool {
             }
         };
         if require_escalated
-            && !args
+            && args
                 .get("justification")
                 .and_then(serde_json::Value::as_str)
-                .is_some_and(|value| !value.trim().is_empty())
+                .is_none_or(|value| value.trim().is_empty())
         {
             return Ok(ToolOutput::error(
                 "justification is required when sandbox_permissions is require_escalated",

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "6.3.0"
+version = "6.3.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.3.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.3.1", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.3.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.3.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.3.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.3.0",
-        "@a3s-lab/code-linux-x64-musl": "6.3.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.3.0"
+        "@a3s-lab/code-darwin-arm64": "6.3.1",
+        "@a3s-lab/code-linux-arm64-gnu": "6.3.1",
+        "@a3s-lab/code-linux-arm64-musl": "6.3.1",
+        "@a3s-lab/code-linux-x64-gnu": "6.3.1",
+        "@a3s-lab/code-linux-x64-musl": "6.3.1",
+        "@a3s-lab/code-win32-x64-msvc": "6.3.1"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.3.0",
-        "@a3s-lab/code-linux-arm64-gnu": "6.3.0",
-        "@a3s-lab/code-linux-arm64-musl": "6.3.0",
-        "@a3s-lab/code-linux-x64-gnu": "6.3.0",
-        "@a3s-lab/code-linux-x64-musl": "6.3.0",
-        "@a3s-lab/code-win32-x64-msvc": "6.3.0"
+        "@a3s-lab/code-darwin-arm64": "6.3.1",
+        "@a3s-lab/code-linux-arm64-gnu": "6.3.1",
+        "@a3s-lab/code-linux-arm64-musl": "6.3.1",
+        "@a3s-lab/code-linux-x64-gnu": "6.3.1",
+        "@a3s-lab/code-linux-x64-musl": "6.3.1",
+        "@a3s-lab/code-win32-x64-msvc": "6.3.1"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "6.3.0",
-    "@a3s-lab/code-linux-x64-gnu": "6.3.0",
-    "@a3s-lab/code-linux-x64-musl": "6.3.0",
-    "@a3s-lab/code-linux-arm64-gnu": "6.3.0",
-    "@a3s-lab/code-linux-arm64-musl": "6.3.0",
-    "@a3s-lab/code-win32-x64-msvc": "6.3.0"
+    "@a3s-lab/code-darwin-arm64": "6.3.1",
+    "@a3s-lab/code-linux-x64-gnu": "6.3.1",
+    "@a3s-lab/code-linux-x64-musl": "6.3.1",
+    "@a3s-lab/code-linux-arm64-gnu": "6.3.1",
+    "@a3s-lab/code-linux-arm64-musl": "6.3.1",
+    "@a3s-lab/code-win32-x64-msvc": "6.3.1"
   }
 }

--- a/sdk/python-bootstrap/README.md
+++ b/sdk/python-bootstrap/README.md
@@ -44,4 +44,4 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.3.0`.
+Replace `<VERSION>` with the release to install, for example `6.3.1`.

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "6.3.0"
+version = "6.3.1"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "6.3.0"
+__version__ = "6.3.1"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [6.3.1] - 2026-07-22
+
+### Fixed
+
+- Updated the bundled Core so managed SRT sandboxes start when protected
+  workspace directories contain absent sensitive-file descendants.
+
 ## [6.3.0] - 2026-07-22
 
 ### Changed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "6.3.0"
+version = "6.3.1"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "6.3.0"
+version = "6.3.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.3.0", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.3.1", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -28,7 +28,7 @@ pip install \
   'https://github.com/A3S-Lab/Code/releases/download/v<VERSION>/a3s_code-<VERSION>-cp312-cp312-manylinux_2_28_x86_64.whl'
 ```
 
-Replace `<VERSION>` with the release to install, for example `6.3.0`.
+Replace `<VERSION>` with the release to install, for example `6.3.1`.
 
 ## Quick Start
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "6.3.0"
+version = "6.3.1"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- collapse redundant SRT deny-write descendants already covered by a protected ancestor
- preserve credential read denial and standalone sensitive-file write protection
- align Core, Node, Python, and bootstrap release metadata at 6.3.1
- keep the escalated Bash justification guard compatible with current Clippy without changing behavior

## Why

The CLI release sandbox probe failed on Linux when `.a3s` was read-only and SRT then tried to create a nested `.a3s/os-auth.json` mount point. Removing only the redundant child write deny lets the sandbox start while the parent write boundary and child read boundary remain fail-closed.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p a3s-code-core --lib -- -D warnings`
- `cargo test -p a3s-code-core --lib` (2528 passed, 14 ignored)
- `cargo check --manifest-path sdk/node/Cargo.toml`
- `cargo check --manifest-path sdk/python/Cargo.toml`
- `bash check-version.sh 6.3.1`
- event protocol artifact check
- SDK API alignment check