### PR TITLE
feat(website): redesign hero run player

### DIFF
--- a/website/theme/components/HomeLayout.tsx
+++ b/website/theme/components/HomeLayout.tsx
@@ -503,7 +503,119 @@ const runtimeFlowSteps = [
   tags: string[];
 }>;
 
-type RuntimeFlowStep = (typeof runtimeFlowSteps)[number];
+const runtimePlayerPhases = [
+  {
+    id: 'prepare',
+    code: '01',
+    stage: { zh: '准备', en: 'PREPARE' },
+    navTitle: { zh: '准备上下文', en: 'Prepare context' },
+    title: { zh: '任务已进入 Session', en: 'The task is in the Session' },
+    summary: {
+      zh: 'A3S 创建本次 Run，并从历史、项目指令和记忆中选出模型需要的上下文。',
+      en: 'A3S creates the run and selects the history, project instructions, and memory needed by the model.',
+    },
+    action: {
+      zh: '取得运行权，组装 messages[] 与 tools[]',
+      en: 'Acquire the run lease and assemble messages[] and tools[]',
+    },
+    result: {
+      zh: 'run_id 已创建，上下文已就绪',
+      en: 'run_id created; context is ready',
+    },
+    command: 'session.stream(prompt)',
+    event: `${runtimeFlowSteps[0].event} · ${runtimeFlowSteps[1].event}`,
+    tags: ['AgentSession', 'ContextAssembler'],
+  },
+  {
+    id: 'decide',
+    code: '02',
+    stage: { zh: '判断', en: 'DECIDE' },
+    navTitle: { zh: '决定下一步', en: 'Choose next step' },
+    title: {
+      zh: '模型提出一次只读搜索',
+      en: 'The model proposes a read-only search',
+    },
+    summary: {
+      zh: '模型根据任务选择 grep，只生成结构化调用；此时还没有读取或改动仓库。',
+      en: 'The model selects grep and emits a structured call. It has not read or changed the repository yet.',
+    },
+    action: {
+      zh: '生成 grep({ pattern: "TODO|FIXME" })',
+      en: 'Produce grep({ pattern: "TODO|FIXME" })',
+    },
+    result: {
+      zh: '工具请求已生成，等待执行前检查',
+      en: 'Tool request created; waiting for checks',
+    },
+    command: 'grep({ pattern: "TODO|FIXME" })',
+    event: runtimeFlowSteps[2].event,
+    tags: ['ScopedLlmClient', 'ToolCall'],
+  },
+  {
+    id: 'execute',
+    code: '03',
+    stage: { zh: '执行', en: 'EXECUTE' },
+    navTitle: { zh: '执行工具', en: 'Run the tool' },
+    title: {
+      zh: '检查通过，Workspace 开始搜索',
+      en: 'Checks pass and the workspace runs the search',
+    },
+    summary: {
+      zh: 'ToolInvoker 校验参数和权限后，Workspace 执行 grep；模型调用不能绕过这一步。',
+      en: 'ToolInvoker validates arguments and permissions before the workspace runs grep. Model calls cannot bypass this step.',
+    },
+    action: {
+      zh: '参数 → 权限 → Workspace.grep()',
+      en: 'schema → permission → Workspace.grep()',
+    },
+    result: {
+      zh: '找到 3 条匹配，完整输出写入 Artifact',
+      en: '3 matches found; full output stored as an Artifact',
+    },
+    command: 'ToolInvoker → Workspace.grep()',
+    event: `${runtimeFlowSteps[3].event} · ${runtimeFlowSteps[4].event}`,
+    tags: ['ToolInvoker', 'Workspace', 'Artifact'],
+  },
+  {
+    id: 'record',
+    code: '04',
+    stage: { zh: '留痕', en: 'RECORD' },
+    navTitle: { zh: '保存记录', en: 'Save the record' },
+    title: {
+      zh: '结果和执行记录已保存',
+      en: 'The result and run record are saved',
+    },
+    summary: {
+      zh: '应用收到可以直接展示的结果；事件、Trace 和快照同时保留，后续可以排查或恢复。',
+      en: 'The app receives a renderable result while events, traces, and the snapshot remain available for inspection or recovery.',
+    },
+    action: {
+      zh: '发布事件并提交本次 generation',
+      en: 'Publish events and commit this generation',
+    },
+    result: {
+      zh: '检查完成，结果可查看、追踪和恢复',
+      en: 'Inspection complete; the result is traceable and recoverable',
+    },
+    command: 'session.save()',
+    event: runtimeFlowSteps[5].event,
+    tags: ['EventEnvelopeV1', 'SessionSnapshotV1'],
+  },
+] satisfies Array<{
+  id: string;
+  code: string;
+  stage: Localized;
+  navTitle: Localized;
+  title: Localized;
+  summary: Localized;
+  action: Localized;
+  result: Localized;
+  command: string;
+  event: string;
+  tags: string[];
+}>;
+
+type RuntimePlayerPhase = (typeof runtimePlayerPhases)[number];
 
 const copy = {
   zh: {
@@ -557,20 +669,21 @@ const copy = {
     boundaryContract: 'API 与事件',
     boundaryHostLabel: '你的应用',
     boundaryHostRole: '账号、权限与界面',
-    stackTitle: 'A3S CODE / 一次执行',
-    stackHint: '点击步骤查看输入与输出',
+    stackTitle: '一次真实运行',
+    stackHint: '点击阶段查看过程',
     stackHintMobile: '点击步骤展开',
     stackTop: '产品',
     stackBottom: '记录',
-    flowTaskLabel: '示例任务',
+    flowTaskLabel: '任务',
     flowTask: '检查仓库并列出发布阻塞项',
-    flowPlay: '演示',
-    flowRunning: '运行中',
-    flowInput: '收到',
-    flowAction: 'A3S 处理',
-    flowOutput: '交给下一步',
-    flowEvent: '对应事件',
-    flowObjects: '相关对象',
+    flowReplay: '重播',
+    flowRunning: '回放中',
+    flowComplete: '已完成 · 1.8s',
+    flowStage: '当前阶段',
+    flowAction: 'A3S 正在做',
+    flowOutput: '本步结果',
+    flowEvidence: '本次运行留下',
+    flowEventCount: '7 个事件',
     tutorialStep: '步骤',
     tutorialCode: '代码',
     tutorialLayers: '当前负责的层',
@@ -634,20 +747,21 @@ const copy = {
     boundaryContract: 'APIs + EVENTS',
     boundaryHostLabel: 'YOUR APP',
     boundaryHostRole: 'OWNS UI + ACCESS',
-    stackTitle: 'A3S CODE / ONE RUN',
-    stackHint: 'SELECT A STEP TO SEE INPUT AND OUTPUT',
+    stackTitle: 'One real run',
+    stackHint: 'SELECT A PHASE TO INSPECT IT',
     stackHintMobile: 'TAP A STEP TO EXPAND',
     stackTop: 'PRODUCT',
     stackBottom: 'RECORDS',
-    flowTaskLabel: 'SAMPLE REQUEST',
+    flowTaskLabel: 'TASK',
     flowTask: 'Inspect the repository and list release blockers',
-    flowPlay: 'PLAY',
-    flowRunning: 'RUNNING',
-    flowInput: 'INPUT',
+    flowReplay: 'REPLAY',
+    flowRunning: 'REPLAYING',
+    flowComplete: 'DONE · 1.8s',
+    flowStage: 'CURRENT PHASE',
     flowAction: 'A3S DOES',
-    flowOutput: 'OUTPUT',
-    flowEvent: 'EVENT',
-    flowObjects: 'OBJECTS',
+    flowOutput: 'RESULT',
+    flowEvidence: 'SAVED WITH THIS RUN',
+    flowEventCount: '7 EVENTS',
     tutorialStep: 'STEP',
     tutorialCode: 'CODE',
     tutorialLayers: 'ACTIVE LAYER',
@@ -748,63 +862,53 @@ function InstallSwitcher({
   );
 }
 
-function RuntimeFlowDetail({
-  className,
-  step,
+function RuntimePlayerStage({
+  phase,
   labels,
   locale,
 }: {
-  className: string;
-  step: RuntimeFlowStep;
+  phase: RuntimePlayerPhase;
   labels: (typeof copy)[Locale];
   locale: Locale;
 }) {
   return (
     <article
-      className={`a3s-runtime-flow-detail ${className}`}
-      data-step={step.id}
+      className="a3s-run-player-stage"
+      data-phase={phase.id}
+      key={phase.id}
     >
-      <header>
+      <div className="a3s-run-player-stage-copy">
         <span>
-          STEP {step.code} / {step.stage}
+          {labels.flowStage} {phase.code} / {localeValue(phase.stage, locale)}
         </span>
-        <h2>{localeValue(step.title, locale)}</h2>
-        <p>{localeValue(step.summary, locale)}</p>
-      </header>
+        <h2>{localeValue(phase.title, locale)}</h2>
+        <p>{localeValue(phase.summary, locale)}</p>
+      </div>
 
-      <div className="a3s-runtime-flow-io">
-        <div>
-          <small>{labels.flowInput}</small>
-          <code>{localeValue(step.input, locale)}</code>
-        </div>
-        <div>
+      <div className="a3s-run-player-exchange">
+        <div className="a3s-run-player-action">
           <small>{labels.flowAction}</small>
-          <code>{localeValue(step.action, locale)}</code>
+          <code>{localeValue(phase.action, locale)}</code>
         </div>
-        <div>
+        <i aria-hidden="true" />
+        <div className="a3s-run-player-result">
           <small>{labels.flowOutput}</small>
-          <code>{localeValue(step.output, locale)}</code>
+          <strong>{localeValue(phase.result, locale)}</strong>
         </div>
       </div>
 
-      <footer>
-        <div className="a3s-runtime-flow-event">
-          <small>{labels.flowEvent}</small>
-          <code>
-            <i aria-hidden="true" />
-            {step.event}
-          </code>
-          <p>{localeValue(step.trace, locale)}</p>
-        </div>
-        <div className="a3s-runtime-flow-objects">
-          <small>{labels.flowObjects}</small>
-          <span>
-            {step.tags.map((tag) => (
-              <code key={tag}>{tag}</code>
-            ))}
-          </span>
-        </div>
-      </footer>
+      <div className="a3s-run-player-stage-meta">
+        <code className="a3s-run-player-command">{phase.command}</code>
+        <code className="a3s-run-player-event">
+          <i aria-hidden="true" />
+          {phase.event}
+        </code>
+        <span>
+          {phase.tags.map((tag) => (
+            <code key={tag}>{tag}</code>
+          ))}
+        </span>
+      </div>
     </article>
   );
 }
@@ -816,20 +920,22 @@ function RuntimeExecutionFlow({
   labels: (typeof copy)[Locale];
   locale: Locale;
 }) {
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(
+    runtimePlayerPhases.length - 1,
+  );
   const [isPlaying, setIsPlaying] = useState(false);
-  const active = runtimeFlowSteps[activeIndex] ?? runtimeFlowSteps[0];
+  const active = runtimePlayerPhases[activeIndex] ?? runtimePlayerPhases[0];
 
   useEffect(() => {
     if (!isPlaying) return undefined;
 
-    const delay = activeIndex === runtimeFlowSteps.length - 1 ? 720 : 920;
+    const delay = activeIndex === runtimePlayerPhases.length - 1 ? 780 : 1280;
     const timer = window.setTimeout(() => {
-      if (activeIndex === runtimeFlowSteps.length - 1) {
+      if (activeIndex === runtimePlayerPhases.length - 1) {
         setIsPlaying(false);
       } else {
         setActiveIndex((index) =>
-          Math.min(index + 1, runtimeFlowSteps.length - 1),
+          Math.min(index + 1, runtimePlayerPhases.length - 1),
         );
       }
     }, delay);
@@ -844,7 +950,7 @@ function RuntimeExecutionFlow({
 
   function playFlow() {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      setActiveIndex(runtimeFlowSteps.length - 1);
+      setActiveIndex(runtimePlayerPhases.length - 1);
       setIsPlaying(false);
       return;
     }
@@ -860,14 +966,14 @@ function RuntimeExecutionFlow({
     let nextIndex: number | undefined;
 
     if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-      nextIndex = (index + 1) % runtimeFlowSteps.length;
+      nextIndex = (index + 1) % runtimePlayerPhases.length;
     } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
       nextIndex =
-        (index - 1 + runtimeFlowSteps.length) % runtimeFlowSteps.length;
+        (index - 1 + runtimePlayerPhases.length) % runtimePlayerPhases.length;
     } else if (event.key === 'Home') {
       nextIndex = 0;
     } else if (event.key === 'End') {
-      nextIndex = runtimeFlowSteps.length - 1;
+      nextIndex = runtimePlayerPhases.length - 1;
     }
 
     if (nextIndex === undefined) return;
@@ -876,19 +982,34 @@ function RuntimeExecutionFlow({
     selectStep(nextIndex);
     const inspector = event.currentTarget.closest('.a3s-runtime-inspector');
     inspector
-      ?.querySelectorAll<HTMLButtonElement>('.a3s-runtime-flow-step')
+      ?.querySelectorAll<HTMLButtonElement>('.a3s-run-player-phase')
       .item(nextIndex)
       .focus();
   }
 
+  const statusLabel = isPlaying ? labels.flowRunning : labels.flowComplete;
+
   return (
-    <div className="a3s-runtime-inspector" aria-label={labels.architectureAlt}>
-      <header className="a3s-runtime-inspector-header">
+    <div
+      className="a3s-runtime-inspector a3s-runtime-inspector--player"
+      aria-label={labels.architectureAlt}
+    >
+      <header className="a3s-runtime-inspector-header a3s-run-player-header">
         <span>
           <i aria-hidden="true" />
+          <b>A3S CODE</b>
+          <em>/</em>
           {labels.stackTitle}
         </span>
         <div>
+          <span
+            className={['a3s-run-player-status', isPlaying ? 'is-running' : '']
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <i aria-hidden="true" />
+            {statusLabel}
+          </span>
           <button
             aria-pressed={isPlaying}
             className={isPlaying ? 'is-playing' : ''}
@@ -896,86 +1017,76 @@ function RuntimeExecutionFlow({
             type="button"
           >
             <i aria-hidden="true" />
-            {isPlaying ? labels.flowRunning : labels.flowPlay}
+            {labels.flowReplay}
           </button>
-          <b>
-            {String(activeIndex + 1).padStart(2, '0')} /{' '}
-            {String(runtimeFlowSteps.length).padStart(2, '0')}
-          </b>
         </div>
       </header>
 
-      <div className="a3s-runtime-flow-request">
-        <span>{labels.flowTaskLabel}</span>
-        <code>
-          <i aria-hidden="true">&gt;&gt;&gt;</i>
-          session.stream(&quot;{labels.flowTask}&quot;)
-        </code>
-      </div>
+      <section className="a3s-run-player-task">
+        <span aria-hidden="true">&gt;_</span>
+        <div>
+          <small>{labels.flowTaskLabel}</small>
+          <strong>{labels.flowTask}</strong>
+        </div>
+        <code>session.stream()</code>
+      </section>
 
-      <div className="a3s-runtime-inspector-body">
-        <nav
-          aria-label={labels.architectureAlt}
-          className="a3s-runtime-flow-nav"
-        >
-          <div className="a3s-runtime-flow-track" aria-hidden="true">
-            <span
-              style={{
-                height: `${(activeIndex / (runtimeFlowSteps.length - 1)) * 100}%`,
-              }}
-            />
-          </div>
+      <nav aria-label={labels.stackHint} className="a3s-run-player-progress">
+        <div className="a3s-run-player-rail" aria-hidden="true">
+          <span
+            style={{
+              width: `${(activeIndex / (runtimePlayerPhases.length - 1)) * 100}%`,
+            }}
+          />
+        </div>
 
-          {runtimeFlowSteps.map((step, index) => (
-            <div className="a3s-runtime-flow-row" key={step.id}>
-              <button
-                aria-pressed={activeIndex === index}
-                className={[
-                  'a3s-runtime-flow-step',
-                  `a3s-runtime-flow-step--${step.id}`,
-                  activeIndex === index ? 'is-active' : '',
-                  activeIndex > index ? 'is-complete' : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-                onClick={() => selectStep(index)}
-                onFocus={() => selectStep(index)}
-                onKeyDown={(event) => handleStepKeyDown(event, index)}
-                onMouseEnter={() => {
-                  if (!isPlaying) setActiveIndex(index);
-                }}
-                type="button"
-              >
-                <span>{step.code}</span>
-                <span>
-                  <small>{step.stage}</small>
-                  <strong>{localeValue(step.title, locale)}</strong>
-                  <em>{step.path}</em>
-                </span>
-                <i aria-hidden="true" />
-              </button>
+        {runtimePlayerPhases.map((phase, index) => (
+          <button
+            aria-current={activeIndex === index ? 'step' : undefined}
+            aria-pressed={activeIndex === index}
+            className={[
+              'a3s-run-player-phase',
+              activeIndex === index ? 'is-active' : '',
+              activeIndex > index ? 'is-complete' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            key={phase.id}
+            onClick={() => selectStep(index)}
+            onFocus={() => selectStep(index)}
+            onKeyDown={(event) => handleStepKeyDown(event, index)}
+            type="button"
+          >
+            <span>{phase.code}</span>
+            <span>
+              <small>{localeValue(phase.stage, locale)}</small>
+              <strong>{localeValue(phase.navTitle, locale)}</strong>
+            </span>
+          </button>
+        ))}
+      </nav>
 
-              {activeIndex === index ? (
-                <RuntimeFlowDetail
-                  className="a3s-runtime-flow-detail--mobile"
-                  key={active.id}
-                  labels={labels}
-                  locale={locale}
-                  step={active}
-                />
-              ) : null}
-            </div>
+      <RuntimePlayerStage
+        key={active.id}
+        labels={labels}
+        locale={locale}
+        phase={active}
+      />
+
+      <footer className="a3s-run-player-evidence">
+        <div>
+          <small>{labels.flowEvidence}</small>
+          <strong>
+            <i aria-hidden="true" />
+            {labels.flowEventCount}
+          </strong>
+        </div>
+        <span>
+          {['RunRecord', 'Trace', 'Artifact', 'Snapshot'].map((item) => (
+            <code key={item}>{item}</code>
           ))}
-        </nav>
-
-        <RuntimeFlowDetail
-          className="a3s-runtime-flow-detail--desktop"
-          key={active.id}
-          labels={labels}
-          locale={locale}
-          step={active}
-        />
-      </div>
+        </span>
+      </footer>
     </div>
   );
 }

--- a/website/theme/index.css
+++ b/website/theme/index.css
@@ -4402,6 +4402,479 @@ body {
   display: none;
 }
 
+.a3s-runtime-inspector--player {
+  display: flex;
+  min-height: 574px;
+  background:
+    radial-gradient(
+      circle at 78% 18%,
+      rgba(89, 121, 183, 0.1),
+      transparent 33%
+    ),
+    linear-gradient(155deg, #0d1117, #090c11 68%);
+  flex-direction: column;
+}
+
+.a3s-run-player-header {
+  min-height: 54px;
+  padding: 0 20px;
+  background: rgba(10, 13, 18, 0.94);
+}
+
+.a3s-run-player-header > span {
+  color: #a5afbd;
+  font-size: 9px;
+}
+
+.a3s-run-player-header > span b {
+  color: #dce4ee;
+  font-weight: 620;
+}
+
+.a3s-run-player-header > span em {
+  color: #4f5b69;
+  font-style: normal;
+}
+
+.a3s-run-player-header > div {
+  gap: 13px;
+}
+
+.a3s-run-player-header > div > button {
+  min-height: 29px;
+  padding: 0 10px;
+  color: #a7b3c1;
+  font-size: 8px;
+}
+
+.a3s-run-player-status {
+  display: inline-flex;
+  color: #718091;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  letter-spacing: 0.05em;
+}
+
+.a3s-run-player-status > i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #5bc596;
+  box-shadow: 0 0 9px rgba(91, 197, 150, 0.58);
+}
+
+.a3s-run-player-status.is-running {
+  color: #91d8ba;
+}
+
+.a3s-run-player-status.is-running > i {
+  animation: a3s-flow-running 900ms ease-in-out infinite alternate;
+}
+
+.a3s-run-player-task {
+  display: grid;
+  min-height: 76px;
+  padding: 13px 20px;
+  border-bottom: 1px solid #252c35;
+  background: rgba(13, 17, 23, 0.78);
+  align-items: center;
+  gap: 13px;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+}
+
+.a3s-run-player-task > span {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  border: 1px solid #34414e;
+  border-radius: 7px;
+  background: #10161d;
+  color: #62cda0;
+  place-items: center;
+  font-family: var(--a3s-mono);
+  font-size: 10px;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.025);
+}
+
+.a3s-run-player-task > div {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.a3s-run-player-task small,
+.a3s-run-player-stage-copy > span,
+.a3s-run-player-exchange small,
+.a3s-run-player-evidence small {
+  color: #5e6a78;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.a3s-run-player-task strong {
+  overflow: hidden;
+  color: #e4e9ef;
+  font-size: 13px;
+  font-weight: 560;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-run-player-task > code {
+  padding: 6px 8px;
+  border: 1px solid #2c3540;
+  border-radius: 4px;
+  background: #0d1218;
+  color: #718091;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+}
+
+.a3s-run-player-progress {
+  position: relative;
+  display: grid;
+  min-height: 92px;
+  padding: 15px 18px 13px;
+  border-bottom: 1px solid #252c35;
+  background: rgba(9, 12, 17, 0.76);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.a3s-run-player-rail {
+  position: absolute;
+  z-index: 0;
+  top: 28px;
+  right: 12.5%;
+  left: 12.5%;
+  height: 2px;
+  background: #28313b;
+  pointer-events: none;
+}
+
+.a3s-run-player-rail > span {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 2px;
+  max-width: 100%;
+  background: linear-gradient(90deg, #7563ce, #65a8d0 54%, #58b98f);
+  box-shadow: 0 0 8px rgba(92, 175, 147, 0.36);
+  transition: width 320ms ease;
+}
+
+.a3s-run-player-phase {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  min-width: 0;
+  padding: 0 5px;
+  border: 0;
+  background: transparent;
+  color: #657180;
+  cursor: pointer;
+  justify-items: center;
+  gap: 7px;
+  text-align: center;
+}
+
+.a3s-run-player-phase > span:first-child {
+  display: grid;
+  width: 27px;
+  height: 27px;
+  border: 1px solid #35404d;
+  border-radius: 50%;
+  background: #0c1117;
+  color: #647181;
+  place-items: center;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.a3s-run-player-phase > span:last-child {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.a3s-run-player-phase small {
+  color: #515e6d;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+  letter-spacing: 0.08em;
+}
+
+.a3s-run-player-phase strong {
+  overflow: hidden;
+  color: #8d99a8;
+  font-size: 10px;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.a3s-run-player-phase:hover > span:first-child {
+  border-color: #67788c;
+  color: #c2ccd8;
+}
+
+.a3s-run-player-phase.is-active > span:first-child {
+  border-color: #6fb8df;
+  background: #12202a;
+  color: #85d3f7;
+  box-shadow: 0 0 13px rgba(99, 183, 225, 0.34);
+}
+
+.a3s-run-player-phase.is-active small {
+  color: #6fb8df;
+}
+
+.a3s-run-player-phase.is-active strong {
+  color: #edf3f8;
+}
+
+.a3s-run-player-phase.is-complete > span:first-child {
+  border-color: #4c846e;
+  color: #65bd97;
+}
+
+.a3s-run-player-phase:focus-visible {
+  border-radius: 5px;
+  outline: 2px solid rgba(111, 184, 223, 0.48);
+  outline-offset: 2px;
+}
+
+.a3s-run-player-stage {
+  --player-accent: #7d83dc;
+  --player-tint: rgba(92, 88, 190, 0.08);
+
+  display: grid;
+  min-height: 282px;
+  padding: 22px 26px 18px;
+  background:
+    radial-gradient(circle at 86% 14%, var(--player-tint), transparent 42%),
+    rgba(10, 13, 18, 0.5);
+  align-content: start;
+  animation: a3s-run-player-stage-in 180ms ease-out;
+}
+
+.a3s-run-player-stage[data-phase='decide'] {
+  --player-accent: #6faee0;
+  --player-tint: rgba(67, 133, 184, 0.09);
+}
+
+.a3s-run-player-stage[data-phase='execute'] {
+  --player-accent: #d2a35d;
+  --player-tint: rgba(181, 123, 42, 0.09);
+}
+
+.a3s-run-player-stage[data-phase='record'] {
+  --player-accent: #60c697;
+  --player-tint: rgba(52, 155, 108, 0.09);
+}
+
+.a3s-run-player-stage-copy > span {
+  color: var(--player-accent);
+}
+
+.a3s-run-player-stage-copy h2 {
+  margin: 7px 0 6px;
+  color: #f0f3f7;
+  font-size: 21px;
+  font-weight: 630;
+  letter-spacing: -0.025em;
+}
+
+.a3s-run-player-stage-copy p {
+  max-width: 620px;
+  margin: 0;
+  color: #8f99a6;
+  font-size: 11px;
+  line-height: 1.62;
+}
+
+.a3s-run-player-exchange {
+  display: grid;
+  margin-top: 17px;
+  align-items: stretch;
+  gap: 9px;
+  grid-template-columns: minmax(0, 1fr) 20px minmax(0, 1fr);
+}
+
+.a3s-run-player-action,
+.a3s-run-player-result {
+  display: grid;
+  min-width: 0;
+  min-height: 68px;
+  padding: 11px 13px;
+  border-radius: 6px;
+  background: rgba(15, 20, 27, 0.78);
+  align-content: center;
+  gap: 7px;
+  box-shadow: inset 0 0 0 1px #29323d;
+}
+
+.a3s-run-player-result {
+  background:
+    linear-gradient(100deg, var(--player-tint), transparent 72%),
+    rgba(15, 20, 27, 0.82);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--player-accent) 34%, #29323d);
+}
+
+.a3s-run-player-action code {
+  color: #b9c4d0;
+  font-family: var(--a3s-mono);
+  font-size: 8px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.a3s-run-player-result strong {
+  color: #e7edf3;
+  font-size: 11px;
+  font-weight: 590;
+  line-height: 1.5;
+}
+
+.a3s-run-player-exchange > i {
+  position: relative;
+  width: 20px;
+}
+
+.a3s-run-player-exchange > i::before {
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  left: 2px;
+  height: 1px;
+  background: #3d4a58;
+  content: '';
+}
+
+.a3s-run-player-exchange > i::after {
+  position: absolute;
+  top: calc(50% - 3px);
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  border-top: 1px solid #718195;
+  border-right: 1px solid #718195;
+  content: '';
+  transform: rotate(45deg);
+}
+
+.a3s-run-player-stage-meta {
+  display: flex;
+  min-width: 0;
+  margin-top: 14px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.a3s-run-player-stage-meta > code,
+.a3s-run-player-stage-meta > span code {
+  padding: 4px 6px;
+  border: 1px solid #2d3742;
+  border-radius: 3px;
+  background: rgba(11, 15, 20, 0.72);
+  color: #697687;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+}
+
+.a3s-run-player-stage-meta > .a3s-run-player-command {
+  border-color: color-mix(in srgb, var(--player-accent) 38%, #2d3742);
+  color: var(--player-accent);
+}
+
+.a3s-run-player-event > i {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: #5dbb92;
+  box-shadow: 0 0 8px rgba(93, 187, 146, 0.52);
+}
+
+.a3s-run-player-stage-meta > span {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.a3s-run-player-evidence {
+  display: flex;
+  min-height: 70px;
+  padding: 12px 20px;
+  border-top: 1px solid #252c35;
+  background: rgba(8, 11, 15, 0.88);
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.a3s-run-player-evidence > div {
+  display: grid;
+  gap: 5px;
+}
+
+.a3s-run-player-evidence strong {
+  display: inline-flex;
+  color: #cbd5df;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--a3s-mono);
+  font-size: 9px;
+  font-weight: 560;
+}
+
+.a3s-run-player-evidence strong i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #5dc195;
+  box-shadow: 0 0 9px rgba(93, 193, 149, 0.52);
+}
+
+.a3s-run-player-evidence > span {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+.a3s-run-player-evidence > span code {
+  padding: 4px 6px;
+  border: 1px solid #303a45;
+  border-radius: 3px;
+  color: #718091;
+  font-family: var(--a3s-mono);
+  font-size: 7px;
+}
+
+@keyframes a3s-run-player-stage-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .a3s-feature-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-template-rows: none;
@@ -4705,6 +5178,110 @@ body {
     grid-template-columns: 68px minmax(0, 1fr);
   }
 
+  .a3s-run-player-header {
+    min-height: 52px;
+  }
+
+  .a3s-run-player-header > span em {
+    display: none;
+  }
+
+  .a3s-run-player-status {
+    display: none;
+  }
+
+  .a3s-run-player-task {
+    min-height: 72px;
+    padding: 12px 14px;
+    gap: 10px;
+    grid-template-columns: 31px minmax(0, 1fr);
+  }
+
+  .a3s-run-player-task > span {
+    width: 31px;
+    height: 31px;
+  }
+
+  .a3s-run-player-task strong {
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: normal;
+  }
+
+  .a3s-run-player-task > code {
+    display: none;
+  }
+
+  .a3s-run-player-progress {
+    min-height: 84px;
+    padding: 13px 5px 11px;
+  }
+
+  .a3s-run-player-rail {
+    top: 25px;
+  }
+
+  .a3s-run-player-phase {
+    padding: 0 2px;
+    gap: 6px;
+  }
+
+  .a3s-run-player-phase > span:first-child {
+    width: 25px;
+    height: 25px;
+  }
+
+  .a3s-run-player-phase small {
+    font-size: 6px;
+  }
+
+  .a3s-run-player-phase strong {
+    max-width: 74px;
+    font-size: 9px;
+  }
+
+  .a3s-run-player-stage {
+    min-height: 0;
+    padding: 20px 16px 18px;
+  }
+
+  .a3s-run-player-stage-copy h2 {
+    font-size: 19px;
+  }
+
+  .a3s-run-player-stage-copy p {
+    font-size: 10px;
+  }
+
+  .a3s-run-player-exchange {
+    gap: 8px;
+    grid-template-columns: 1fr;
+  }
+
+  .a3s-run-player-exchange > i {
+    display: none;
+  }
+
+  .a3s-run-player-action,
+  .a3s-run-player-result {
+    min-height: 62px;
+  }
+
+  .a3s-run-player-stage-meta > .a3s-run-player-event {
+    display: none;
+  }
+
+  .a3s-run-player-evidence {
+    padding: 13px 16px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .a3s-run-player-evidence > span {
+    justify-content: flex-start;
+  }
+
   .a3s-feature-grid {
     grid-template-columns: 1fr;
   }
@@ -4748,13 +5325,17 @@ body {
   .a3s-runtime-model-slab,
   .a3s-runtime-layer-control,
   .a3s-runtime-flow-step,
-  .a3s-runtime-flow-track > span {
+  .a3s-runtime-flow-track > span,
+  .a3s-run-player-phase > span:first-child,
+  .a3s-run-player-rail > span {
     transition: none;
   }
 
   .a3s-runtime-layer-detail--mobile,
   .a3s-runtime-flow-detail,
-  .a3s-runtime-inspector-header > div > button.is-playing > i {
+  .a3s-runtime-inspector-header > div > button.is-playing > i,
+  .a3s-run-player-stage,
+  .a3s-run-player-status.is-running > i {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- replace the dense two-column runtime inspector with a focused run replay
- group six internal operations into four product-facing phases: prepare, decide, execute, and record
- make task, action, result, and saved evidence readable at a glance
- default to the completed outcome and retain click, keyboard, and replay interactions
- add responsive layouts for desktop, tablet, and mobile

## Verification
- npm run lint
- zh/en language parity: 59 pages each
- Playwright interaction checks across 1440, 1180, 1024, 768, and 390px viewports
- no horizontal or vertical overflow in the player
- replay verified through all four phases