### PR TITLE
feat(tools): add context-efficient repository operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-07-28
+
+### Added
+
+- Added budget-bounded `read.files` calls for 1-32 text files with ordered
+  per-file results, isolated member failures, and lossless continuation
+  arguments that are included in the response budget.
+- Added `grep` output modes for content, paginated matching paths, paginated
+  per-file matching-line counts, and full-scan summaries without rendering
+  discarded match text.
+- Added read-only `edit` dry runs plus exact and maximum replacement-count
+  guards so mechanical edits can be previewed and bounded before CAS writes.
+
+### Changed
+
+- Added explicit `glob` ordering: `sort: "path"` provides deterministic lexical
+  order before cursor pagination, while the compatible `sort: "backend"`
+  default retains backend relevance or recency order.
+- Added explicit README attribution for the FastCtx repository-tool ergonomics
+  that informed these context-efficiency improvements.
+
 ## [6.4.3] - 2026-07-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.4.3"
+version = "6.5.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ the model.
 
 | Concern | Built-in surface |
 | --- | --- |
-| Files and directories | `read`, `write`, `edit`, `patch`, `ls`, `glob`, `grep` with ranged or resumable operations and compare-and-swap mutation |
+| Files and directories | Budgeted single/multi-file `read`, `write`, previewable CAS `edit`, `patch`, `ls`, order-selectable paginated `glob`, and mode-selectable `grep` |
 | Commands and source control | Bounded `bash` plus typed `git` operations, cancellation, and Unix process-group termination |
 | Code intelligence | `code_symbols`, `code_navigation`, and `code_diagnostics`; source reading and mutation remain in file tools |
 | Web evidence | Multi-engine `web_search` and bounded `web_fetch` with structured failures, fallback, source normalization, and SSRF protections |
@@ -218,6 +218,51 @@ Every invocation declares `ToolCapabilities`, including read-only,
 idempotent, resumable, cancellation-safe, paginated, output-kind, and parallel
 limits. `batch` parallelizes only calls that declare safe read-only behavior;
 mutations and unknown tools are serialized.
+
+### Context-efficient repository tools
+
+`read` can pack 1-32 known text files into one ordered response. The shared
+budget includes headers and the continuation itself, so the result reaches the
+model intact instead of relying on downstream truncation:
+
+```json
+{
+  "files": [
+    { "path": "src/lib.rs" },
+    { "path": "src/config.rs", "offset": 40, "limit": 80 }
+  ],
+  "max_output_bytes": 65536
+}
+```
+
+If the budget fills, copy `metadata.batch.continuation` back into `files`.
+Offsets and remaining per-file limits are advanced without repeating completed
+lines. One missing or unreadable member is reported in its own segment while
+the other files continue.
+
+`grep.output_mode` controls how much evidence enters the context:
+
+| Mode | Result |
+| --- | --- |
+| `content` | Matching lines with optional context (default) |
+| `files_with_matches` | Lexically cursor-paginated matching paths only |
+| `count` | Lexically cursor-paginated matching-line counts per file |
+| `summary` | Full-scan line and file totals without rendered matches |
+
+The non-content modes ask built-in workspace backends to count matches without
+constructing discarded match text. `glob` retains a backend's recency or
+relevance order by default; request `sort: "path"` when cursor pages require
+stable lexical ordering.
+
+Use `edit` with `dry_run: true` to receive the exact before/after diff without
+writing. The dry run is declared read-only and can be safely batched. Apply the
+result with `expected_replacements` and optionally `max_replacements` to reject
+stale or unexpectedly broad changes before the compare-and-swap write.
+
+These repository-context ergonomics were informed by
+[FastCtx](https://github.com/yc-duan/fastctx). Their implementation here stays
+inside A3S Code's workspace abstractions, capability declarations, permission
+path, remote-backend contracts, and structured metadata.
 
 ### Sandbox and credential boundaries
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "6.4.3"
+version = "6.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/mcp/transport/stdio.rs
+++ b/core/src/mcp/transport/stdio.rs
@@ -445,7 +445,7 @@ mod tests {
     ) -> StdioTransport {
         let args = vec![
             "-c".to_string(),
-            "touch \"$1\"; (sleep 0.30; touch \"$2\") & wait".to_string(),
+            "(sleep 0.30; : > \"$2\") & : > \"$1\"; wait".to_string(),
             "mcp-process-tree-test".to_string(),
             started.to_string_lossy().into_owned(),
             leaked.to_string_lossy().into_owned(),

--- a/core/src/tools/builtin/edit.rs
+++ b/core/src/tools/builtin/edit.rs
@@ -37,6 +37,20 @@ impl Tool for EditTool {
                 "replace_all": {
                     "type": "boolean",
                     "description": "Optional. Replace all occurrences. Default: false."
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Optional. Preview the exact diff and replacement count without writing. Default: false."
+                },
+                "max_replacements": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional safety ceiling. Reject the edit before writing when it would replace more occurrences."
+                },
+                "expected_replacements": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional compare guard. Reject the edit before writing unless the observed replacement count is exactly this value."
                 }
             },
             "required": ["file_path", "old_string", "new_string"],
@@ -50,14 +64,24 @@ impl Tool for EditTool {
                     "file_path": "src/lib.rs",
                     "old_string": "foo",
                     "new_string": "bar",
-                    "replace_all": true
+                    "replace_all": true,
+                    "dry_run": true,
+                    "max_replacements": 20
                 }
             ]
         })
     }
 
-    fn capabilities(&self, _args: &serde_json::Value) -> crate::tools::ToolCapabilities {
-        let mut capabilities = crate::tools::ToolCapabilities::conservative();
+    fn capabilities(&self, args: &serde_json::Value) -> crate::tools::ToolCapabilities {
+        let mut capabilities = if args
+            .get("dry_run")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            crate::tools::ToolCapabilities::parallel_safe_read(16)
+        } else {
+            crate::tools::ToolCapabilities::conservative()
+        };
         capabilities.output_kind = crate::tools::ToolOutputKind::Diff;
         capabilities
     }
@@ -77,11 +101,26 @@ impl Tool for EditTool {
             Some(s) => s,
             None => return Ok(ToolOutput::error("new_string parameter is required")),
         };
+        if old_string.is_empty() {
+            return Ok(ToolOutput::error("old_string must not be empty"));
+        }
 
         let replace_all = args
             .get("replace_all")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let dry_run = args
+            .get("dry_run")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let max_replacements = match positive_usize_arg(args, "max_replacements") {
+            Ok(value) => value,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let expected_replacements = match positive_usize_arg(args, "expected_replacements") {
+            Ok(value) => value,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
 
         let workspace_path = match ctx.resolve_workspace_path(file_path) {
             Ok(path) => path,
@@ -116,31 +155,68 @@ impl Tool for EditTool {
             )));
         }
 
+        let replacement_count = if replace_all { count } else { 1 };
+        if let Some(expected) = expected_replacements {
+            if replacement_count != expected {
+                return Ok(ToolOutput::error(format!(
+                    "Replacement count mismatch in {display_path}: expected {expected} replacement(s), found {replacement_count}. Re-run dry_run to inspect the current file."
+                ))
+                .with_metadata(serde_json::json!({
+                    "file_path": file_path,
+                    "dry_run": dry_run,
+                    "expected_replacements": expected,
+                    "replacement_count": replacement_count,
+                })));
+            }
+        }
+        if let Some(maximum) = max_replacements {
+            if replacement_count > maximum {
+                return Ok(ToolOutput::error(format!(
+                    "Edit would replace {replacement_count} occurrence(s) in {display_path}, which exceeds max_replacements={maximum}."
+                ))
+                .with_metadata(serde_json::json!({
+                    "file_path": file_path,
+                    "dry_run": dry_run,
+                    "max_replacements": maximum,
+                    "replacement_count": replacement_count,
+                })));
+            }
+        }
+
         let new_content = if replace_all {
             content.replace(old_string, new_string)
         } else {
             content.replacen(old_string, new_string, 1)
         };
 
+        let change_metadata = || {
+            serde_json::json!({
+                "file_path": file_path,
+                "before": content,
+                "after": new_content,
+                "dry_run": dry_run,
+                "replacement_count": replacement_count,
+                "expected_replacements": expected_replacements,
+                "max_replacements": max_replacements,
+            })
+        };
+        if dry_run {
+            return Ok(ToolOutput::success(format!(
+                "Dry run: would replace {replacement_count} occurrence(s) in {display_path}; nothing was written"
+            ))
+            .with_metadata(change_metadata()));
+        }
+
         match ctx
             .workspace_services
             .write_for_edit(&workspace_path, &new_content, version.as_deref())
             .await
         {
-            Ok(_) => {
-                // Attach diff metadata so frontend can show Monaco diff
-                let mut metadata = serde_json::Map::new();
-                metadata.insert("file_path".to_string(), serde_json::json!(file_path));
-                metadata.insert("before".to_string(), serde_json::json!(content));
-                metadata.insert("after".to_string(), serde_json::json!(new_content));
-
-                Ok(ToolOutput::success(format!(
-                    "Replaced {} occurrence(s) in {}",
-                    if replace_all { count } else { 1 },
-                    display_path
-                ))
-                .with_metadata(serde_json::Value::Object(metadata)))
-            }
+            Ok(_) => Ok(ToolOutput::success(format!(
+                "Replaced {} occurrence(s) in {}",
+                replacement_count, display_path
+            ))
+            .with_metadata(change_metadata())),
             Err(e) => {
                 // Surface the typed kind via ToolOutput.error_kind so SDK
                 // callers can react programmatically; the human-readable
@@ -161,6 +237,21 @@ impl Tool for EditTool {
                 })
             }
         }
+    }
+}
+
+fn positive_usize_arg(
+    args: &serde_json::Value,
+    name: &str,
+) -> std::result::Result<Option<usize>, String> {
+    match args.get(name) {
+        Some(value) => value
+            .as_u64()
+            .and_then(|value| usize::try_from(value).ok())
+            .filter(|value| *value > 0)
+            .map(Some)
+            .ok_or_else(|| format!("{name} must be a positive integer")),
+        None => Ok(None),
     }
 }
 
@@ -217,6 +308,95 @@ mod tests {
         assert!(result.success);
         let content = std::fs::read_to_string(temp.path().join("test.txt")).unwrap();
         assert_eq!(content, "ccc bbb ccc");
+    }
+
+    #[tokio::test]
+    async fn test_edit_dry_run_returns_diff_without_writing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("test.txt");
+        std::fs::write(&path, "alpha alpha").unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let result = EditTool
+            .execute(
+                &serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "alpha",
+                    "new_string": "beta",
+                    "replace_all": true,
+                    "dry_run": true
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.content);
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "alpha alpha");
+        let metadata = result.metadata.unwrap();
+        assert_eq!(metadata["dry_run"], true);
+        assert_eq!(metadata["replacement_count"], 2);
+        assert_eq!(metadata["before"], "alpha alpha");
+        assert_eq!(metadata["after"], "beta beta");
+        assert!(
+            EditTool
+                .capabilities(&serde_json::json!({"dry_run": true}))
+                .read_only
+        );
+    }
+
+    #[tokio::test]
+    async fn test_edit_expected_replacements_mismatch_does_not_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("test.txt");
+        std::fs::write(&path, "alpha alpha").unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let result = EditTool
+            .execute(
+                &serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "alpha",
+                    "new_string": "beta",
+                    "replace_all": true,
+                    "expected_replacements": 3
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .content
+            .contains("expected 3 replacement(s), found 2"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "alpha alpha");
+    }
+
+    #[tokio::test]
+    async fn test_edit_max_replacements_blocks_oversized_change() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("test.txt");
+        std::fs::write(&path, "alpha alpha alpha").unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let result = EditTool
+            .execute(
+                &serde_json::json!({
+                    "file_path": "test.txt",
+                    "old_string": "alpha",
+                    "new_string": "beta",
+                    "replace_all": true,
+                    "max_replacements": 2
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.content.contains("exceeds max_replacements=2"));
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "alpha alpha alpha");
     }
 
     #[tokio::test]
@@ -279,6 +459,15 @@ mod tests {
         let examples = params["examples"].as_array().unwrap();
         assert_eq!(examples[0]["file_path"], "src/lib.rs");
         assert!(examples[0].get("path").is_none());
+        assert_eq!(params["properties"]["dry_run"]["type"], "boolean");
+        assert_eq!(
+            params["properties"]["max_replacements"]["minimum"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            params["properties"]["expected_replacements"]["minimum"],
+            serde_json::json!(1)
+        );
     }
 
     #[tokio::test]

--- a/core/src/tools/builtin/glob_tool.rs
+++ b/core/src/tools/builtin/glob_tool.rs
@@ -40,6 +40,11 @@ impl Tool for GlobTool {
                 "cursor": {
                     "type": "string",
                     "description": "Optional. Omit on the first call. On a continuation, copy the exact opaque cursor returned by the previous glob call; never invent a placeholder."
+                },
+                "sort": {
+                    "type": "string",
+                    "enum": ["path", "backend"],
+                    "description": "Optional. 'backend' (default) preserves backend relevance or recency order. 'path' applies deterministic lexical ordering before pagination."
                 }
             },
             "required": ["pattern"],
@@ -49,7 +54,8 @@ impl Tool for GlobTool {
                 },
                 {
                     "pattern": "*.md",
-                    "path": "docs"
+                    "path": "docs",
+                    "sort": "path"
                 }
             ]
         })
@@ -67,6 +73,14 @@ impl Tool for GlobTool {
         let page_request = match PageRequest::parse(args, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT) {
             Ok(request) => request,
             Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let sort = match args
+            .get("sort")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("backend")
+        {
+            value @ ("path" | "backend") => value,
+            _ => return Ok(ToolOutput::error("sort must be 'path' or 'backend'")),
         };
 
         let path_str = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
@@ -98,11 +112,14 @@ impl Tool for GlobTool {
                 )))
             }
         };
-        let matches: Vec<String> = result
+        let mut matches: Vec<String> = result
             .matches
             .into_iter()
             .map(|path| path.as_str().to_string())
             .collect();
+        if sort == "path" {
+            matches.sort();
+        }
         let page = match page_request.page(matches) {
             Ok(page) => page,
             Err(error) => return Ok(ToolOutput::error(error)),
@@ -125,8 +142,12 @@ impl Tool for GlobTool {
                     "\nMore files available; continue with cursor={cursor}"
                 ));
             }
-            Ok(ToolOutput::success(output)
-                .with_metadata(serde_json::json!({ "page": page.metadata() })))
+            Ok(
+                ToolOutput::success(output).with_metadata(serde_json::json!({
+                    "page": page.metadata(),
+                    "sort": sort,
+                })),
+            )
         }
     }
 }
@@ -134,7 +155,40 @@ impl Tool for GlobTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workspace::{
+        LocalWorkspaceBackend, WorkspaceFileSystem, WorkspaceGlobResult, WorkspaceGrepRequest,
+        WorkspaceGrepResult, WorkspaceRef, WorkspaceSearch, WorkspaceServices,
+    };
+    use async_trait::async_trait;
     use std::path::PathBuf;
+    use std::sync::Arc;
+
+    struct UnsortedSearch;
+
+    #[async_trait]
+    impl WorkspaceSearch for UnsortedSearch {
+        async fn glob(&self, _request: WorkspaceGlobRequest) -> Result<WorkspaceGlobResult> {
+            Ok(WorkspaceGlobResult {
+                matches: ["c.rs", "a.rs", "b.rs"]
+                    .into_iter()
+                    .map(crate::workspace::WorkspacePath::from_normalized)
+                    .collect(),
+            })
+        }
+
+        async fn grep(&self, _request: WorkspaceGrepRequest) -> Result<WorkspaceGrepResult> {
+            unreachable!("glob test backend does not implement grep")
+        }
+    }
+
+    fn unsorted_context(root: &std::path::Path) -> ToolContext {
+        let local = Arc::new(LocalWorkspaceBackend::new(root.to_path_buf()));
+        let fs: Arc<dyn WorkspaceFileSystem> = local;
+        let services = WorkspaceServices::builder(WorkspaceRef::new("test", "test://glob"), fs)
+            .search(Arc::new(UnsortedSearch))
+            .build();
+        ToolContext::new(root.to_path_buf()).with_workspace_services(services)
+    }
 
     #[tokio::test]
     async fn test_glob_find_files() {
@@ -226,6 +280,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_glob_supports_explicit_stable_path_sorting() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = unsorted_context(temp.path());
+
+        let first = GlobTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "*.rs",
+                    "limit": 2,
+                    "sort": "path"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.content);
+        assert!(first.content.find("a.rs") < first.content.find("b.rs"));
+        assert!(!first.content.contains("c.rs"));
+
+        let default_backend_order = GlobTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "*.rs",
+                    "limit": 2
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(
+            default_backend_order.success,
+            "{}",
+            default_backend_order.content
+        );
+        assert!(
+            default_backend_order.content.find("c.rs") < default_backend_order.content.find("a.rs")
+        );
+        assert!(!default_backend_order.content.contains("b.rs"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_rejects_unknown_sort_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = GlobTool
+            .execute(
+                &serde_json::json!({"pattern": "*.rs", "sort": "newest"}),
+                &ToolContext::new(temp.path().to_path_buf()),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.content.contains("sort must be 'path' or 'backend'"));
+    }
+
+    #[tokio::test]
     async fn test_glob_missing_pattern() {
         let tool = GlobTool;
         let ctx = ToolContext::new(PathBuf::from("/tmp"));
@@ -243,5 +352,9 @@ mod tests {
         let examples = params["examples"].as_array().unwrap();
         assert_eq!(examples[0]["pattern"], "**/*.rs");
         assert!(examples[0].get("glob").is_none());
+        assert_eq!(
+            params["properties"]["sort"]["enum"],
+            serde_json::json!(["path", "backend"])
+        );
     }
 }

--- a/core/src/tools/builtin/grep.rs
+++ b/core/src/tools/builtin/grep.rs
@@ -1,15 +1,57 @@
 //! Grep tool - Search file contents with regex
 
+use crate::tools::pagination::{PageRequest, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
 use crate::tools::types::{Tool, ToolContext, ToolOutput};
 use crate::tools::MAX_OUTPUT_SIZE;
 use crate::workspace::{WorkspaceGrepRequest, WorkspaceGrepResult, WorkspacePath};
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 
 const MAX_GREP_SOURCE_ANCHORS: usize = 64;
 const MAX_GREP_FALLBACK_CANDIDATES: usize = MAX_GREP_SOURCE_ANCHORS * 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GrepOutputMode {
+    Content,
+    FilesWithMatches,
+    Count,
+    Summary,
+}
+
+impl GrepOutputMode {
+    fn parse(args: &serde_json::Value) -> std::result::Result<Self, String> {
+        match args
+            .get("output_mode")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("content")
+        {
+            "content" => Ok(Self::Content),
+            "files_with_matches" => Ok(Self::FilesWithMatches),
+            "count" => Ok(Self::Count),
+            "summary" => Ok(Self::Summary),
+            _ => Err(
+                "output_mode must be 'content', 'files_with_matches', 'count', or 'summary'"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Content => "content",
+            Self::FilesWithMatches => "files_with_matches",
+            Self::Count => "count",
+            Self::Summary => "summary",
+        }
+    }
+
+    fn paginated(self) -> bool {
+        matches!(self, Self::FilesWithMatches | Self::Count)
+    }
+}
 
 pub struct GrepTool;
 
@@ -20,7 +62,7 @@ impl Tool for GrepTool {
     }
 
     fn description(&self) -> &str {
-        "Search for a pattern in files using ripgrep. Returns matching lines with file paths and line numbers."
+        "Search file contents with regex. Return matching content, a paginated file list, per-file matching-line counts, or a compact full-scan summary."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -47,6 +89,21 @@ impl Tool for GrepTool {
                 "-i": {
                     "type": "boolean",
                     "description": "Optional. Case insensitive search."
+                },
+                "output_mode": {
+                    "type": "string",
+                    "enum": ["content", "files_with_matches", "count", "summary"],
+                    "description": "Optional. content returns matching lines (default); files_with_matches returns lexically paginated paths; count returns lexically paginated matching-line counts per file; summary returns only full-scan totals."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_PAGE_LIMIT,
+                    "description": "Optional for files_with_matches/count. Maximum files to return. Default: 200; maximum: 1000."
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Optional for files_with_matches/count. Copy the exact cursor from the previous result."
                 }
             },
             "required": ["pattern"],
@@ -58,20 +115,47 @@ impl Tool for GrepTool {
                     "pattern": "fn main",
                     "path": "src",
                     "glob": "*.rs",
-                    "context": 2
+                    "context": 2,
+                    "output_mode": "content"
+                },
+                {
+                    "pattern": "TODO",
+                    "output_mode": "files_with_matches",
+                    "limit": 100
                 }
             ]
         })
     }
 
-    fn capabilities(&self, _args: &serde_json::Value) -> crate::tools::ToolCapabilities {
-        crate::tools::ToolCapabilities::parallel_safe_read(16)
+    fn capabilities(&self, args: &serde_json::Value) -> crate::tools::ToolCapabilities {
+        if GrepOutputMode::parse(args).is_ok_and(GrepOutputMode::paginated) {
+            crate::tools::ToolCapabilities::read_only_paginated(16)
+        } else {
+            crate::tools::ToolCapabilities::parallel_safe_read(16)
+        }
     }
 
     async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext) -> Result<ToolOutput> {
         let pattern_str = match args.get("pattern").and_then(|v| v.as_str()) {
             Some(p) => p,
             None => return Ok(ToolOutput::error("pattern parameter is required")),
+        };
+        let output_mode = match GrepOutputMode::parse(args) {
+            Ok(mode) => mode,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let page_request = if output_mode.paginated() {
+            match PageRequest::parse(args, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT) {
+                Ok(request) => Some(request),
+                Err(error) => return Ok(ToolOutput::error(error)),
+            }
+        } else {
+            if args.get("limit").is_some() || args.get("cursor").is_some() {
+                return Ok(ToolOutput::error(
+                    "limit and cursor are supported only with output_mode='files_with_matches' or 'count'",
+                ));
+            }
+            None
         };
 
         let case_insensitive = args.get("-i").and_then(|v| v.as_bool()).unwrap_or(false);
@@ -112,7 +196,13 @@ impl Tool for GrepTool {
             glob: glob_filter.map(str::to_string),
             context_lines,
             case_insensitive,
-            max_output_size: MAX_OUTPUT_SIZE,
+            // Metadata-only modes ask built-in backends to count all matches
+            // without constructing content that the caller does not want.
+            max_output_size: if output_mode == GrepOutputMode::Content {
+                MAX_OUTPUT_SIZE
+            } else {
+                0
+            },
         };
         let anchor_request = request.clone();
         let outcome = match ctx
@@ -127,15 +217,60 @@ impl Tool for GrepTool {
             Err(e) => return Ok(ToolOutput::error(format!("Grep search failed: {}", e))),
         };
 
+        let result = outcome.result;
+        let matched_paths = outcome.matched_paths;
+
+        if output_mode == GrepOutputMode::Summary {
+            let mut content = format!(
+                "{} matching line(s) in {} file(s)",
+                result.match_count, result.file_count
+            );
+            if result.truncated {
+                content.push_str(" (scan truncated by backend limits)");
+            }
+            return Ok(
+                ToolOutput::success(content).with_metadata(serde_json::json!({
+                    "output_mode": output_mode.as_str(),
+                    "search": grep_search_metadata(&result),
+                })),
+            );
+        }
+
+        if output_mode.paginated() {
+            let Some(page_request) = page_request else {
+                return Ok(ToolOutput::error(
+                    "Unable to construct the requested grep page",
+                ));
+            };
+            let Some(matched_paths) = matched_paths else {
+                return Ok(ToolOutput::error(format!(
+                    "output_mode='{}' requires structured match paths from the workspace backend; use output_mode='content' with this backend",
+                    output_mode.as_str()
+                ))
+                .with_metadata(serde_json::json!({
+                    "output_mode": output_mode.as_str(),
+                    "search": grep_search_metadata(&result),
+                })));
+            };
+            return render_paginated_grep(
+                output_mode,
+                page_request,
+                matched_paths,
+                result,
+                &regex,
+                ctx,
+            )
+            .await;
+        }
+
         let source_anchors = grep_source_anchors(
-            &outcome.result,
-            outcome.matched_paths.as_deref(),
+            &result,
+            matched_paths.as_deref(),
             &anchor_request,
             &regex,
             ctx,
         )
         .await;
-        let result = outcome.result;
         let content = if result.match_count == 0 {
             format!("No matches found for pattern: {}", pattern_str)
         } else if result.truncated {
@@ -158,6 +293,120 @@ impl Tool for GrepTool {
             })))
         }
     }
+}
+
+async fn render_paginated_grep(
+    output_mode: GrepOutputMode,
+    page_request: PageRequest,
+    matched_paths: Vec<WorkspacePath>,
+    result: WorkspaceGrepResult,
+    regex: &Regex,
+    ctx: &ToolContext,
+) -> Result<ToolOutput> {
+    let mut seen = HashSet::new();
+    let mut paths = matched_paths
+        .into_iter()
+        .filter_map(|path| ctx.resolve_workspace_path(path.as_str()).ok())
+        .filter(|path| !path.is_root() && seen.insert(path.as_str().to_string()))
+        .collect::<Vec<_>>();
+    paths.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+    let page = match page_request.page(paths) {
+        Ok(page) => page,
+        Err(error) => return Ok(ToolOutput::error(error)),
+    };
+    let page_metadata = page.metadata();
+    let next_cursor = page.next_cursor.clone();
+    let total_items = page.total_items;
+    let source_anchors = page
+        .items
+        .iter()
+        .map(|path| path.as_str().to_string())
+        .collect::<Vec<_>>();
+
+    let (mut content, failed_reads) = match output_mode {
+        GrepOutputMode::FilesWithMatches => (source_anchors.join("\n"), 0usize),
+        GrepOutputMode::Count => count_matching_lines(page.items, regex, ctx).await,
+        GrepOutputMode::Content | GrepOutputMode::Summary => {
+            return Ok(ToolOutput::error(
+                "Only files_with_matches and count support grep pagination",
+            ));
+        }
+    };
+    if content.is_empty() {
+        content = "No matches found".to_string();
+    } else {
+        content.push_str(&format!(
+            "\n\n{} of {total_items} matching file(s) shown",
+            source_anchors.len()
+        ));
+        if let Some(cursor) = next_cursor {
+            content.push_str(&format!(
+                "\nMore files available; continue with cursor={cursor}"
+            ));
+        }
+    }
+    if result.truncated {
+        content.push_str(
+            "\nWarning: the workspace backend reached its scan limit; totals and paths may be incomplete.",
+        );
+    }
+
+    Ok(
+        ToolOutput::success(content).with_metadata(serde_json::json!({
+            "output_mode": output_mode.as_str(),
+            "sort": "path",
+            "source_anchors": source_anchors,
+            "page": page_metadata,
+            "search": grep_search_metadata(&result),
+            "failed_reads": failed_reads,
+        })),
+    )
+}
+
+async fn count_matching_lines(
+    paths: Vec<WorkspacePath>,
+    regex: &Regex,
+    ctx: &ToolContext,
+) -> (String, usize) {
+    let calls = paths.into_iter().map(|path| {
+        let services = ctx.workspace_services.clone();
+        let fs = services.fs();
+        let regex = regex.clone();
+        async move {
+            let read_path = path.clone();
+            let result = services
+                .run_with_timeout(
+                    "grep count read",
+                    async move { fs.read_text(&read_path).await },
+                )
+                .await;
+            (path, result, regex)
+        }
+    });
+    let results = stream::iter(calls).buffered(16).collect::<Vec<_>>().await;
+    let mut rows = Vec::with_capacity(results.len());
+    let mut failed_reads = 0usize;
+    for (path, content, regex) in results {
+        match content {
+            Ok(content) => {
+                let count = content.lines().filter(|line| regex.is_match(line)).count();
+                rows.push(format!("{}: {count} matching line(s)", path.as_str()));
+            }
+            Err(error) => {
+                failed_reads += 1;
+                rows.push(format!("{}: unable to recount ({error})", path.as_str()));
+            }
+        }
+    }
+    (rows.join("\n"), failed_reads)
+}
+
+fn grep_search_metadata(result: &WorkspaceGrepResult) -> serde_json::Value {
+    serde_json::json!({
+        "matching_lines": result.match_count,
+        "matching_files": result.file_count,
+        "truncated": result.truncated,
+    })
 }
 
 async fn grep_source_anchors(
@@ -359,6 +608,133 @@ mod tests {
         assert!(result.content.contains("2 match(es)"));
     }
 
+    #[tokio::test]
+    async fn test_grep_files_mode_is_paginated_without_rendering_matches() {
+        let temp = tempfile::tempdir().unwrap();
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            std::fs::write(temp.path().join(name), format!("needle in {name}")).unwrap();
+        }
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let first = GrepTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "needle",
+                    "output_mode": "files_with_matches",
+                    "limit": 2
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(first.success, "{}", first.content);
+        assert!(!first.content.contains("needle in"));
+        let page = &first.metadata.as_ref().unwrap()["page"];
+        assert_eq!(page["returned_items"], 2);
+        assert_eq!(page["total_items"], 3);
+        assert_eq!(page["next_cursor"], "2");
+
+        let second = GrepTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "needle",
+                    "output_mode": "files_with_matches",
+                    "limit": 2,
+                    "cursor": "2"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(second.success, "{}", second.content);
+        assert_eq!(second.metadata.unwrap()["page"]["returned_items"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_grep_paginated_modes_sort_paths_before_applying_cursor() {
+        let temp = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+        let result = render_paginated_grep(
+            GrepOutputMode::FilesWithMatches,
+            PageRequest {
+                offset: 0,
+                requested_limit: 2,
+                limit: 2,
+            },
+            ["c.txt", "a.txt", "b.txt"]
+                .into_iter()
+                .map(WorkspacePath::from_normalized)
+                .collect(),
+            WorkspaceGrepResult {
+                output: String::new(),
+                match_count: 3,
+                file_count: 3,
+                truncated: false,
+            },
+            &Regex::new("needle").unwrap(),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.success, "{}", result.content);
+        assert_eq!(
+            result.metadata.unwrap()["source_anchors"],
+            serde_json::json!(["a.txt", "b.txt"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grep_count_mode_reports_matching_lines_per_file() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("a.txt"), "needle\nnone\nneedle\n").unwrap();
+        std::fs::write(temp.path().join("b.txt"), "needle\n").unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let result = GrepTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "needle",
+                    "output_mode": "count"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.contains("a.txt: 2 matching line(s)"));
+        assert!(result.content.contains("b.txt: 1 matching line(s)"));
+        assert!(!result.content.contains(">a.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_grep_summary_counts_full_scan_without_rendering_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let content = (0..80)
+            .map(|index| format!("needle-{index}-{}", "x".repeat(2_000)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(temp.path().join("large.txt"), content).unwrap();
+        let ctx = ToolContext::new(temp.path().to_path_buf());
+
+        let result = GrepTool
+            .execute(
+                &serde_json::json!({
+                    "pattern": "needle",
+                    "output_mode": "summary"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.contains("80 matching line(s) in 1 file(s)"));
+        assert!(!result.content.contains("needle-0"));
+        assert_eq!(result.metadata.unwrap()["search"]["truncated"], false);
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn test_grep_source_anchor_preserves_newline_filename_without_injection() {
@@ -466,5 +842,9 @@ mod tests {
         let examples = params["examples"].as_array().unwrap();
         assert_eq!(examples[0]["pattern"], "TODO");
         assert!(examples[0].get("query").is_none());
+        assert_eq!(
+            params["properties"]["output_mode"]["enum"],
+            serde_json::json!(["content", "files_with_matches", "count", "summary"])
+        );
     }
 }

--- a/core/src/tools/builtin/read.rs
+++ b/core/src/tools/builtin/read.rs
@@ -2,10 +2,32 @@
 
 use crate::text::truncate_utf8;
 use crate::tools::types::{Tool, ToolContext, ToolOutput};
-use crate::tools::{MAX_LINE_LENGTH, MAX_READ_LINES};
-use crate::workspace::WorkspaceTextRange;
+use crate::tools::{MAX_LINE_LENGTH, MAX_OUTPUT_SIZE, MAX_READ_LINES};
+use crate::workspace::{escape_control_chars_for_display, WorkspaceTextRange};
 use anyhow::Result;
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+const MAX_BATCH_READ_FILES: usize = 32;
+const MIN_BATCH_READ_OUTPUT_BYTES: usize = 1_024;
+const DEFAULT_BATCH_READ_OUTPUT_BYTES: usize = 64 * 1_024;
+const MAX_BATCH_READ_OUTPUT_BYTES: usize = MAX_OUTPUT_SIZE - (4 * 1_024);
+const MAX_BATCH_READ_PATH_BYTES: usize = 4 * 1_024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct BatchReadEntry {
+    path: String,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    offset: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    limit: Option<usize>,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
+}
 
 pub struct ReadTool;
 
@@ -16,7 +38,7 @@ impl Tool for ReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read the contents of a file. Returns line-numbered output. Supports text files and images. Large outputs are capped; use offset/limit for long files."
+        "Read one text or image file, or pack 1-32 text files into one bounded response. Returns line-numbered text and exact continuation arguments when more content remains."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -26,7 +48,7 @@ impl Tool for ReadTool {
             "properties": {
                 "file_path": {
                     "type": "string",
-                    "description": "Required. Path to the file to read, absolute or relative to the workspace. Always provide this exact field name: 'file_path'."
+                    "description": "Path to one file, absolute or relative to the workspace. Use exactly one of file_path or files."
                 },
                 "offset": {
                     "type": "integer",
@@ -38,9 +60,48 @@ impl Tool for ReadTool {
                     "minimum": 1,
                     "maximum": MAX_READ_LINES,
                     "description": "Optional. Maximum number of lines to read. Default and maximum: 2000."
+                },
+                "files": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": MAX_BATCH_READ_FILES,
+                    "description": "Read several independent text ranges in request order under one shared output budget. A failed member is reported in its own segment without discarding successful members.",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "path": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": MAX_BATCH_READ_PATH_BYTES,
+                                "description": "Path to a text file, absolute or relative to the workspace."
+                            },
+                            "offset": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "description": "Optional 0-based starting line. Default: 0."
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": MAX_READ_LINES,
+                                "description": "Optional maximum lines for this file. Default and maximum: 2000."
+                            }
+                        },
+                        "required": ["path"]
+                    }
+                },
+                "max_output_bytes": {
+                    "type": "integer",
+                    "minimum": MIN_BATCH_READ_OUTPUT_BYTES,
+                    "maximum": MAX_BATCH_READ_OUTPUT_BYTES,
+                    "description": "Optional shared byte budget for a files read. Default: 65536; maximum: 98304. The returned continuation is included inside this budget."
                 }
             },
-            "required": ["file_path"],
+            "oneOf": [
+                {"required": ["file_path"]},
+                {"required": ["files"]}
+            ],
             "examples": [
                 {
                     "file_path": "src/main.rs"
@@ -49,6 +110,12 @@ impl Tool for ReadTool {
                     "file_path": "src/main.rs",
                     "offset": 40,
                     "limit": 80
+                },
+                {
+                    "files": [
+                        {"path": "src/lib.rs"},
+                        {"path": "src/config.rs", "offset": 20, "limit": 60}
+                    ]
                 }
             ]
         })
@@ -59,6 +126,15 @@ impl Tool for ReadTool {
     }
 
     async fn execute(&self, args: &serde_json::Value, ctx: &ToolContext) -> Result<ToolOutput> {
+        if args.get("files").is_some() {
+            if args.get("file_path").is_some() {
+                return Ok(ToolOutput::error(
+                    "file_path and files are mutually exclusive; provide exactly one",
+                ));
+            }
+            return execute_batch_read(args, ctx).await;
+        }
+
         let file_path = match args.get("file_path").and_then(|v| v.as_str()) {
             Some(p) => p,
             None => return Ok(ToolOutput::error("file_path parameter is required")),
@@ -143,6 +219,403 @@ impl Tool for ReadTool {
     }
 }
 
+async fn execute_batch_read(args: &serde_json::Value, ctx: &ToolContext) -> Result<ToolOutput> {
+    for parameter in ["offset", "limit"] {
+        if args.get(parameter).is_some() {
+            return Ok(ToolOutput::error(format!(
+                "{parameter} cannot be combined with files; put it on each files entry"
+            )));
+        }
+    }
+
+    let raw_entries = match args.get("files").and_then(serde_json::Value::as_array) {
+        Some(entries) if !entries.is_empty() && entries.len() <= MAX_BATCH_READ_FILES => entries,
+        Some(entries) if entries.is_empty() => {
+            return Ok(ToolOutput::error("files must contain at least one entry"))
+        }
+        Some(_) => {
+            return Ok(ToolOutput::error(format!(
+                "files accepts at most {MAX_BATCH_READ_FILES} entries"
+            )))
+        }
+        None => return Ok(ToolOutput::error("files parameter must be an array")),
+    };
+    let entries = match raw_entries
+        .iter()
+        .cloned()
+        .map(serde_json::from_value::<BatchReadEntry>)
+        .collect::<std::result::Result<Vec<_>, _>>()
+    {
+        Ok(entries) => entries,
+        Err(error) => return Ok(ToolOutput::error(format!("Invalid files entry: {error}"))),
+    };
+    if let Some(error) = validate_batch_entries(&entries, ctx) {
+        return Ok(ToolOutput::error(error));
+    }
+
+    let max_output_bytes = match args.get("max_output_bytes") {
+        Some(value) => match value
+            .as_u64()
+            .and_then(|value| usize::try_from(value).ok())
+        {
+            Some(value)
+                if (MIN_BATCH_READ_OUTPUT_BYTES..=MAX_BATCH_READ_OUTPUT_BYTES).contains(&value) =>
+            {
+                value
+            }
+            _ => {
+                return Ok(ToolOutput::error(format!(
+                    "max_output_bytes must be between {MIN_BATCH_READ_OUTPUT_BYTES} and {MAX_BATCH_READ_OUTPUT_BYTES}"
+                )))
+            }
+        },
+        None => DEFAULT_BATCH_READ_OUTPUT_BYTES,
+    };
+
+    let total = entries.len();
+    let mut progress = entries.iter().cloned().map(Some).collect::<Vec<_>>();
+    let mut segments = Vec::new();
+    let mut source_anchors = Vec::new();
+    let mut successful_files = 0usize;
+    let mut failed_files = 0usize;
+    let mut returned_lines = 0usize;
+
+    for (index, entry) in entries.iter().enumerate() {
+        let workspace_path = match ctx.resolve_workspace_path(&entry.path) {
+            Ok(path) => path,
+            Err(error) => {
+                let display_path = escape_control_chars_for_display(&entry.path);
+                let segment = format!("=== {display_path} ===\nFailed to resolve path: {error}");
+                if !accept_batch_message(
+                    &mut segments,
+                    &mut progress,
+                    index,
+                    segment,
+                    total,
+                    max_output_bytes,
+                ) {
+                    if segments.is_empty() {
+                        return Ok(batch_budget_too_small(max_output_bytes));
+                    }
+                    break;
+                }
+                failed_files += 1;
+                continue;
+            }
+        };
+        // Batch headers stay workspace-relative so repeated roots do not consume
+        // the shared context budget. Source anchors carry the same canonical path.
+        let display_path = escape_control_chars_for_display(workspace_path.as_str());
+        let limit = entry.limit.unwrap_or(MAX_READ_LINES);
+        let range = match read_range(ctx, &workspace_path, entry.offset, limit).await {
+            Ok(range) => range,
+            Err(error) => {
+                let segment =
+                    format!("=== {display_path} ===\nFailed to read file {display_path}: {error}");
+                if !accept_batch_message(
+                    &mut segments,
+                    &mut progress,
+                    index,
+                    segment,
+                    total,
+                    max_output_bytes,
+                ) {
+                    if segments.is_empty() {
+                        return Ok(batch_budget_too_small(max_output_bytes));
+                    }
+                    break;
+                }
+                failed_files += 1;
+                continue;
+            }
+        };
+        if range.lines.is_empty()
+            && range.eof
+            && range
+                .total_lines
+                .is_some_and(|total_lines| entry.offset > total_lines)
+        {
+            let total_lines = range.total_lines.unwrap_or_default();
+            let segment = format!(
+                "=== {display_path} ===\nOffset {} exceeds file length ({total_lines} lines)",
+                entry.offset
+            );
+            if !accept_batch_message(
+                &mut segments,
+                &mut progress,
+                index,
+                segment,
+                total,
+                max_output_bytes,
+            ) {
+                if segments.is_empty() {
+                    return Ok(batch_budget_too_small(max_output_bytes));
+                }
+                break;
+            }
+            failed_files += 1;
+            continue;
+        }
+
+        if range.lines.is_empty() && range.eof {
+            let segment = format!(
+                "=== {display_path} ===\n(end of file: offset {} equals file length)",
+                entry.offset
+            );
+            if !accept_batch_message(
+                &mut segments,
+                &mut progress,
+                index,
+                segment,
+                total,
+                max_output_bytes,
+            ) {
+                if segments.is_empty() {
+                    return Ok(batch_budget_too_small(max_output_bytes));
+                }
+                break;
+            }
+            successful_files += 1;
+            source_anchors.push(workspace_path.as_str().to_string());
+            continue;
+        }
+
+        let lines = range
+            .lines
+            .iter()
+            .enumerate()
+            .map(|(line_index, line)| {
+                format!(
+                    "{:>6}\t{}",
+                    entry.offset + line_index + 1,
+                    truncate_utf8(line, MAX_LINE_LENGTH)
+                )
+            })
+            .collect::<Vec<_>>();
+        let shown = largest_batch_prefix(
+            &segments,
+            &progress,
+            index,
+            entry,
+            &range,
+            &display_path,
+            &lines,
+            total,
+            max_output_bytes,
+        );
+        if shown == 0 {
+            if segments.is_empty() {
+                return Ok(batch_budget_too_small(max_output_bytes));
+            }
+            break;
+        }
+
+        progress[index] = batch_progress_after(entry, &range, shown);
+        segments.push(batch_content_segment(&display_path, &lines[..shown]));
+        returned_lines += shown;
+        successful_files += 1;
+        source_anchors.push(workspace_path.as_str().to_string());
+        if progress[index].is_some() {
+            break;
+        }
+    }
+
+    let content = render_batch_response(&segments, &progress, total);
+    debug_assert!(content.len() <= max_output_bytes);
+    let continuation = batch_continuation(&progress);
+    let truncated = !continuation.is_empty();
+    let metadata = serde_json::json!({
+        "source_anchors": source_anchors,
+        "batch": {
+            "status": if truncated {
+                "partial"
+            } else if failed_files > 0 {
+                "partial_failure"
+            } else {
+                "complete"
+            },
+            "requested_files": total,
+            "successful_files": successful_files,
+            "failed_files": failed_files,
+            "completed_files": total.saturating_sub(continuation.len()),
+            "returned_lines": returned_lines,
+            "max_output_bytes": max_output_bytes,
+            "output_bytes": content.len(),
+            "truncated": truncated,
+            "continuation": continuation,
+        }
+    });
+
+    if successful_files > 0 || truncated {
+        Ok(ToolOutput::success(content).with_metadata(metadata))
+    } else {
+        Ok(ToolOutput::error(content).with_metadata(metadata))
+    }
+}
+
+fn validate_batch_entries(entries: &[BatchReadEntry], ctx: &ToolContext) -> Option<String> {
+    let mut seen = HashSet::new();
+    for entry in entries {
+        if entry.path.is_empty() || entry.path.len() > MAX_BATCH_READ_PATH_BYTES {
+            return Some(format!(
+                "files path must contain 1-{MAX_BATCH_READ_PATH_BYTES} bytes"
+            ));
+        }
+        if entry
+            .limit
+            .is_some_and(|limit| limit == 0 || limit > MAX_READ_LINES)
+        {
+            return Some(format!(
+                "files limit must be between 1 and {MAX_READ_LINES}"
+            ));
+        }
+        let Ok(path) = ctx.resolve_workspace_path(&entry.path) else {
+            continue;
+        };
+        let key = path.as_str().to_string();
+        if !seen.insert(key.clone()) {
+            let display_path = escape_control_chars_for_display(&key);
+            return Some(format!(
+                "Duplicate path in files: {display_path}. List each file once."
+            ));
+        }
+    }
+    None
+}
+
+fn accept_batch_message(
+    segments: &mut Vec<String>,
+    progress: &mut [Option<BatchReadEntry>],
+    index: usize,
+    segment: String,
+    total: usize,
+    budget: usize,
+) -> bool {
+    let mut proposed = progress.to_vec();
+    proposed[index] = None;
+    if !batch_candidate_fits(segments, &segment, &proposed, total, budget) {
+        return false;
+    }
+    segments.push(segment);
+    progress[index] = None;
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
+fn largest_batch_prefix(
+    segments: &[String],
+    progress: &[Option<BatchReadEntry>],
+    index: usize,
+    entry: &BatchReadEntry,
+    range: &WorkspaceTextRange,
+    display_path: &str,
+    lines: &[String],
+    total: usize,
+    budget: usize,
+) -> usize {
+    let fits = |shown: usize| {
+        let mut proposed = progress.to_vec();
+        proposed[index] = batch_progress_after(entry, range, shown);
+        let segment = batch_content_segment(display_path, &lines[..shown]);
+        batch_candidate_fits(segments, &segment, &proposed, total, budget)
+    };
+
+    if fits(lines.len()) {
+        return lines.len();
+    }
+    if lines.len() <= 1 {
+        return 0;
+    }
+    let mut low = 1usize;
+    let mut high = lines.len() - 1;
+    let mut best = 0usize;
+    while low <= high {
+        let middle = low + ((high - low) / 2);
+        if fits(middle) {
+            best = middle;
+            low = middle + 1;
+        } else if middle == 1 {
+            break;
+        } else {
+            high = middle - 1;
+        }
+    }
+    best
+}
+
+fn batch_progress_after(
+    entry: &BatchReadEntry,
+    range: &WorkspaceTextRange,
+    shown: usize,
+) -> Option<BatchReadEntry> {
+    let offset = entry.offset.saturating_add(shown);
+    if shown < range.lines.len() {
+        return Some(BatchReadEntry {
+            path: entry.path.clone(),
+            offset,
+            limit: entry.limit.map(|limit| limit.saturating_sub(shown)),
+        });
+    }
+
+    if entry.limit.is_some() {
+        return None;
+    }
+    range.next_offset.map(|next_offset| BatchReadEntry {
+        path: entry.path.clone(),
+        offset: next_offset,
+        limit: None,
+    })
+}
+
+fn batch_content_segment(display_path: &str, lines: &[String]) -> String {
+    format!("=== {display_path} ===\n{}", lines.join("\n"))
+}
+
+fn batch_candidate_fits(
+    segments: &[String],
+    segment: &str,
+    progress: &[Option<BatchReadEntry>],
+    total: usize,
+    budget: usize,
+) -> bool {
+    let mut proposed = segments.to_vec();
+    proposed.push(segment.to_string());
+    render_batch_response(&proposed, progress, total).len() <= budget
+}
+
+fn render_batch_response(
+    segments: &[String],
+    progress: &[Option<BatchReadEntry>],
+    total: usize,
+) -> String {
+    let mut output = segments.join("\n\n");
+    let continuation = batch_continuation(progress);
+    let footer = if continuation.is_empty() {
+        format!("(Complete: all {total} file(s) processed.)")
+    } else {
+        let encoded = serde_json::to_string(&continuation).unwrap_or_else(|_| "[]".to_string());
+        format!(
+            "(Partial: {} of {total} file(s) processed. Continue with files={encoded}.)",
+            total.saturating_sub(continuation.len())
+        )
+    };
+    if !output.is_empty() {
+        output.push_str("\n\n");
+    }
+    output.push_str(&footer);
+    output
+}
+
+fn batch_continuation(progress: &[Option<BatchReadEntry>]) -> Vec<BatchReadEntry> {
+    progress.iter().flatten().cloned().collect()
+}
+
+fn batch_budget_too_small(budget: usize) -> ToolOutput {
+    ToolOutput::error(format!(
+        "max_output_bytes={budget} is too small to return one line plus a lossless files continuation; increase the budget or shorten the files list"
+    ))
+}
+
 async fn read_range(
     ctx: &ToolContext,
     path: &crate::workspace::WorkspacePath,
@@ -185,6 +658,10 @@ async fn read_range(
         total_lines: Some(lines.len()),
     })
 }
+
+#[cfg(test)]
+#[path = "read/batch_tests.rs"]
+mod batch_tests;
 
 #[cfg(test)]
 mod tests {
@@ -380,10 +857,31 @@ mod tests {
         let tool = ReadTool;
         let params = tool.parameters();
         assert_eq!(params["additionalProperties"], false);
-        assert_eq!(params["required"], serde_json::json!(["file_path"]));
+        assert_eq!(params["oneOf"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            params["properties"]["files"]["maxItems"],
+            serde_json::json!(32)
+        );
         let examples = params["examples"].as_array().unwrap();
         assert_eq!(examples[0]["file_path"], "src/main.rs");
         assert!(examples[0].get("path").is_none());
+        assert_eq!(examples[2]["files"][0]["path"], "src/lib.rs");
+    }
+
+    #[test]
+    fn test_read_schema_accepts_exactly_one_input_shape() {
+        let schema = ReadTool.parameters();
+        let validator = jsonschema::draft202012::options().build(&schema).unwrap();
+
+        assert!(validator.is_valid(&serde_json::json!({"file_path": "README.md"})));
+        assert!(validator.is_valid(&serde_json::json!({
+            "files": [{"path": "README.md"}]
+        })));
+        assert!(!validator.is_valid(&serde_json::json!({})));
+        assert!(!validator.is_valid(&serde_json::json!({
+            "file_path": "README.md",
+            "files": [{"path": "README.md"}]
+        })));
     }
 
     #[tokio::test]

--- a/core/src/tools/builtin/read/batch_tests.rs
+++ b/core/src/tools/builtin/read/batch_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+#[tokio::test]
+async fn preserves_order_and_isolates_file_errors() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("a.txt"), "alpha\n").unwrap();
+    std::fs::write(temp.path().join("b.txt"), "bravo\n").unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf());
+
+    let result = ReadTool
+        .execute(
+            &serde_json::json!({
+                "files": [
+                    {"path": "a.txt"},
+                    {"path": "missing.txt"},
+                    {"path": "b.txt"}
+                ]
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(result.success, "{}", result.content);
+    let a = result.content.find("=== a.txt ===").unwrap();
+    let missing = result.content.find("=== missing.txt ===").unwrap();
+    let b = result.content.find("=== b.txt ===").unwrap();
+    assert!(a < missing && missing < b);
+    assert!(result.content.contains("alpha"));
+    assert!(result.content.contains("bravo"));
+    assert!(result.content.contains("Failed to read file missing.txt"));
+
+    let metadata = result.metadata.unwrap();
+    assert_eq!(
+        metadata["source_anchors"],
+        serde_json::json!(["a.txt", "b.txt"])
+    );
+    assert_eq!(metadata["batch"]["requested_files"], 3);
+    assert_eq!(metadata["batch"]["successful_files"], 2);
+    assert_eq!(metadata["batch"]["failed_files"], 1);
+    assert_eq!(metadata["batch"]["truncated"], false);
+}
+
+#[tokio::test]
+async fn continuation_is_bounded_and_lossless() {
+    let temp = tempfile::tempdir().unwrap();
+    let a = (0..8)
+        .map(|index| format!("A{index:02}-{}", "x".repeat(700)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let b = (0..4)
+        .map(|index| format!("B{index:02}-{}", "y".repeat(700)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(temp.path().join("a.txt"), a).unwrap();
+    std::fs::write(temp.path().join("b.txt"), b).unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf());
+    let mut files = serde_json::json!([
+        {"path": "a.txt"},
+        {"path": "b.txt"}
+    ]);
+    let mut combined = String::new();
+
+    for _ in 0..16 {
+        let result = ReadTool
+            .execute(
+                &serde_json::json!({
+                    "files": files,
+                    "max_output_bytes": 2048
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.len() <= 2048, "{}", result.content.len());
+        combined.push_str(&result.content);
+
+        let metadata = result.metadata.unwrap();
+        files = metadata["batch"]["continuation"].clone();
+        if files.as_array().unwrap().is_empty() {
+            break;
+        }
+    }
+
+    assert!(
+        files.as_array().unwrap().is_empty(),
+        "continuation did not finish"
+    );
+    for prefix in (0..8)
+        .map(|index| format!("A{index:02}-"))
+        .chain((0..4).map(|index| format!("B{index:02}-")))
+    {
+        assert_eq!(
+            combined.matches(&prefix).count(),
+            1,
+            "marker {prefix} was duplicated or skipped"
+        );
+    }
+}
+
+#[tokio::test]
+async fn rejects_duplicate_paths() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("same.txt"), "content").unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf());
+
+    let result = ReadTool
+        .execute(
+            &serde_json::json!({
+                "files": [
+                    {"path": "same.txt"},
+                    {"path": "./same.txt"}
+                ]
+            }),
+            &ctx,
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.success);
+    assert!(result.content.contains("Duplicate path"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn escapes_control_characters_in_batch_headers() {
+    let temp = tempfile::tempdir().unwrap();
+    let filename = "actual\n=== injected.txt ===";
+    std::fs::write(temp.path().join(filename), "safe content").unwrap();
+    let ctx = ToolContext::new(temp.path().to_path_buf());
+
+    let result = ReadTool
+        .execute(&serde_json::json!({"files": [{"path": filename}]}), &ctx)
+        .await
+        .unwrap();
+
+    assert!(result.success, "{}", result.content);
+    assert!(result.content.contains(r"actual\n=== injected.txt ==="));
+    assert!(!result
+        .content
+        .lines()
+        .any(|line| line == "=== injected.txt === ==="));
+    assert_eq!(
+        result.metadata.unwrap()["source_anchors"],
+        serde_json::json!([filename])
+    );
+}

--- a/core/src/workspace/local.rs
+++ b/core/src/workspace/local.rs
@@ -489,6 +489,7 @@ impl WorkspaceSearch for LocalWorkspaceBackend {
         let mut file_count = 0;
         let mut total_size = 0;
         let mut matched_paths = Vec::new();
+        let metadata_only = request.max_output_size == 0;
 
         for entry in builder.build().flatten() {
             if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
@@ -520,7 +521,7 @@ impl WorkspaceSearch for LocalWorkspaceBackend {
             let mut path_recorded = false;
 
             for &match_idx in &file_matches {
-                if total_size > request.max_output_size {
+                if !metadata_only && total_size > request.max_output_size {
                     return Ok(WorkspaceGrepOutcome {
                         result: WorkspaceGrepResult {
                             output,
@@ -537,6 +538,9 @@ impl WorkspaceSearch for LocalWorkspaceBackend {
                     path_recorded = true;
                 }
                 match_count += 1;
+                if metadata_only {
+                    continue;
+                }
 
                 let start = match_idx.saturating_sub(request.context_lines);
                 let end = (match_idx + request.context_lines + 1).min(lines.len());

--- a/core/src/workspace/manifest.rs
+++ b/core/src/workspace/manifest.rs
@@ -586,6 +586,7 @@ impl WorkspaceSearch for ManifestWorkspaceBackend {
         let mut file_count = 0;
         let mut total_size = 0;
         let mut matched_paths = Vec::new();
+        let metadata_only = request.max_output_size == 0;
 
         let candidates = request
             .glob
@@ -631,7 +632,7 @@ impl WorkspaceSearch for ManifestWorkspaceBackend {
             let display_path = escape_control_chars_for_display(&file.path);
             let mut path_recorded = false;
             for &match_idx in &file_matches {
-                if total_size > request.max_output_size {
+                if !metadata_only && total_size > request.max_output_size {
                     return Ok(WorkspaceGrepOutcome {
                         result: WorkspaceGrepResult {
                             output,
@@ -648,6 +649,9 @@ impl WorkspaceSearch for ManifestWorkspaceBackend {
                     path_recorded = true;
                 }
                 match_count += 1;
+                if metadata_only {
+                    continue;
+                }
                 let start = match_idx.saturating_sub(request.context_lines);
                 let end = (match_idx + request.context_lines + 1).min(lines.len());
 

--- a/core/src/workspace/manifest/tests.rs
+++ b/core/src/workspace/manifest/tests.rs
@@ -124,6 +124,29 @@ async fn manifest_search_matches_glob_and_grep() {
     assert_eq!(grep.match_count, 1);
     assert_eq!(grep.file_count, 1);
     assert!(grep.output.contains("src/main.rs:2"));
+
+    let metadata_only = backend
+        .grep_with_sources(WorkspaceGrepRequest {
+            base: WorkspacePath::root(),
+            pattern: "hello".to_string(),
+            glob: None,
+            context_lines: 0,
+            case_insensitive: false,
+            max_output_size: 0,
+        })
+        .await
+        .unwrap();
+    assert_eq!(metadata_only.result.match_count, 2);
+    assert_eq!(metadata_only.result.file_count, 2);
+    assert!(metadata_only.result.output.is_empty());
+    assert!(!metadata_only.result.truncated);
+    assert_eq!(
+        metadata_only.matched_paths.unwrap(),
+        vec![
+            WorkspacePath::from_normalized("README.md"),
+            WorkspacePath::from_normalized("src/main.rs")
+        ]
+    );
 }
 
 #[tokio::test]

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -27,12 +27,11 @@ pub use manifest::{
     LocalWorkspaceManifestSnapshot, ManifestWorkspaceBackend, RecentWorkspaceFile,
     WorkspaceFileChange, WorkspaceFileChangeKind,
 };
-pub(crate) use path::validate_relative_pattern;
 pub use path::VirtualPathResolver;
 use path::{
-    default_path_input, escape_control_chars_for_display, has_windows_path_prefix,
-    normalize_relative_path, pathbuf_to_workspace_path,
+    default_path_input, has_windows_path_prefix, normalize_relative_path, pathbuf_to_workspace_path,
 };
+pub(crate) use path::{escape_control_chars_for_display, validate_relative_pattern};
 pub use remote_git::{RemoteGitBackend, RemoteGitBackendConfig, RemoteGitConflict};
 #[cfg(feature = "s3")]
 pub use s3::{S3BackendConfig, S3WorkspaceBackend};
@@ -196,6 +195,9 @@ pub struct WorkspaceGrepRequest {
     pub glob: Option<String>,
     pub context_lines: usize,
     pub case_insensitive: bool,
+    /// Maximum rendered match bytes. Zero requests a metadata-only scan:
+    /// backends count every matching line and collect distinct source paths
+    /// without constructing match text.
     pub max_output_size: usize,
 }
 

--- a/core/src/workspace/path.rs
+++ b/core/src/workspace/path.rs
@@ -89,7 +89,7 @@ pub(super) fn pathbuf_to_workspace_path(path: &Path) -> WorkspacePath {
     WorkspacePath::from_normalized(display)
 }
 
-pub(super) fn escape_control_chars_for_display(path: &str) -> String {
+pub(crate) fn escape_control_chars_for_display(path: &str) -> String {
     let mut escaped = String::with_capacity(path.len());
     for ch in path.chars() {
         if ch.is_control() {

--- a/core/src/workspace/s3.rs
+++ b/core/src/workspace/s3.rs
@@ -778,12 +778,13 @@ impl WorkspaceSearch for S3WorkspaceBackend {
         let mut total_size = 0usize;
         let mut output_truncated = false;
         let mut matched_paths = Vec::new();
+        let metadata_only = request.max_output_size == 0;
 
         'outer: for (workspace_path, display_str, lines, file_matches) in hits {
             file_count += 1;
             let mut path_recorded = false;
             for &match_idx in &file_matches {
-                if total_size > request.max_output_size {
+                if !metadata_only && total_size > request.max_output_size {
                     output_truncated = true;
                     break 'outer;
                 }
@@ -792,6 +793,9 @@ impl WorkspaceSearch for S3WorkspaceBackend {
                     path_recorded = true;
                 }
                 match_count += 1;
+                if metadata_only {
+                    continue;
+                }
 
                 let start = match_idx.saturating_sub(request.context_lines);
                 let end = (match_idx + request.context_lines + 1).min(lines.len());

--- a/manual/USER_GUIDE.md
+++ b/manual/USER_GUIDE.md
@@ -207,18 +207,53 @@ session = agent.session(".", opts)
 
 | Tool | Description | Example |
 |------|-------------|---------|
-| `read` | Read file content | `read: /path/to/file.py` |
+| `read` | Read one file range or 1-32 ordered file ranges under one shared output budget | `read: /path/to/file.py` |
 | `write` | Write file | `write: /path/to/file.py` |
-| `edit` | Edit file | `edit: /path/to/file.py` |
+| `edit` | Preview or apply a CAS-protected exact-string edit with replacement-count guards | `edit: /path/to/file.py` |
 | `patch` | Apply patch | `patch: /path/to/file.py` |
 
 #### Search Tools
 
 | Tool | Description | Example |
 |------|-------------|---------|
-| `grep` | Text search | `grep: "function name"` |
-| `glob` | File matching | `glob: "**/*.py"` |
+| `grep` | Content, matching-file, per-file-count, or summary regex search | `grep: "function name"` |
+| `glob` | Cursor-paginated file matching with backend or stable path ordering | `glob: "**/*.py"` |
 | `ls` | Directory listing | `ls: /path/to/dir` |
+
+#### Bounded repository context
+
+Use `read.files` when the relevant paths are already known:
+
+```json
+{
+  "files": [
+    { "path": "src/lib.rs" },
+    { "path": "src/config.rs", "offset": 20, "limit": 60 }
+  ],
+  "max_output_bytes": 65536
+}
+```
+
+The response preserves request order and isolates member errors. When
+`metadata.batch.truncated` is true, pass `metadata.batch.continuation` back as
+the next `files` value. The continuation text is already included in the byte
+budget.
+
+Choose a grep result shape with `output_mode`:
+
+- `content` returns matching lines and optional context.
+- `files_with_matches` returns lexically cursor-paginated paths.
+- `count` returns lexically cursor-paginated matching-line counts per file.
+- `summary` completes the scan and returns totals without match text.
+
+`glob` defaults to `sort: "backend"` to retain backend recency or relevance
+order. Use `sort: "path"` when deterministic lexical cursor pages are more
+important.
+
+For mechanical changes, first call `edit` with `dry_run: true`. Then apply the
+same edit with `expected_replacements` set to the previewed count; add
+`max_replacements` when an independent upper bound is required. A dry run is a
+read-only tool invocation and never writes the workspace.
 
 #### Other Tools
 

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.4.3"
+version = "6.5.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "6.4.3"
+version = "6.5.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "6.4.3"
+version = "6.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.4.3", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.5.0", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "6.4.3",
+      "version": "6.5.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.4.3",
-        "@a3s-lab/code-linux-arm64-gnu": "6.4.3",
-        "@a3s-lab/code-linux-arm64-musl": "6.4.3",
-        "@a3s-lab/code-linux-x64-gnu": "6.4.3",
-        "@a3s-lab/code-linux-x64-musl": "6.4.3",
-        "@a3s-lab/code-win32-x64-msvc": "6.4.3"
+        "@a3s-lab/code-darwin-arm64": "6.5.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.5.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.5.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.5.0",
+        "@a3s-lab/code-linux-x64-musl": "6.5.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.5.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "6.4.3",
+      "version": "6.5.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.4.3",
-        "@a3s-lab/code-linux-arm64-gnu": "6.4.3",
-        "@a3s-lab/code-linux-arm64-musl": "6.4.3",
-        "@a3s-lab/code-linux-x64-gnu": "6.4.3",
-        "@a3s-lab/code-linux-x64-musl": "6.4.3",
-        "@a3s-lab/code-win32-x64-msvc": "6.4.3"
+        "@a3s-lab/code-darwin-arm64": "6.5.0",
+        "@a3s-lab/code-linux-arm64-gnu": "6.5.0",
+        "@a3s-lab/code-linux-arm64-musl": "6.5.0",
+        "@a3s-lab/code-linux-x64-gnu": "6.5.0",
+        "@a3s-lab/code-linux-x64-musl": "6.5.0",
+        "@a3s-lab/code-win32-x64-msvc": "6.5.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.4.3",
+  "version": "6.5.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "6.4.3",
-    "@a3s-lab/code-linux-x64-gnu": "6.4.3",
-    "@a3s-lab/code-linux-x64-musl": "6.4.3",
-    "@a3s-lab/code-linux-arm64-gnu": "6.4.3",
-    "@a3s-lab/code-linux-arm64-musl": "6.4.3",
-    "@a3s-lab/code-win32-x64-msvc": "6.4.3"
+    "@a3s-lab/code-darwin-arm64": "6.5.0",
+    "@a3s-lab/code-linux-x64-gnu": "6.5.0",
+    "@a3s-lab/code-linux-x64-musl": "6.5.0",
+    "@a3s-lab/code-linux-arm64-gnu": "6.5.0",
+    "@a3s-lab/code-linux-arm64-musl": "6.5.0",
+    "@a3s-lab/code-win32-x64-msvc": "6.5.0"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "6.4.3"
+version = "6.5.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "6.4.3"
+__version__ = "6.5.0"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-07-28
+
+### Changed
+
+- Updated the bundled Core with budgeted multi-file reads, compact grep result
+  modes, explicit glob ordering, and previewable replacement-count-guarded
+  edits.
+
 ## [6.4.3] - 2026-07-25
 
 ### Fixed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.4.3"
+version = "6.5.0"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "6.4.3"
+version = "6.5.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "6.4.3"
+version = "6.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.4.3", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.5.0", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "6.4.3"
+version = "6.5.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}

--- a/website/docs/v6/en/guide/tools.mdx
+++ b/website/docs/v6/en/guide/tools.mdx
@@ -79,6 +79,49 @@ evade it. Timeout and cancellation terminate the complete Unix process group.
 Large file changes replace full before/after event payloads with bounded
 previews and unified diff text plus hashes, sizes, and artifact references.
 
+### Repository-context modes
+
+Use `read.files` when the relevant paths are already known and one bounded
+response is cheaper than several tool turns:
+
+```json
+{
+  "files": [
+    { "path": "src/lib.rs" },
+    { "path": "src/config.rs", "offset": 40, "limit": 80 }
+  ],
+  "max_output_bytes": 65536
+}
+```
+
+The shared byte budget includes headers and the continuation text. Results
+stay in request order, and one unreadable member does not discard successful
+members. When `metadata.batch.truncated` is true, copy
+`metadata.batch.continuation` into the next call's `files` value; its offsets
+and remaining limits resume without repeating completed lines.
+
+`grep.output_mode` selects the smallest useful result shape:
+
+| Mode                 | Result                                                        |
+| -------------------- | ------------------------------------------------------------- |
+| `content`            | Matching lines and optional context (default)                 |
+| `files_with_matches` | Lexically cursor-paginated matching paths                     |
+| `count`              | Lexically cursor-paginated matching-line counts per file      |
+| `summary`            | Full-scan line and file totals without rendered match content |
+
+Built-in workspace backends perform non-content scans without constructing
+discarded match text. S3 results set `metadata.search.truncated` and warn when
+the backend's object scan limit makes totals or paths incomplete.
+
+`glob` keeps backend relevance or recency order by default. Set `sort: "path"`
+before cursor pagination when stable lexical pages are required.
+
+For exact-string changes, call `edit` with `dry_run: true` to return the same
+before/after diff metadata without writing. Then apply the edit with
+`expected_replacements` set to the previewed count, and optionally add
+`max_replacements` as an independent upper bound. Dry runs advertise read-only
+capability and are safe for `batch` parallelization.
+
 `batch` accepts at most 32 calls and applies at most 16-way concurrency. It
 fans out only when every child declares safe read-only, idempotent behavior;
 mutating and unknown tools are serialized. A partial batch identifies failed


### PR DESCRIPTION
## Summary

- add budget-bounded multi-file reads with ordered results, isolated failures, and lossless continuation arguments
- add grep output modes for content, matching files, per-file counts, and summaries with stable lexical pagination
- add edit dry runs and replacement-count guards, plus explicit glob ordering
- document the repository-context contracts in README, the user guide, and the public website, with FastCtx attribution
- stabilize the MCP process-group teardown fixture and prepare release 6.5.0 across Core, Node, and Python packages

## Validation

- `SKIP_REAL_PROVIDER=1 scripts/release_preflight.sh`
- `cargo test -p a3s-code-core --all-features`
- `cargo clippy -p a3s-code-core --all-targets --all-features -- -D warnings`
- Node native debug build, SDK smoke/helpers, and example typecheck
- website format, lint/typecheck/language parity, production build, and built-site reference checks
- MCP drop cleanup test repeated 30 times after fixture synchronization fix

## Release notes

Version `6.5.0` is available on crates.io, npm, PyPI, and Git tags. The deterministic release gates pass; real-provider network smoke tests were explicitly skipped to avoid consuming local credentials.