### PR TITLE
fix(website): complete the TUI prompt after input

### DIFF
--- a/website/theme/components/HomeLayout.tsx
+++ b/website/theme/components/HomeLayout.tsx
@@ -1084,7 +1084,10 @@ function RuntimeExecutionFlow({
           <div>
             <small>{labels.flowTaskLabel}</small>
             <p>
-              {labels.flowTask.slice(0, typedCount)}
+              {labels.flowTask.slice(
+                0,
+                activeIndex === 0 ? typedCount : labels.flowTask.length,
+              )}
               <i aria-hidden="true" />
             </p>
           </div>


### PR DESCRIPTION
## Summary
- always show the full submitted task after the input phase
- prevent background-tab timer throttling from leaving the final artifact state with a partial prompt

## Validation
- npm run lint
- production browser test reproduced the throttled-timer case