### PR TITLE
chore(release): prepare 6.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.2] - 2026-07-28
+
 ### Added
 
 - Added strict `generate_object` argument validation, root JSON Schema support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "6.5.1"
+version = "6.5.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "6.5.1"
+version = "6.5.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.5.1", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.5.2", path = "../../core", features = ["s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "6.5.1",
+      "version": "6.5.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.5.1",
-        "@a3s-lab/code-linux-arm64-gnu": "6.5.1",
-        "@a3s-lab/code-linux-arm64-musl": "6.5.1",
-        "@a3s-lab/code-linux-x64-gnu": "6.5.1",
-        "@a3s-lab/code-linux-x64-musl": "6.5.1",
-        "@a3s-lab/code-win32-x64-msvc": "6.5.1"
+        "@a3s-lab/code-darwin-arm64": "6.5.2",
+        "@a3s-lab/code-linux-arm64-gnu": "6.5.2",
+        "@a3s-lab/code-linux-arm64-musl": "6.5.2",
+        "@a3s-lab/code-linux-x64-gnu": "6.5.2",
+        "@a3s-lab/code-linux-x64-musl": "6.5.2",
+        "@a3s-lab/code-win32-x64-msvc": "6.5.2"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "6.5.1",
+      "version": "6.5.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "6.5.1",
-        "@a3s-lab/code-linux-arm64-gnu": "6.5.1",
-        "@a3s-lab/code-linux-arm64-musl": "6.5.1",
-        "@a3s-lab/code-linux-x64-gnu": "6.5.1",
-        "@a3s-lab/code-linux-x64-musl": "6.5.1",
-        "@a3s-lab/code-win32-x64-msvc": "6.5.1"
+        "@a3s-lab/code-darwin-arm64": "6.5.2",
+        "@a3s-lab/code-linux-arm64-gnu": "6.5.2",
+        "@a3s-lab/code-linux-arm64-musl": "6.5.2",
+        "@a3s-lab/code-linux-x64-gnu": "6.5.2",
+        "@a3s-lab/code-linux-x64-musl": "6.5.2",
+        "@a3s-lab/code-win32-x64-msvc": "6.5.2"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -44,11 +44,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "6.5.1",
-    "@a3s-lab/code-linux-x64-gnu": "6.5.1",
-    "@a3s-lab/code-linux-x64-musl": "6.5.1",
-    "@a3s-lab/code-linux-arm64-gnu": "6.5.1",
-    "@a3s-lab/code-linux-arm64-musl": "6.5.1",
-    "@a3s-lab/code-win32-x64-msvc": "6.5.1"
+    "@a3s-lab/code-darwin-arm64": "6.5.2",
+    "@a3s-lab/code-linux-x64-gnu": "6.5.2",
+    "@a3s-lab/code-linux-x64-musl": "6.5.2",
+    "@a3s-lab/code-linux-arm64-gnu": "6.5.2",
+    "@a3s-lab/code-linux-arm64-musl": "6.5.2",
+    "@a3s-lab/code-win32-x64-msvc": "6.5.2"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "6.5.1"
+version = "6.5.2"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "6.5.1"
+__version__ = "6.5.2"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [6.5.2] - 2026-07-28
+
+### Changed
+
+- Updated the bundled Core with strict built-in tool contracts, root JSON
+  Schema value support, governed generation timeouts, and typed transport
+  failures.
+
 ## [6.5.1] - 2026-07-28
 
 ### Changed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "6.5.1"
+version = "6.5.2"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "6.5.1"
+version = "6.5.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "6.5.1", path = "../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "6.5.2", path = "../../core", features = ["s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "6.5.1"
+version = "6.5.2"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- release the hardened parallel_task and generate_object contracts
- publish typed transport error support across Rust, Node, and Python artifacts
- align Core, Node, Python, bootstrap, lockfiles, and changelogs at 6.5.2

## Validation

- bash check-version.sh 6.5.2: passed
- cargo fmt --all -- --check: passed
- npm run test:types: passed
- Python bootstrap unit tests: 14 passed, 1 explicit live test skipped
- underlying Core suite and live k3-agent structured/parallel contracts passed before the version-only release bump