### PR TITLE
fix(srt): tolerate concurrent workspace removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept SRT workspace policy scans stable when another process removes an
+  enumerated file or directory concurrently, while preserving fail-closed
+  behavior for permission and other I/O failures.
+
 ## [6.4.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -324,9 +324,11 @@ it exits; timeout or cancellation terminates the Unix process group. It never
 searches `PATH` for a sandbox runtime and never falls back to the host runner
 when its explicitly provisioned runtime is missing or fails. Write-deny paths
 already covered by a protected ancestor are collapsed before SRT startup,
-while more-specific credential read denies remain intact. The embedding host
-remains responsible for choosing whether an unavailable sandbox causes an
-interactive escalation or a deterministic denial.
+while more-specific credential read denies remain intact. Workspace policy
+scans treat an entry removed concurrently after enumeration as absent, but
+permission and other I/O failures remain fatal. The embedding host remains
+responsible for choosing whether an unavailable sandbox causes an interactive
+escalation or a deterministic denial.
 
 Shell isolation does not automatically govern in-process workspace tools.
 Interactive hosts should construct `LocalWorkspaceBackend` or

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -870,17 +870,27 @@ fn workspace_nested_env_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
 
     while let Some((directory, depth)) = pending.pop() {
-        let entries = std::fs::read_dir(&directory)
-            .with_context(|| format!("failed to scan SRT workspace {}", directory.display()))?;
+        let Some(entries) = workspace_scan_result(std::fs::read_dir(&directory), || {
+            format!("failed to scan SRT workspace {}", directory.display())
+        })?
+        else {
+            continue;
+        };
         for entry in entries {
-            let entry = entry.with_context(|| {
+            let Some(entry) = workspace_scan_result(entry, || {
                 format!("failed to enumerate SRT workspace {}", directory.display())
-            })?;
+            })?
+            else {
+                continue;
+            };
             scanned = next_workspace_scan_entry(scanned)?;
             let path = entry.path();
-            let file_type = entry.file_type().with_context(|| {
+            let Some(file_type) = workspace_scan_result(entry.file_type(), || {
                 format!("failed to inspect SRT workspace path {}", path.display())
-            })?;
+            })?
+            else {
+                continue;
+            };
             if entry
                 .file_name()
                 .to_str()
@@ -906,18 +916,28 @@ pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>>
     let mut hardlinks = Vec::new();
 
     while let Some((directory, depth)) = pending.pop() {
-        let entries = std::fs::read_dir(&directory)
-            .with_context(|| format!("failed to scan SRT workspace {}", directory.display()))?;
+        let Some(entries) = workspace_scan_result(std::fs::read_dir(&directory), || {
+            format!("failed to scan SRT workspace {}", directory.display())
+        })?
+        else {
+            continue;
+        };
         for entry in entries {
-            let entry = entry.with_context(|| {
+            let Some(entry) = workspace_scan_result(entry, || {
                 format!("failed to enumerate SRT workspace {}", directory.display())
-            })?;
+            })?
+            else {
+                continue;
+            };
             scanned = next_workspace_scan_entry(scanned)?;
 
             let path = entry.path();
-            let metadata = std::fs::symlink_metadata(&path).with_context(|| {
+            let Some(metadata) = workspace_scan_result(std::fs::symlink_metadata(&path), || {
                 format!("failed to inspect SRT workspace path {}", path.display())
-            })?;
+            })?
+            else {
+                continue;
+            };
             if metadata.file_type().is_symlink() {
                 continue;
             }
@@ -943,6 +963,17 @@ pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>>
     hardlinks.sort();
     hardlinks.dedup();
     Ok(hardlinks)
+}
+
+fn workspace_scan_result<T>(
+    result: std::io::Result<T>,
+    context: impl FnOnce() -> String,
+) -> Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(context),
+    }
 }
 
 fn next_workspace_scan_entry(scanned: usize) -> Result<usize> {

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -190,6 +190,39 @@ async fn adapter_denies_every_preexisting_workspace_hardlink_alias() {
     }
 }
 
+#[test]
+fn workspace_scan_treats_a_concurrently_removed_entry_as_absent() {
+    let workspace = tempfile::tempdir().unwrap();
+    let transient = workspace.path().join("transient");
+    std::fs::write(&transient, "temporary").unwrap();
+    std::fs::remove_file(&transient).unwrap();
+
+    let metadata = workspace_scan_result(std::fs::symlink_metadata(&transient), || {
+        format!("failed to inspect {}", transient.display())
+    })
+    .unwrap();
+
+    assert!(metadata.is_none());
+}
+
+#[test]
+fn workspace_scan_keeps_non_missing_io_failures_fatal() {
+    let error = workspace_scan_result::<()>(
+        Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        || "failed to inspect protected entry".to_string(),
+    )
+    .unwrap_err();
+
+    assert_eq!(error.to_string(), "failed to inspect protected entry");
+    assert_eq!(
+        error
+            .source()
+            .and_then(|source| source.downcast_ref::<std::io::Error>())
+            .map(std::io::Error::kind),
+        Some(std::io::ErrorKind::PermissionDenied)
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn adapter_preserves_stdout_and_stderr_as_separate_streams() {
@@ -418,6 +451,70 @@ async fn real_srt_allows_workspace_writes_and_blocks_outside_writes() {
         assert_ne!(denied.exit_code, 0);
         assert!(!outside.join("symlink-escaped.txt").exists());
     }
+}
+
+/// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/cli.js` and
+/// `A3S_TEST_SRT_NODE=/absolute/path/to/node`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires an installed srt runtime and Node.js"]
+async fn real_srt_probe_survives_concurrent_workspace_churn() {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    let binary = std::env::var_os("A3S_TEST_SRT_BIN")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_BIN");
+    let node = std::env::var_os("A3S_TEST_SRT_NODE")
+        .map(PathBuf::from)
+        .expect("set A3S_TEST_SRT_NODE");
+    let workspace = tempfile::tempdir().unwrap();
+    let churn_root = workspace.path().join("concurrent-writer");
+    std::fs::create_dir_all(&churn_root).unwrap();
+
+    let running = Arc::new(AtomicBool::new(true));
+    let writer_running = Arc::clone(&running);
+    let writer = std::thread::spawn(move || {
+        let mut generation = 0usize;
+        while writer_running.load(Ordering::Acquire) {
+            let batch = churn_root.join(format!("batch-{}", generation % 4));
+            let nested = batch.join("nested");
+            let _ = std::fs::remove_dir_all(&batch);
+            if std::fs::create_dir_all(&nested).is_ok() {
+                for index in 0..4 {
+                    let _ =
+                        std::fs::write(nested.join(format!(".env-{index}")), b"TRANSIENT=removed");
+                }
+            }
+            let _ = std::fs::remove_dir_all(&batch);
+            generation = generation.wrapping_add(1);
+        }
+    });
+
+    let result = async {
+        for _ in 0..50 {
+            let sandbox =
+                SrtBashSandbox::from_verified_npm_with_node(&binary, &node, workspace.path())?;
+            let output = sandbox
+                .exec_command("printf a3s-managed-srt-ready", "/workspace")
+                .await?;
+            if output.exit_code != 0 || output.stdout != "a3s-managed-srt-ready" {
+                bail!(
+                    "SRT capability probe failed with code {}: {}{}",
+                    output.exit_code,
+                    output.stdout,
+                    output.stderr
+                );
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    running.store(false, Ordering::Release);
+    writer.join().unwrap();
+    result.unwrap();
 }
 
 /// Run explicitly with `A3S_TEST_SRT_BIN=/absolute/path/to/srt`.


### PR DESCRIPTION
## Summary
- treat `NotFound` during SRT workspace policy scans as a concurrently removed entry
- keep permission and all other I/O failures fatal with their context chain
- add deterministic error-classification coverage and a real SRT concurrent-churn probe
- document the repaired startup behavior

## Validation
- `cargo fmt --all`
- `cargo test -p a3s-code-core`
- `cargo clippy -p a3s-code-core --all-targets -- -D warnings`
- real Homebrew SRT 0.0.66 churn probe: 50/50 with Node 24.14.0
- real Homebrew SRT 0.0.66 churn probe: 50/50 with Node 26.5.0
- A/B control on unpatched `origin/main`: reproduced `No such file or directory (os error 2)` while opening an already-enqueued directory