### PR TITLE
docs: explain runtime flow and animate CTA border

### DIFF
--- a/website/theme/components/HomeLayout.tsx
+++ b/website/theme/components/HomeLayout.tsx
@@ -1,4 +1,8 @@
-import { useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import {
+  useEffect,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import { useLang, useSite, useVersion, withBase } from '@rspress/core/runtime';
 import {
   InnerLine,
@@ -309,7 +313,197 @@ const runtimeLayers = [
   tags: string[];
 }>;
 
-type RuntimeLayer = (typeof runtimeLayers)[number];
+const runtimeFlowSteps = [
+  {
+    id: 'admission',
+    code: '01',
+    stage: 'SESSION',
+    title: { zh: '开始一次 Run', en: 'Admit one run' },
+    path: 'prompt → run_id',
+    summary: {
+      zh: '同一个 Session 不会同时改写两份对话历史。请求先取得 single-flight 运行权，再生成这次执行的身份与取消信号。',
+      en: 'A session never mutates two conversation histories at once. The request first acquires its single-flight lease, then receives a run identity and cancellation signal.',
+    },
+    input: {
+      zh: 'session.stream(prompt)',
+      en: 'session.stream(prompt)',
+    },
+    action: {
+      zh: '检查 Session 状态并取得运行权',
+      en: 'Check session state and acquire the run lease',
+    },
+    output: {
+      zh: 'run_id + InvocationContext',
+      en: 'run_id + InvocationContext',
+    },
+    event: 'run_start',
+    trace: {
+      zh: 'Run 已准入，后续模型与工具共享同一个 run_id。',
+      en: 'The run is admitted; model and tool work now share one run_id.',
+    },
+    tags: ['AgentSession', 'RunAdmission', 'CancellationToken'],
+  },
+  {
+    id: 'context',
+    code: '02',
+    stage: 'CONTEXT',
+    title: { zh: '组装本轮上下文', en: 'Assemble turn context' },
+    path: 'history → messages',
+    summary: {
+      zh: '历史、项目指令、记忆和 Workspace 信息不会整包塞给模型。ContextAssembler 会在预算内挑选内容，并附上本轮可见的工具定义。',
+      en: 'History, project instructions, memory, and workspace data are not dumped into the model. ContextAssembler selects what fits and attaches the visible tool schemas.',
+    },
+    input: {
+      zh: 'history + instructions + memory',
+      en: 'history + instructions + memory',
+    },
+    action: {
+      zh: '按上下文预算筛选、排序并组装',
+      en: 'Select, rank, and assemble within the context budget',
+    },
+    output: {
+      zh: 'messages[] + tools[]',
+      en: 'messages[] + tools[]',
+    },
+    event: 'turn_start',
+    trace: {
+      zh: '模型只看到本轮需要的上下文和允许使用的工具。',
+      en: 'The model sees only the context and tools available to this turn.',
+    },
+    tags: ['ContextAssembler', 'Memory', 'ToolDefinition'],
+  },
+  {
+    id: 'model',
+    code: '03',
+    stage: 'MODEL',
+    title: { zh: '模型决定下一步', en: 'Let the model decide' },
+    path: 'messages → tool call',
+    summary: {
+      zh: '受约束的模型调用会检查预算与取消状态。这个示例里，模型没有直接操作文件，而是提出一次只读搜索。',
+      en: 'The scoped model call checks budget and cancellation. In this example the model does not touch files directly; it proposes a read-only search.',
+    },
+    input: {
+      zh: 'messages[] + tools[]',
+      en: 'messages[] + tools[]',
+    },
+    action: {
+      zh: '流式生成文本或结构化工具请求',
+      en: 'Stream text or produce a structured tool request',
+    },
+    output: {
+      zh: 'grep({ pattern: "TODO|FIXME" })',
+      en: 'grep({ pattern: "TODO|FIXME" })',
+    },
+    event: 'tool_start',
+    trace: {
+      zh: '模型提出 grep 调用，但此时工具还没有执行。',
+      en: 'The model proposes grep, but the tool has not executed yet.',
+    },
+    tags: ['ScopedLlmClient', 'BudgetGuard', 'ToolCall'],
+  },
+  {
+    id: 'governance',
+    code: '04',
+    stage: 'GOVERNANCE',
+    title: { zh: '工具调用先过检查', en: 'Govern the tool call' },
+    path: 'tool call → allowed call',
+    summary: {
+      zh: '所有模型工具、嵌套工具和委派工具都经过同一个 ToolInvoker；内部调用不能绕过权限、Hook、确认、预算或超时。',
+      en: 'Model, nested, and delegated tools all pass through one ToolInvoker. Internal calls cannot bypass permissions, hooks, approvals, budgets, or timeouts.',
+    },
+    input: {
+      zh: 'ToolInvocation: grep(...)',
+      en: 'ToolInvocation: grep(...)',
+    },
+    action: {
+      zh: '参数 → 权限 → Hook → 确认 → 预算 → 超时',
+      en: 'schema → permission → hook → approval → budget → timeout',
+    },
+    output: {
+      zh: '受控且带作用域的工具调用',
+      en: 'A governed, scoped invocation',
+    },
+    event: 'tool_execution_start',
+    trace: {
+      zh: '只读 grep 通过当前策略，Runtime 允许它进入 Workspace。',
+      en: 'Read-only grep passes the active policy and may enter the workspace.',
+    },
+    tags: ['ToolInvoker', 'PermissionPolicy', 'HookExecutor'],
+  },
+  {
+    id: 'execution',
+    code: '05',
+    stage: 'WORKSPACE',
+    title: { zh: '在 Workspace 执行', en: 'Execute in the workspace' },
+    path: 'allowed call → result',
+    summary: {
+      zh: '真正接触文件、Shell、Git、MCP 或子任务的是 Workspace 工具。结果会先清理和记录，再送回模型继续判断。',
+      en: 'Workspace tools are what actually reach files, shell, Git, MCP, or child tasks. Results are sanitized and recorded before returning to the model.',
+    },
+    input: {
+      zh: '受控 grep 调用',
+      en: 'Governed grep invocation',
+    },
+    action: {
+      zh: '执行搜索，清理输出并保存大结果',
+      en: 'Run the search, sanitize output, and store large results',
+    },
+    output: {
+      zh: '3 matches + Artifact 引用',
+      en: '3 matches + Artifact reference',
+    },
+    event: 'tool_end',
+    trace: {
+      zh: '结果回到本轮对话；如果模型还需要工具，会回到步骤 03。',
+      en: 'The result returns to the turn. If another tool is needed, the flow returns to step 03.',
+    },
+    tags: ['Workspace', 'ToolResult', 'Artifact'],
+  },
+  {
+    id: 'evidence',
+    code: '06',
+    stage: 'EVIDENCE',
+    title: { zh: '把过程交给界面和存储', en: 'Publish events and evidence' },
+    path: 'events → UI / snapshot',
+    summary: {
+      zh: '界面消费统一事件格式，不需要从文本里猜进度。启用 autoSave 或调用 save() 时，对话、Trace、Artifact 与验证结果会作为一个完整快照提交。',
+      en: 'The UI consumes a stable event format instead of guessing progress from text. With autoSave or save(), conversation, traces, artifacts, and verification are committed as one snapshot.',
+    },
+    input: {
+      zh: 'AgentEvent + AgentResult',
+      en: 'AgentEvent + AgentResult',
+    },
+    action: {
+      zh: '投影事件，并在保存时提交完整 generation',
+      en: 'Project events and commit a complete generation on save',
+    },
+    output: {
+      zh: 'EventEnvelopeV1 + SessionSnapshotV1',
+      en: 'EventEnvelopeV1 + SessionSnapshotV1',
+    },
+    event: 'end · snapshot',
+    trace: {
+      zh: '应用拿到可渲染的结果；Session 也具备排查、审计与恢复依据。',
+      en: 'The app receives renderable output, while the session keeps evidence for debugging, audit, and recovery.',
+    },
+    tags: ['EventEnvelopeV1', 'RunRecord', 'SessionSnapshotV1'],
+  },
+] satisfies Array<{
+  id: string;
+  code: string;
+  stage: string;
+  title: Localized;
+  path: string;
+  summary: Localized;
+  input: Localized;
+  action: Localized;
+  output: Localized;
+  event: string;
+  trace: Localized;
+  tags: string[];
+}>;
+
+type RuntimeFlowStep = (typeof runtimeFlowSteps)[number];
 
 const copy = {
   zh: {
@@ -341,7 +535,7 @@ const copy = {
     architectureBody:
       '示例使用仓库中实际提供的 a3s_code API。滚动或点击步骤，代码会逐步加入 Session、上下文限制、权限、事件流和持久化。',
     architectureAlt:
-      'A3S Code 运行时分层图，展示接入方式、AgentSession、上下文、权限检查、工具与运行记录。',
+      'A3S Code 一次执行的交互流程图，展示请求的输入、Runtime 的处理和每一步输出。',
     capabilitiesEyebrow: 'WHAT YOU GET',
     capabilitiesTitle: 'Runtime 提供的五类能力',
     capabilitiesBody:
@@ -363,11 +557,20 @@ const copy = {
     boundaryContract: 'API 与事件',
     boundaryHostLabel: '你的应用',
     boundaryHostRole: '账号、权限与界面',
-    stackTitle: 'A3S CODE / 分层检查器',
-    stackHint: '悬停预览 · 点击固定',
-    stackHintMobile: '点击展开',
+    stackTitle: 'A3S CODE / 一次执行',
+    stackHint: '点击步骤查看输入与输出',
+    stackHintMobile: '点击步骤展开',
     stackTop: '产品',
     stackBottom: '记录',
+    flowTaskLabel: '示例任务',
+    flowTask: '检查仓库并列出发布阻塞项',
+    flowPlay: '演示',
+    flowRunning: '运行中',
+    flowInput: '收到',
+    flowAction: 'A3S 处理',
+    flowOutput: '交给下一步',
+    flowEvent: '对应事件',
+    flowObjects: '相关对象',
     tutorialStep: '步骤',
     tutorialCode: '代码',
     tutorialLayers: '当前负责的层',
@@ -409,7 +612,7 @@ const copy = {
     architectureBody:
       'The example uses the actual a3s_code API in this repository. Scroll or select a step to add the Session, context limits, policy, event stream, and persistence.',
     architectureAlt:
-      'A3S Code runtime layers showing entry points, AgentSession, context, permission checks, tools, and run records.',
+      'An interactive A3S Code run showing the input, runtime work, and output of each step.',
     capabilitiesEyebrow: 'WHAT YOU GET',
     capabilitiesTitle: 'Five parts of the runtime',
     capabilitiesBody:
@@ -431,11 +634,20 @@ const copy = {
     boundaryContract: 'APIs + EVENTS',
     boundaryHostLabel: 'YOUR APP',
     boundaryHostRole: 'OWNS UI + ACCESS',
-    stackTitle: 'A3S CODE / LAYER INSPECTOR',
-    stackHint: 'HOVER TO PREVIEW · CLICK TO PIN',
-    stackHintMobile: 'TAP TO EXPAND',
+    stackTitle: 'A3S CODE / ONE RUN',
+    stackHint: 'SELECT A STEP TO SEE INPUT AND OUTPUT',
+    stackHintMobile: 'TAP A STEP TO EXPAND',
     stackTop: 'PRODUCT',
     stackBottom: 'RECORDS',
+    flowTaskLabel: 'SAMPLE REQUEST',
+    flowTask: 'Inspect the repository and list release blockers',
+    flowPlay: 'PLAY',
+    flowRunning: 'RUNNING',
+    flowInput: 'INPUT',
+    flowAction: 'A3S DOES',
+    flowOutput: 'OUTPUT',
+    flowEvent: 'EVENT',
+    flowObjects: 'OBJECTS',
     tutorialStep: 'STEP',
     tutorialCode: 'CODE',
     tutorialLayers: 'ACTIVE LAYER',
@@ -528,72 +740,135 @@ function InstallSwitcher({
   );
 }
 
-function RuntimeLayerDetail({
+function RuntimeFlowDetail({
   className,
-  layer,
+  step,
+  labels,
   locale,
 }: {
   className: string;
-  layer: RuntimeLayer;
+  step: RuntimeFlowStep;
+  labels: (typeof copy)[Locale];
   locale: Locale;
 }) {
   return (
     <article
-      className={`a3s-runtime-layer-detail ${className}`}
-      data-layer={layer.id}
+      className={`a3s-runtime-flow-detail ${className}`}
+      data-step={step.id}
     >
-      <span>{layer.code}</span>
-      <h2>{localeValue(layer.title, locale)}</h2>
-      <p>{localeValue(layer.body, locale)}</p>
-      <div>
-        {layer.tags.map((tag) => (
-          <small key={tag}>{tag}</small>
-        ))}
+      <header>
+        <span>
+          STEP {step.code} / {step.stage}
+        </span>
+        <h2>{localeValue(step.title, locale)}</h2>
+        <p>{localeValue(step.summary, locale)}</p>
+      </header>
+
+      <div className="a3s-runtime-flow-io">
+        <div>
+          <small>{labels.flowInput}</small>
+          <code>{localeValue(step.input, locale)}</code>
+        </div>
+        <div>
+          <small>{labels.flowAction}</small>
+          <code>{localeValue(step.action, locale)}</code>
+        </div>
+        <div>
+          <small>{labels.flowOutput}</small>
+          <code>{localeValue(step.output, locale)}</code>
+        </div>
       </div>
+
+      <footer>
+        <div className="a3s-runtime-flow-event">
+          <small>{labels.flowEvent}</small>
+          <code>
+            <i aria-hidden="true" />
+            {step.event}
+          </code>
+          <p>{localeValue(step.trace, locale)}</p>
+        </div>
+        <div className="a3s-runtime-flow-objects">
+          <small>{labels.flowObjects}</small>
+          <span>
+            {step.tags.map((tag) => (
+              <code key={tag}>{tag}</code>
+            ))}
+          </span>
+        </div>
+      </footer>
     </article>
   );
 }
 
-function RuntimeLayerInspector({
+function RuntimeExecutionFlow({
   labels,
   locale,
 }: {
   labels: (typeof copy)[Locale];
   locale: Locale;
 }) {
-  const [selectedIndex, setSelectedIndex] = useState(3);
-  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
-  const activeIndex = previewIndex ?? selectedIndex;
-  const active = runtimeLayers[activeIndex] ?? runtimeLayers[3];
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const active = runtimeFlowSteps[activeIndex] ?? runtimeFlowSteps[0];
 
-  function selectLayer(index: number) {
-    setPreviewIndex(null);
-    setSelectedIndex(index);
+  useEffect(() => {
+    if (!isPlaying) return undefined;
+
+    const delay = activeIndex === runtimeFlowSteps.length - 1 ? 720 : 920;
+    const timer = window.setTimeout(() => {
+      if (activeIndex === runtimeFlowSteps.length - 1) {
+        setIsPlaying(false);
+      } else {
+        setActiveIndex((index) =>
+          Math.min(index + 1, runtimeFlowSteps.length - 1),
+        );
+      }
+    }, delay);
+
+    return () => window.clearTimeout(timer);
+  }, [activeIndex, isPlaying]);
+
+  function selectStep(index: number) {
+    setIsPlaying(false);
+    setActiveIndex(index);
   }
 
-  function handleLayerKeyDown(
+  function playFlow() {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setActiveIndex(runtimeFlowSteps.length - 1);
+      setIsPlaying(false);
+      return;
+    }
+
+    setActiveIndex(0);
+    setIsPlaying(true);
+  }
+
+  function handleStepKeyDown(
     event: ReactKeyboardEvent<HTMLButtonElement>,
     index: number,
   ) {
     let nextIndex: number | undefined;
 
     if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-      nextIndex = (index + 1) % runtimeLayers.length;
+      nextIndex = (index + 1) % runtimeFlowSteps.length;
     } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-      nextIndex = (index - 1 + runtimeLayers.length) % runtimeLayers.length;
+      nextIndex =
+        (index - 1 + runtimeFlowSteps.length) % runtimeFlowSteps.length;
     } else if (event.key === 'Home') {
       nextIndex = 0;
     } else if (event.key === 'End') {
-      nextIndex = runtimeLayers.length - 1;
+      nextIndex = runtimeFlowSteps.length - 1;
     }
 
     if (nextIndex === undefined) return;
 
     event.preventDefault();
-    selectLayer(nextIndex);
+    selectStep(nextIndex);
     const inspector = event.currentTarget.closest('.a3s-runtime-inspector');
     inspector
-      ?.querySelectorAll<HTMLButtonElement>('.a3s-runtime-layer-control')
+      ?.querySelectorAll<HTMLButtonElement>('.a3s-runtime-flow-step')
       .item(nextIndex)
       .focus();
   }
@@ -605,119 +880,93 @@ function RuntimeLayerInspector({
           <i aria-hidden="true" />
           {labels.stackTitle}
         </span>
-        <small>
-          <span className="a3s-runtime-hint-desktop">{labels.stackHint}</span>
-          <span className="a3s-runtime-hint-mobile">
-            {labels.stackHintMobile}
-          </span>
+        <div>
+          <button
+            aria-pressed={isPlaying}
+            className={isPlaying ? 'is-playing' : ''}
+            onClick={playFlow}
+            type="button"
+          >
+            <i aria-hidden="true" />
+            {isPlaying ? labels.flowRunning : labels.flowPlay}
+          </button>
           <b>
             {String(activeIndex + 1).padStart(2, '0')} /{' '}
-            {String(runtimeLayers.length).padStart(2, '0')}
+            {String(runtimeFlowSteps.length).padStart(2, '0')}
           </b>
-        </small>
+        </div>
       </header>
+
+      <div className="a3s-runtime-flow-request">
+        <span>{labels.flowTaskLabel}</span>
+        <code>
+          <i aria-hidden="true">&gt;&gt;&gt;</i>
+          session.stream(&quot;{labels.flowTask}&quot;)
+        </code>
+      </div>
+
       <div className="a3s-runtime-inspector-body">
-        <div
-          className="a3s-runtime-inspector-visual"
-          onMouseLeave={() => setPreviewIndex(null)}
+        <nav
+          aria-label={labels.architectureAlt}
+          className="a3s-runtime-flow-nav"
         >
-          <div className="a3s-runtime-model-scale" aria-hidden="true">
-            <span>{labels.stackTop}</span>
-            <i />
-            <span>{labels.stackBottom}</span>
+          <div className="a3s-runtime-flow-track" aria-hidden="true">
+            <span
+              style={{
+                height: `${(activeIndex / (runtimeFlowSteps.length - 1)) * 100}%`,
+              }}
+            />
           </div>
-          <div className="a3s-runtime-layer-model">
-            {runtimeLayers.map((layer, index) => (
+
+          {runtimeFlowSteps.map((step, index) => (
+            <div className="a3s-runtime-flow-row" key={step.id}>
               <button
-                aria-label={`${layer.code}: ${localeValue(layer.title, locale)}`}
-                aria-pressed={selectedIndex === index}
+                aria-pressed={activeIndex === index}
                 className={[
-                  'a3s-runtime-model-slab',
-                  `a3s-runtime-model-slab--${layer.id}`,
+                  'a3s-runtime-flow-step',
+                  `a3s-runtime-flow-step--${step.id}`,
                   activeIndex === index ? 'is-active' : '',
-                  selectedIndex === index ? 'is-selected' : '',
+                  activeIndex > index ? 'is-complete' : '',
                 ]
                   .filter(Boolean)
                   .join(' ')}
-                key={layer.id}
-                onClick={() => selectLayer(index)}
-                onMouseEnter={() => setPreviewIndex(index)}
-                style={{
-                  left: `${index * 3}px`,
-                  top: `${24 + index * 47}px`,
+                onClick={() => selectStep(index)}
+                onFocus={() => selectStep(index)}
+                onKeyDown={(event) => handleStepKeyDown(event, index)}
+                onMouseEnter={() => {
+                  if (!isPlaying) setActiveIndex(index);
                 }}
-                tabIndex={-1}
                 type="button"
               >
+                <span>{step.code}</span>
                 <span>
-                  <i />
-                  <i />
-                  <i />
+                  <small>{step.stage}</small>
+                  <strong>{localeValue(step.title, locale)}</strong>
+                  <em>{step.path}</em>
                 </span>
+                <i aria-hidden="true" />
               </button>
-            ))}
-          </div>
-          <div
-            className="a3s-runtime-model-caption"
-            data-layer={active.id}
-            aria-live="polite"
-          >
-            <span>
-              <i aria-hidden="true" />
-              {active.code}
-            </span>
-            <strong>{localeValue(active.title, locale)}</strong>
-          </div>
-        </div>
-        <div
-          className="a3s-runtime-inspector-panel"
-          onMouseLeave={() => setPreviewIndex(null)}
-        >
-          <nav
-            aria-label={labels.architectureAlt}
-            className="a3s-runtime-layer-list"
-          >
-            {runtimeLayers.map((layer, index) => (
-              <div className="a3s-runtime-layer-row" key={layer.id}>
-                <button
-                  aria-pressed={selectedIndex === index}
-                  className={[
-                    'a3s-runtime-layer-control',
-                    `a3s-runtime-layer-control--${layer.id}`,
-                    activeIndex === index ? 'is-active' : '',
-                    selectedIndex === index ? 'is-selected' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                  onClick={() => selectLayer(index)}
-                  onFocus={() => selectLayer(index)}
-                  onKeyDown={(event) => handleLayerKeyDown(event, index)}
-                  onMouseEnter={() => setPreviewIndex(index)}
-                  type="button"
-                >
-                  <span>{String(index + 1).padStart(2, '0')}</span>
-                  <span>
-                    <small>{layer.code.replace(/^L\d+\s*\/\s*/, '')}</small>
-                    <strong>{localeValue(layer.title, locale)}</strong>
-                  </span>
-                  <i aria-hidden="true" />
-                </button>
-                {activeIndex === index ? (
-                  <RuntimeLayerDetail
-                    className="a3s-runtime-layer-detail--mobile"
-                    layer={active}
-                    locale={locale}
-                  />
-                ) : null}
-              </div>
-            ))}
-          </nav>
-          <RuntimeLayerDetail
-            className="a3s-runtime-layer-detail--desktop"
-            layer={active}
-            locale={locale}
-          />
-        </div>
+
+              {activeIndex === index ? (
+                <RuntimeFlowDetail
+                  className="a3s-runtime-flow-detail--mobile"
+                  key={active.id}
+                  labels={labels}
+                  locale={locale}
+                  step={active}
+                />
+              ) : null}
+            </div>
+          ))}
+        </nav>
+
+        <RuntimeFlowDetail
+          className="a3s-runtime-flow-detail--desktop"
+          key={active.id}
+          labels={labels}
+          locale={locale}
+          step={active}
+        />
       </div>
     </div>
   );
@@ -1035,7 +1284,7 @@ export function HomeLayout() {
           <InstallSwitcher labels={labels} locale={locale} />
         </div>
         <div className="a3s-hero-visual">
-          <RuntimeLayerInspector labels={labels} locale={locale} />
+          <RuntimeExecutionFlow labels={labels} locale={locale} />
         </div>
       </section>
 

--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -244,40 +244,63 @@ body {
   transform: translateY(-1px);
 }
 
+@property --a3s-cta-angle {
+  syntax: '<angle>';
+  inherits: true;
+  initial-value: 68deg;
+}
+
 .a3s-button--primary {
+  --a3s-cta-angle: 68deg;
+
   position: relative;
-  overflow: hidden;
-  border-color: transparent;
+  border: 2px solid transparent;
   border-radius: 10px;
-  background: transparent;
+  background:
+    linear-gradient(180deg, #171a21, #101217) padding-box,
+    conic-gradient(
+        from var(--a3s-cta-angle),
+        #582cff 0deg 220deg,
+        #7b3fff 240deg,
+        #38d3ff 262deg,
+        #fbffff 292deg,
+        #72dcff 316deg,
+        #864aff 342deg,
+        #582cff 360deg
+      )
+      border-box;
   color: #f7f8fb !important;
   box-shadow:
-    0 0 0 1px rgba(117, 74, 255, 0.18),
+    0 0 0 1px rgba(117, 74, 255, 0.3),
     0 10px 28px rgba(0, 0, 0, 0.28);
   isolation: isolate;
 }
 
 .a3s-button--primary::before {
   position: absolute;
-  z-index: -2;
+  z-index: -1;
+  border-radius: 13px;
   background: conic-gradient(
-    #6636ff 0 18%,
-    #5be2ff 24%,
-    #f7f9ff 28%,
-    #7640ff 35% 72%,
-    #be55ff 82%,
-    #6636ff 100%
+    from var(--a3s-cta-angle),
+    transparent 0deg 238deg,
+    rgba(104, 219, 255, 0.22) 264deg,
+    rgba(255, 255, 255, 0.76) 292deg,
+    rgba(113, 65, 255, 0.22) 340deg,
+    transparent 360deg
   );
   content: '';
-  inset: -170%;
+  filter: blur(7px);
+  inset: -4px;
+  opacity: 0.48;
   pointer-events: none;
 }
 
 .a3s-button--primary::after {
   position: absolute;
-  z-index: -1;
-  border-radius: 8px;
-  background: linear-gradient(180deg, #171a21, #101217);
+  border-radius: 7px;
+  box-shadow:
+    inset 0 1px rgba(255, 255, 255, 0.08),
+    inset 0 -1px rgba(0, 0, 0, 0.32);
   content: '';
   inset: 2px;
   pointer-events: none;
@@ -286,14 +309,14 @@ body {
 .a3s-button--primary:hover {
   border-color: transparent;
   box-shadow:
-    0 0 0 1px rgba(111, 76, 255, 0.2),
-    0 0 24px rgba(99, 100, 255, 0.18),
+    0 0 0 1px rgba(111, 76, 255, 0.38),
+    0 0 22px rgba(99, 100, 255, 0.2),
     0 12px 32px rgba(0, 0, 0, 0.34);
 }
 
-.a3s-button--primary:hover::before,
-.a3s-button--primary:focus-visible::before {
-  animation: a3s-button-border-flow 1.15s linear infinite;
+.a3s-button--primary:hover,
+.a3s-button--primary:focus-visible {
+  animation: a3s-button-border-flow 1s linear infinite;
 }
 
 .a3s-button--primary:focus-visible {
@@ -303,7 +326,7 @@ body {
 
 @keyframes a3s-button-border-flow {
   to {
-    transform: rotate(1turn);
+    --a3s-cta-angle: 428deg;
   }
 }
 
@@ -3875,6 +3898,500 @@ body {
   display: none;
 }
 
+.a3s-runtime-inspector {
+  min-height: 574px;
+  background:
+    radial-gradient(
+      circle at 84% 18%,
+      rgba(86, 119, 181, 0.08),
+      transparent 31%
+    ),
+    #0b0e13;
+}
+
+.a3s-runtime-inspector::before {
+  display: none;
+}
+
+.a3s-runtime-inspector-header {
+  min-height: 48px;
+}
+
+.a3s-runtime-inspector-header > div {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.a3s-runtime-inspector-header > div > button {
+  display: inline-flex;
+  min-height: 26px;
+  padding: 0 9px;
+  border: 1px solid #313a46;
+  border-radius: 4px;
+  background: #10151c;
+  color: #7f8a98;
+  cursor: pointer;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.a3s-runtime-inspector-header > div > button:hover,
+.a3s-runtime-inspector-header > div > button:focus-visible {
+  border-color: #65768b;
+  background: #151b24;
+  color: #dbe4ef;
+}
+
+.a3s-runtime-inspector-header > div > button:focus-visible {
+  outline: 2px solid rgba(124, 174, 238, 0.48);
+  outline-offset: 2px;
+}
+
+.a3s-runtime-inspector-header > div > button > i {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid #62cda0;
+}
+
+.a3s-runtime-inspector-header > div > button.is-playing > i {
+  width: 6px;
+  height: 6px;
+  border: 0;
+  border-radius: 50%;
+  background: #62cda0;
+  box-shadow: 0 0 10px rgba(98, 205, 160, 0.7);
+  animation: a3s-flow-running 900ms ease-in-out infinite alternate;
+}
+
+.a3s-runtime-inspector-header > div > b {
+  color: #788493;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  font-weight: 560;
+}
+
+.a3s-runtime-flow-request {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  min-height: 68px;
+  padding: 12px 18px;
+  border-bottom: 1px solid #282f39;
+  background: rgba(14, 18, 24, 0.86);
+  align-items: center;
+  gap: 14px;
+  grid-template-columns: 78px minmax(0, 1fr);
+}
+
+.a3s-runtime-flow-request > span {
+  color: #566271;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.a3s-runtime-flow-request > code {
+  overflow: hidden;
+  color: #cad3df;
+  font-family: var(--a3s-mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-runtime-flow-request > code i {
+  margin-right: 9px;
+  color: #60c99d;
+  font-style: normal;
+}
+
+.a3s-runtime-inspector-body {
+  display: grid;
+  min-height: 458px;
+  grid-template-columns: minmax(235px, 0.82fr) minmax(0, 1.18fr);
+}
+
+.a3s-runtime-flow-nav {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  padding: 12px;
+  border-right: 1px solid #282f39;
+  background:
+    linear-gradient(rgba(105, 131, 171, 0.024) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(105, 131, 171, 0.024) 1px, transparent 1px),
+    rgba(10, 13, 18, 0.6);
+  background-size: 28px 28px;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+}
+
+.a3s-runtime-flow-track {
+  position: absolute;
+  z-index: 0;
+  top: 44px;
+  bottom: 44px;
+  left: 35px;
+  width: 1px;
+  background: #252d37;
+  pointer-events: none;
+}
+
+.a3s-runtime-flow-track > span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  max-height: 100%;
+  background: linear-gradient(#8870dd, #64a9dc 48%, #5db78f);
+  box-shadow: 0 0 8px rgba(102, 163, 212, 0.35);
+  transition: height 320ms ease;
+}
+
+.a3s-runtime-flow-row {
+  position: relative;
+  z-index: 1;
+}
+
+.a3s-runtime-flow-step {
+  --flow-accent: #8870dd;
+  --flow-tint: rgba(110, 82, 202, 0.08);
+
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-height: 66px;
+  padding: 7px 12px 7px 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: #667281;
+  cursor: pointer;
+  align-items: center;
+  gap: 10px;
+  grid-template-columns: 27px minmax(0, 1fr) 7px;
+  text-align: left;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+.a3s-runtime-flow-step > span:first-child {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  width: 27px;
+  height: 27px;
+  border: 1px solid #303946;
+  border-radius: 50%;
+  background: #0e1218;
+  color: #576372;
+  place-items: center;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.a3s-runtime-flow-step > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  align-content: center;
+  gap: 1px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.a3s-runtime-flow-step small {
+  color: #505d6c;
+  grid-column: 1 / -1;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+}
+
+.a3s-runtime-flow-step strong {
+  overflow: hidden;
+  color: #aeb7c4;
+  font-size: 11px;
+  font-weight: 580;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-runtime-flow-step em {
+  overflow: hidden;
+  color: #495563;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  font-style: normal;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-runtime-flow-step > i {
+  width: 6px;
+  height: 6px;
+  border: 1px solid #3a4552;
+  border-radius: 50%;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.a3s-runtime-flow-step:hover {
+  border-color: #28313c;
+  background: rgba(18, 23, 31, 0.72);
+}
+
+.a3s-runtime-flow-step.is-active {
+  border-color: color-mix(in srgb, var(--flow-accent) 48%, #28313c);
+  background:
+    linear-gradient(100deg, var(--flow-tint), transparent 62%), #121720;
+  transform: translateX(2px);
+}
+
+.a3s-runtime-flow-step.is-active > span:first-child {
+  border-color: var(--flow-accent);
+  background: #151a23;
+  color: var(--flow-accent);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--flow-accent) 25%, transparent);
+}
+
+.a3s-runtime-flow-step.is-active small,
+.a3s-runtime-flow-step.is-active em {
+  color: var(--flow-accent);
+}
+
+.a3s-runtime-flow-step.is-active strong {
+  color: #f0f3f7;
+}
+
+.a3s-runtime-flow-step.is-active > i {
+  border-color: var(--flow-accent);
+  background: var(--flow-accent);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--flow-accent) 55%, transparent);
+}
+
+.a3s-runtime-flow-step.is-complete > span:first-child {
+  border-color: #456f63;
+  color: #68b798;
+}
+
+.a3s-runtime-flow-step.is-complete > i {
+  border-color: #4e7d6d;
+  background: #5da98b;
+}
+
+.a3s-runtime-flow-step:focus-visible {
+  border-color: #8294aa;
+  outline: 2px solid rgba(130, 171, 224, 0.48);
+  outline-offset: 2px;
+}
+
+.a3s-runtime-flow-step--context {
+  --flow-accent: #65a6c3;
+  --flow-tint: rgba(71, 139, 168, 0.09);
+}
+
+.a3s-runtime-flow-step--model {
+  --flow-accent: #6f9ee1;
+  --flow-tint: rgba(75, 120, 190, 0.1);
+}
+
+.a3s-runtime-flow-step--governance {
+  --flow-accent: #d1a252;
+  --flow-tint: rgba(175, 119, 34, 0.1);
+}
+
+.a3s-runtime-flow-step--execution {
+  --flow-accent: #c67e57;
+  --flow-tint: rgba(158, 82, 43, 0.1);
+}
+
+.a3s-runtime-flow-step--evidence {
+  --flow-accent: #5ab38a;
+  --flow-tint: rgba(42, 133, 94, 0.1);
+}
+
+.a3s-runtime-flow-detail {
+  --flow-accent: #8870dd;
+  --flow-tint: rgba(110, 82, 202, 0.065);
+
+  display: flex;
+  min-width: 0;
+  padding: 22px 24px 20px;
+  background:
+    linear-gradient(120deg, var(--flow-tint), transparent 56%),
+    rgba(11, 14, 19, 0.84);
+  flex-direction: column;
+  animation: a3s-flow-detail-in 180ms ease-out;
+}
+
+.a3s-runtime-flow-detail[data-step='context'] {
+  --flow-accent: #65a6c3;
+  --flow-tint: rgba(71, 139, 168, 0.065);
+}
+
+.a3s-runtime-flow-detail[data-step='model'] {
+  --flow-accent: #6f9ee1;
+  --flow-tint: rgba(75, 120, 190, 0.07);
+}
+
+.a3s-runtime-flow-detail[data-step='governance'] {
+  --flow-accent: #d1a252;
+  --flow-tint: rgba(175, 119, 34, 0.07);
+}
+
+.a3s-runtime-flow-detail[data-step='execution'] {
+  --flow-accent: #c67e57;
+  --flow-tint: rgba(158, 82, 43, 0.07);
+}
+
+.a3s-runtime-flow-detail[data-step='evidence'] {
+  --flow-accent: #5ab38a;
+  --flow-tint: rgba(42, 133, 94, 0.07);
+}
+
+.a3s-runtime-flow-detail > header > span {
+  color: var(--flow-accent);
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+}
+
+.a3s-runtime-flow-detail > header h2 {
+  margin: 9px 0 8px;
+  color: #edf1f6;
+  font-size: 19px;
+  font-weight: 630;
+  letter-spacing: -0.025em;
+}
+
+.a3s-runtime-flow-detail > header p {
+  margin: 0;
+  color: #8c96a3;
+  font-size: 11px;
+  line-height: 1.62;
+}
+
+.a3s-runtime-flow-io {
+  margin-top: 18px;
+  border: 1px solid #29313b;
+  border-bottom: 0;
+}
+
+.a3s-runtime-flow-io > div {
+  display: grid;
+  min-height: 51px;
+  padding: 9px 12px;
+  border-bottom: 1px solid #29313b;
+  align-items: center;
+  gap: 12px;
+  grid-template-columns: 78px minmax(0, 1fr);
+}
+
+.a3s-runtime-flow-io small,
+.a3s-runtime-flow-event > small,
+.a3s-runtime-flow-objects > small {
+  color: #566170;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.a3s-runtime-flow-io code {
+  color: #b8c2ce;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.a3s-runtime-flow-detail > footer {
+  display: grid;
+  margin-top: auto;
+  padding-top: 16px;
+  gap: 14px;
+}
+
+.a3s-runtime-flow-event {
+  display: grid;
+  padding-left: 12px;
+  border-left: 2px solid var(--flow-accent);
+  gap: 5px;
+  grid-template-columns: 72px minmax(0, 1fr);
+}
+
+.a3s-runtime-flow-event > code {
+  color: var(--flow-accent);
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+}
+
+.a3s-runtime-flow-event > code i {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin-right: 7px;
+  border-radius: 50%;
+  background: var(--flow-accent);
+  box-shadow: 0 0 9px var(--flow-accent);
+}
+
+.a3s-runtime-flow-event > p {
+  margin: 0;
+  color: #737f8d;
+  grid-column: 2;
+  font-size: 9px;
+  line-height: 1.5;
+}
+
+.a3s-runtime-flow-objects {
+  display: grid;
+  align-items: start;
+  gap: 10px;
+  grid-template-columns: 74px minmax(0, 1fr);
+}
+
+.a3s-runtime-flow-objects > span {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.a3s-runtime-flow-objects code {
+  padding: 3px 5px;
+  border: 1px solid #303844;
+  color: #697585;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+}
+
+.a3s-runtime-flow-detail--mobile {
+  display: none;
+}
+
 .a3s-feature-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-template-rows: none;
@@ -3989,15 +4506,7 @@ body {
   }
 
   .a3s-runtime-inspector-body {
-    grid-template-columns: minmax(205px, 0.78fr) minmax(290px, 1.22fr);
-  }
-
-  .a3s-runtime-layer-model {
-    width: 218px;
-  }
-
-  .a3s-runtime-model-slab {
-    width: 196px;
+    grid-template-columns: minmax(220px, 0.82fr) minmax(0, 1.18fr);
   }
 
   .a3s-feature-grid {
@@ -4081,17 +4590,31 @@ body {
     padding: 0 14px;
   }
 
-  .a3s-runtime-inspector-header small {
-    max-width: 144px;
+  .a3s-runtime-inspector-header > span {
+    font-size: 8px;
+    letter-spacing: 0.045em;
+  }
+
+  .a3s-runtime-inspector-header > div {
+    gap: 7px;
+  }
+
+  .a3s-runtime-inspector-header > div > button {
+    min-height: 25px;
+    padding: 0 7px;
+  }
+
+  .a3s-runtime-flow-request {
+    min-height: 76px;
+    padding: 12px 14px;
     gap: 8px;
+    grid-template-columns: 66px minmax(0, 1fr);
   }
 
-  .a3s-runtime-hint-desktop {
-    display: none;
-  }
-
-  .a3s-runtime-hint-mobile {
-    display: inline;
+  .a3s-runtime-flow-request > code {
+    font-size: 9px;
+    line-height: 1.55;
+    white-space: normal;
   }
 
   .a3s-runtime-inspector-body {
@@ -4099,56 +4622,77 @@ body {
     min-height: 0;
   }
 
-  .a3s-runtime-inspector-visual {
-    display: none;
-  }
-
-  .a3s-runtime-inspector-panel {
-    display: block;
-  }
-
-  .a3s-runtime-layer-list {
+  .a3s-runtime-flow-nav {
     padding: 0;
+    border-right: 0;
+    background: rgba(10, 13, 18, 0.62);
     gap: 0;
   }
 
-  .a3s-runtime-layer-row + .a3s-runtime-layer-row {
-    border-top: 1px solid #252c35;
-  }
-
-  .a3s-runtime-layer-control {
-    min-height: 64px;
-    padding: 9px 16px;
-    border: 0;
-    border-radius: 0;
-  }
-
-  .a3s-runtime-layer-control:hover,
-  .a3s-runtime-layer-control.is-active {
-    border-color: transparent;
-  }
-
-  .a3s-runtime-layer-control strong {
-    font-size: 12px;
-  }
-
-  .a3s-runtime-layer-detail--desktop {
+  .a3s-runtime-flow-track {
     display: none;
   }
 
-  .a3s-runtime-layer-detail--mobile {
-    display: block;
-    padding: 17px 18px 20px 54px;
+  .a3s-runtime-flow-row + .a3s-runtime-flow-row {
     border-top: 1px solid #252c35;
-    animation: a3s-layer-detail-in 180ms ease-out;
   }
 
-  .a3s-runtime-layer-detail--mobile h2 {
-    font-size: 17px;
+  .a3s-runtime-flow-step {
+    min-height: 72px;
+    padding: 9px 15px;
+    border: 0;
+    border-radius: 0;
+    grid-template-columns: 28px minmax(0, 1fr) 7px;
   }
 
-  .a3s-runtime-layer-detail--mobile p {
+  .a3s-runtime-flow-step > span:nth-child(2) {
+    grid-template-columns: 1fr;
+  }
+
+  .a3s-runtime-flow-step:hover,
+  .a3s-runtime-flow-step.is-active {
+    border-color: transparent;
+    transform: none;
+  }
+
+  .a3s-runtime-flow-step strong {
+    font-size: 12px;
+  }
+
+  .a3s-runtime-flow-step em {
+    margin-left: 0;
+  }
+
+  .a3s-runtime-flow-detail--desktop {
+    display: none;
+  }
+
+  .a3s-runtime-flow-detail--mobile {
+    display: flex;
+    padding: 20px 17px 22px 54px;
+    border-top: 1px solid #252c35;
+    border-bottom: 1px solid #252c35;
+  }
+
+  .a3s-runtime-flow-detail > header h2 {
+    font-size: 18px;
+  }
+
+  .a3s-runtime-flow-detail > header p {
     font-size: 11px;
+  }
+
+  .a3s-runtime-flow-io > div {
+    padding: 9px 10px;
+    grid-template-columns: 74px minmax(0, 1fr);
+  }
+
+  .a3s-runtime-flow-event {
+    grid-template-columns: 66px minmax(0, 1fr);
+  }
+
+  .a3s-runtime-flow-objects {
+    grid-template-columns: 68px minmax(0, 1fr);
   }
 
   .a3s-feature-grid {
@@ -4191,12 +4735,21 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .a3s-button--primary:hover,
+  .a3s-button--primary:focus-visible {
+    animation: none;
+  }
+
   .a3s-runtime-model-slab,
-  .a3s-runtime-layer-control {
+  .a3s-runtime-layer-control,
+  .a3s-runtime-flow-step,
+  .a3s-runtime-flow-track > span {
     transition: none;
   }
 
-  .a3s-runtime-layer-detail--mobile {
+  .a3s-runtime-layer-detail--mobile,
+  .a3s-runtime-flow-detail,
+  .a3s-runtime-inspector-header > div > button.is-playing > i {
     animation: none;
   }
 }
@@ -4210,5 +4763,29 @@ body {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes a3s-flow-detail-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes a3s-flow-running {
+  from {
+    opacity: 0.45;
+    transform: scale(0.82);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }


### PR DESCRIPTION
## Summary
- replace the decorative runtime slabs with a concrete six-step execution flow built from the real A3S runtime boundaries
- show the input, runtime action, output, event, and core objects for one Python session request
- add hover, click, keyboard, mobile accordion, and play-through interactions
- rebuild the primary CTA as a purple border track with a short cyan-white highlight that moves clockwise on hover/focus

## Verification
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run check:site`
- Edge desktop/mobile checks: 6 steps, 3 I/O rows, keyboard navigation, play-through, no console errors, no horizontal overflow
- CTA computed border angle: `68deg` idle → `154deg` after 220ms hover