### PR TITLE
docs: remove external repository attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added explicit `glob` ordering: `sort: "path"` provides deterministic lexical
   order before cursor pagination, while the compatible `sort: "backend"`
   default retains backend relevance or recency order.
-- Added explicit README attribution for the FastCtx repository-tool ergonomics
-  that informed these context-efficiency improvements.
 
 ## [6.4.3] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -259,11 +259,6 @@ writing. The dry run is declared read-only and can be safely batched. Apply the
 result with `expected_replacements` and optionally `max_replacements` to reject
 stale or unexpectedly broad changes before the compare-and-swap write.
 
-These repository-context ergonomics were informed by
-[FastCtx](https://github.com/yc-duan/fastctx). Their implementation here stays
-inside A3S Code's workspace abstractions, capability declarations, permission
-path, remote-backend contracts, and structured metadata.
-
 ### Sandbox and credential boundaries
 
 Hosts can attach a `BashSandbox`. The fail-closed local `SrtBashSandbox` limits


### PR DESCRIPTION
## Summary

- remove the external repository attribution from the repository-context section
- remove the corresponding attribution entry from the v6.5.0 changelog
- keep the A3S Code feature descriptions and implementation unchanged

## Validation

- repository-wide case-insensitive reference search returns no matches
- `git diff --check`
- commit-time Cargo formatting check
