### PR TITLE
fix(website): unify capability demos with Code TUI

### DIFF
--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -50,11 +50,20 @@ for (const file of requiredFiles) {
 
 const capabilityMarkers = [
   'a3s-capability-stories',
+  'data-a3s-code-tui="hero"',
+  'data-a3s-code-tui="capability-hitl"',
   'HITL',
   'PROGRESSIVE API',
   'RUNTIME TOOL',
   'CODE INTELLIGENCE',
   'CTX RECALL',
+];
+
+const sharedTuiRegionMarkers = [
+  'data-tui-region="titlebar"',
+  'data-tui-region="terminal"',
+  'data-tui-region="composer"',
+  'data-tui-region="footer"',
 ];
 
 for (const homepage of ['index.html', 'en/index.html']) {
@@ -63,6 +72,15 @@ for (const homepage of ['index.html', 'en/index.html']) {
     if (!html.includes(marker)) {
       throw new Error(
         `${homepage} is missing homepage capability marker: ${marker}`,
+      );
+    }
+  }
+
+  for (const marker of sharedTuiRegionMarkers) {
+    const count = html.split(marker).length - 1;
+    if (count < 2) {
+      throw new Error(
+        `${homepage} must render the shared A3S Code TUI ${marker} region for both the hero and capability player`,
       );
     }
   }

--- a/website/theme/capability-responsive.css
+++ b/website/theme/capability-responsive.css
@@ -15,16 +15,9 @@
     height: 31px;
   }
 
-  .a3s-capability-player-stage {
-    padding-right: 20px;
-    padding-left: 20px;
-    gap: 16px;
-    grid-template-columns: 120px minmax(0, 1fr);
-  }
-
   .a3s-capability-player-intro {
     align-items: flex-start;
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 14px;
   }
 }
@@ -37,13 +30,12 @@
 
   .a3s-capability-console {
     min-height: 0;
+    gap: 14px;
     grid-template-columns: 1fr;
   }
 
   .a3s-capability-selector {
     overflow-x: auto;
-    border-right: 0;
-    border-bottom: 1px solid #29313c;
     flex-direction: row;
     scrollbar-width: none;
   }
@@ -76,7 +68,7 @@
   }
 
   .a3s-capability-player-stage {
-    min-height: 460px;
+    min-height: 390px;
   }
 }
 
@@ -86,10 +78,8 @@
     padding-bottom: 76px;
   }
 
-  .a3s-capability-console {
-    border-right: 0;
-    border-left: 0;
-    border-radius: 0;
+  .a3s-capability-player.a3s-runtime-inspector {
+    min-height: 680px;
   }
 
   .a3s-capability-selector > button {
@@ -112,50 +102,20 @@
   }
 
   .a3s-capability-player-intro {
-    padding: 22px 18px 20px;
+    gap: 9px;
   }
 
   .a3s-capability-player-intro h3 {
-    font-size: 23px;
+    font-size: 16px;
   }
 
   .a3s-capability-player-stage {
-    min-height: 0;
-    padding: 16px 12px 18px;
-    grid-template-columns: 1fr;
-  }
-
-  .a3s-capability-stage-rail {
-    display: grid;
-    padding: 0 0 4px;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .a3s-capability-stage-rail li {
-    min-height: 52px;
-    padding-right: 8px;
-    grid-template-columns: 19px minmax(0, 1fr);
-    gap: 5px;
-  }
-
-  .a3s-capability-stage-rail li::after {
-    width: auto;
-    height: 1px;
-    inset: 9px 0 auto 20px;
-  }
-
-  .a3s-capability-stage-rail li > i {
-    width: 19px;
-    height: 19px;
-  }
-
-  .a3s-capability-stage-rail li > span {
-    font-size: 7px;
+    min-height: 360px;
   }
 
   .a3s-capability-scene {
-    min-height: 390px;
-    padding: 12px;
+    min-height: 350px;
+    padding: 0;
   }
 
   .a3s-capability-call,
@@ -217,14 +177,14 @@
     grid-template-columns: 1fr;
   }
 
-  .a3s-capability-player-footer > div code:nth-child(n + 3) {
+  .a3s-capability-tui-tag:nth-of-type(n + 4) {
     display: none;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .a3s-capability-player-stage,
-  .a3s-capability-stage-rail li.is-active > i,
+  .a3s-capability-tui-plan li.is-active > i,
   .a3s-progressive-steps .is-active i,
   .a3s-progressive-view.is-ready,
   .a3s-runtime-batch > div.is-running > i b,

--- a/website/theme/capability-scenes.css
+++ b/website/theme/capability-scenes.css
@@ -608,37 +608,6 @@
   font-size: 6px;
 }
 
-.a3s-capability-player-footer {
-  display: flex;
-  min-width: 0;
-  padding: 0 16px;
-  border-top: 1px solid #29313c;
-  background: rgba(9, 13, 17, 0.92);
-  color: #596675;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  font-family: var(--a3s-mono);
-  font-size: 7px;
-}
-
-.a3s-capability-player-footer > div {
-  display: flex;
-  min-width: 0;
-  overflow: hidden;
-  justify-content: flex-end;
-  gap: 5px;
-}
-
-.a3s-capability-player-footer code {
-  padding: 3px 5px;
-  border: 1px solid #2b3540;
-  border-radius: 3px;
-  color: #697786;
-  font-size: 6px;
-  white-space: nowrap;
-}
-
 @keyframes a3s-capability-story-in {
   from {
     opacity: 0;

--- a/website/theme/capability-showcase.css
+++ b/website/theme/capability-showcase.css
@@ -36,21 +36,10 @@
 
   position: relative;
   display: grid;
-  overflow: hidden;
-  min-height: 720px;
-  border: 1px solid #29313c;
-  border-radius: 14px;
-  background:
-    linear-gradient(
-      135deg,
-      rgba(var(--capability-accent-rgb), 0.035),
-      transparent 38%
-    ),
-    rgba(8, 11, 15, 0.94);
+  min-height: 0;
+  background: transparent;
+  gap: 18px;
   grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.8fr);
-  box-shadow:
-    0 46px 110px rgba(0, 0, 0, 0.44),
-    inset 0 1px rgba(255, 255, 255, 0.045);
   transition: --capability-accent 240ms ease;
 }
 
@@ -109,9 +98,14 @@
   position: relative;
   z-index: 1;
   display: flex;
-  border-right: 1px solid #29313c;
+  overflow: hidden;
+  border: 1px solid #29313c;
+  border-radius: 8px;
   background: rgba(10, 13, 18, 0.82);
   flex-direction: column;
+  box-shadow:
+    0 28px 72px rgba(0, 0, 0, 0.28),
+    inset 0 1px rgba(255, 255, 255, 0.025);
 }
 
 .a3s-capability-selector > button {
@@ -254,139 +248,33 @@
   width: calc((var(--capability-progress, 1) / 4) * 100%);
 }
 
-.a3s-capability-player {
+.a3s-capability-player.a3s-runtime-inspector {
   position: relative;
   z-index: 1;
-  display: grid;
+  width: 100%;
   min-width: 0;
-  grid-template-rows: 46px auto minmax(0, 1fr) 42px;
+  min-height: 720px;
+  border-color: #343a40;
+  background: #15191f;
 }
 
-.a3s-capability-player-bar {
-  display: grid;
-  min-width: 0;
-  padding: 0 16px;
-  border-bottom: 1px solid #29313c;
-  background: rgba(11, 15, 20, 0.9);
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 14px;
+.a3s-capability-player > .a3s-tui-terminal {
+  padding: 18px 20px 10px;
+  flex: 1 1 auto;
 }
 
-.a3s-capability-player-bar > span {
-  display: flex;
-  gap: 5px;
-}
-
-.a3s-capability-player-bar > span i {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #343e49;
-}
-
-.a3s-capability-player-bar > span i:first-child {
-  background: #d56d6d;
-}
-
-.a3s-capability-player-bar > span i:nth-child(2) {
-  background: #d3aa60;
-}
-
-.a3s-capability-player-bar > span i:last-child {
-  background: #59ad83;
-}
-
-.a3s-capability-player-bar > p {
-  display: flex;
-  min-width: 0;
-  margin: 0;
-  align-items: center;
-  gap: 9px;
-}
-
-.a3s-capability-player-bar > p b,
-.a3s-capability-player-bar > p small,
-.a3s-capability-player-bar > button {
-  font-family: var(--a3s-mono);
-  font-size: 8px;
-  letter-spacing: 0.08em;
-}
-
-.a3s-capability-player-bar > p b {
-  color: var(--capability-accent);
-}
-
-.a3s-capability-player-bar > p small {
-  overflow: hidden;
-  color: #596573;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.a3s-capability-player-bar > button {
-  display: inline-flex;
-  height: 27px;
-  padding: 0 9px;
-  border: 1px solid #313b46;
-  border-radius: 4px;
-  background: #11171d;
-  color: #909dac;
-  cursor: pointer;
-  align-items: center;
-  gap: 6px;
-}
-
-.a3s-capability-player-bar > button:hover {
-  border-color: rgba(var(--capability-accent-rgb), 0.52);
-  color: #dae3ec;
-}
-
-.a3s-capability-player-bar > button > i {
-  position: relative;
-  display: block;
-  width: 8px;
-  height: 8px;
-}
-
-.a3s-capability-player-bar > button > i.is-play::before {
-  position: absolute;
-  border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent;
-  border-left: 6px solid currentColor;
-  content: '';
-  inset: 0 auto auto 1px;
-}
-
-.a3s-capability-player-bar > button > i.is-pause::before,
-.a3s-capability-player-bar > button > i.is-pause::after {
-  position: absolute;
-  width: 2px;
-  background: currentColor;
-  content: '';
-  inset: 0 auto 0 1px;
-}
-
-.a3s-capability-player-bar > button > i.is-pause::after {
-  right: 1px;
-  left: auto;
+.a3s-capability-player > .a3s-tui-composer {
+  flex: 0 0 auto;
 }
 
 .a3s-capability-player-intro {
-  display: flex;
+  display: grid;
   min-width: 0;
-  padding: 28px 32px 24px;
-  border-bottom: 1px solid #242c35;
-  background:
-    linear-gradient(
-      100deg,
-      rgba(var(--capability-accent-rgb), 0.055),
-      transparent 58%
-    ),
-    rgba(10, 14, 19, 0.6);
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 28px;
+  padding: 0 0 12px;
+  border-bottom: 1px solid #292f36;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 18px;
 }
 
 .a3s-capability-player-intro > div {
@@ -401,26 +289,27 @@
 }
 
 .a3s-capability-player-intro h3 {
-  margin: 8px 0 8px;
+  margin: 5px 0 6px;
   color: #edf2f7;
-  font-size: clamp(22px, 2.5vw, 31px);
-  font-weight: 620;
-  letter-spacing: -0.03em;
-  line-height: 1.15;
+  font-family: var(--a3s-mono);
+  font-size: clamp(16px, 1.8vw, 20px);
+  font-weight: 580;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
 }
 
 .a3s-capability-player-intro p {
   max-width: 650px;
   margin: 0;
   color: #8c97a4;
-  font-size: 12px;
-  line-height: 1.7;
+  font-size: 10px;
+  line-height: 1.55;
 }
 
 .a3s-capability-player-intro > small {
   display: inline-flex;
   flex: 0 0 auto;
-  padding: 7px 9px;
+  padding: 5px 7px;
   border: 1px solid #2e3944;
   border-radius: 999px;
   background: rgba(10, 15, 20, 0.76);
@@ -428,7 +317,7 @@
   align-items: center;
   gap: 6px;
   font-family: var(--a3s-mono);
-  font-size: 8px;
+  font-size: 7.5px;
   white-space: nowrap;
 }
 
@@ -441,121 +330,56 @@
 }
 
 .a3s-capability-player-stage {
-  display: grid;
-  min-height: 444px;
-  padding: 24px 28px;
-  gap: 24px;
-  grid-template-columns: 144px minmax(0, 1fr);
+  min-height: 350px;
+  margin-top: 10px;
+  padding: 10px 0 0;
+  flex: 1 1 auto;
   animation: a3s-capability-story-in 240ms ease-out;
 }
 
-.a3s-capability-stage-rail {
-  display: flex;
-  min-width: 0;
-  margin: 0;
-  padding: 4px 0;
-  list-style: none;
-  flex-direction: column;
+.a3s-capability-tui-plan {
+  padding-bottom: 7px;
 }
 
-.a3s-capability-stage-rail li {
-  position: relative;
-  display: grid;
-  min-height: 82px;
-  color: #566271;
-  grid-template-columns: 22px minmax(0, 1fr);
-  align-items: start;
-  gap: 8px;
-  font-size: 9px;
-  line-height: 1.45;
-  transition: color 180ms ease;
-}
-
-.a3s-capability-stage-rail li::after {
-  position: absolute;
-  width: 1px;
-  background: #2b343f;
-  content: '';
-  inset: 25px auto 3px 10px;
-}
-
-.a3s-capability-stage-rail li:last-child::after {
-  display: none;
-}
-
-.a3s-capability-stage-rail li > i {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  width: 21px;
-  height: 21px;
-  border: 1px solid #303a46;
-  border-radius: 50%;
-  background: #0d1218;
-  color: #596675;
-  place-items: center;
-  font-family: var(--a3s-mono);
-  font-size: 7px;
-  font-style: normal;
-}
-
-.a3s-capability-stage-rail li.is-active {
-  color: #e1e8ef;
-}
-
-.a3s-capability-stage-rail li.is-active > i {
-  border-color: var(--capability-accent);
+.a3s-capability-tui-plan li.is-active > i {
   color: var(--capability-accent);
-  box-shadow: 0 0 14px rgba(var(--capability-accent-rgb), 0.2);
-  animation: a3s-capability-pulse 700ms ease-in-out infinite alternate;
 }
 
-.a3s-capability-stage-rail li.is-complete {
-  color: #8995a2;
-}
-
-.a3s-capability-stage-rail li.is-complete > i {
-  border-color: rgba(var(--capability-accent-rgb), 0.4);
-  background: rgba(var(--capability-accent-rgb), 0.1);
-  color: var(--capability-accent);
+.a3s-capability-tui-plan li.is-done > i {
+  color: #4ec98b;
 }
 
 .a3s-capability-scene-wrap {
   position: relative;
+  display: flex;
   min-width: 0;
-  overflow: hidden;
-  border: 1px solid #2a343f;
-  border-radius: 9px;
-  background:
-    linear-gradient(rgba(113, 130, 150, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(113, 130, 150, 0.035) 1px, transparent 1px),
-    #0b1015;
-  background-size: 28px 28px;
-  box-shadow:
-    0 22px 48px rgba(0, 0, 0, 0.28),
-    inset 0 1px rgba(255, 255, 255, 0.03);
+  flex: 1 1 auto;
 }
 
 .a3s-capability-scene-wrap::after {
-  position: absolute;
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    var(--capability-accent),
-    transparent
-  );
-  content: '';
-  inset: 0 12% auto;
-  opacity: 0.42;
-  pointer-events: none;
+  display: none;
 }
 
 .a3s-capability-scene {
+  width: 100%;
   min-height: 100%;
-  padding: 20px;
+  padding: 2px 0;
   color: #9da9b5;
   font-family: var(--a3s-mono);
+}
+
+.a3s-capability-tui-meta {
+  margin-top: 8px;
+}
+
+.a3s-capability-tui-meta > span:first-child {
+  color: var(--capability-accent);
+}
+
+.a3s-capability-tui-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .a3s-capability-call,

--- a/website/theme/components/A3sCodeTui.tsx
+++ b/website/theme/components/A3sCodeTui.tsx
@@ -1,0 +1,142 @@
+import { forwardRef, type ReactNode } from 'react';
+
+export type A3sCodeTuiInputMode = 'default' | 'shell' | 'research';
+
+type A3sCodeTuiProps = {
+  activity?: ReactNode;
+  afterFooter?: ReactNode;
+  ariaLabel: string;
+  beforeInput?: ReactNode;
+  branch?: string;
+  children: ReactNode;
+  className?: string;
+  composerMode?: A3sCodeTuiInputMode;
+  composerStatus: string;
+  composerSymbol?: string;
+  composerText: string;
+  contextLabel: string;
+  identity?: string;
+  isPlaying: boolean;
+  modeLabel: string;
+  model?: string;
+  onPlayback: () => void;
+  phase?: string;
+  playbackLabel: string;
+  showCursor?: boolean;
+  surface: string;
+  workspace: string;
+};
+
+function classNames(...values: Array<string | false | undefined>) {
+  return values.filter(Boolean).join(' ');
+}
+
+export const A3sCodeTui = forwardRef<HTMLDivElement, A3sCodeTuiProps>(
+  function A3sCodeTui(
+    {
+      activity,
+      afterFooter,
+      ariaLabel,
+      beforeInput,
+      branch = 'git:(main)',
+      children,
+      className,
+      composerMode = 'default',
+      composerStatus,
+      composerSymbol = '❯',
+      composerText,
+      contextLabel,
+      identity = 'a3s',
+      isPlaying,
+      modeLabel,
+      model = 'gpt-5 (128k context)',
+      onPlayback,
+      phase,
+      playbackLabel,
+      showCursor = true,
+      surface,
+      workspace,
+    },
+    ref,
+  ) {
+    return (
+      <div
+        aria-label={ariaLabel}
+        className={classNames(
+          'a3s-runtime-inspector',
+          'a3s-tui-player',
+          isPlaying && 'is-running',
+          className,
+        )}
+        data-a3s-code-tui={surface}
+        data-phase={phase}
+        ref={ref}
+      >
+        <header className="a3s-tui-titlebar" data-tui-region="titlebar">
+          <span className="a3s-tui-window-dots" aria-hidden="true">
+            <i />
+            <i />
+            <i />
+          </span>
+          <div className="a3s-tui-title">
+            <b>a3s code</b>
+            <em>{workspace}</em>
+          </div>
+          <button
+            aria-pressed={isPlaying}
+            className={isPlaying ? 'is-playing' : ''}
+            onClick={onPlayback}
+            type="button"
+          >
+            <i aria-hidden="true" />
+            {playbackLabel}
+          </button>
+        </header>
+
+        <section className="a3s-tui-terminal" data-tui-region="terminal">
+          {children}
+        </section>
+
+        <section
+          className="a3s-tui-composer"
+          data-input-mode={composerMode}
+          data-tui-region="composer"
+        >
+          <div className="a3s-tui-activity" aria-live="polite">
+            {activity}
+          </div>
+          {beforeInput}
+          <div className="a3s-tui-effort-rule">
+            <span>{composerStatus}</span>
+          </div>
+          <div className="a3s-tui-input">
+            <span aria-hidden="true">{composerSymbol}</span>
+            <p>
+              {composerText}
+              {showCursor ? <i aria-hidden="true" /> : null}
+            </p>
+          </div>
+          <div className="a3s-tui-input-rule" />
+          <footer className="a3s-tui-footer" data-tui-region="footer">
+            <span className="a3s-tui-mode">
+              <i aria-hidden="true">●</i>
+              {modeLabel}
+            </span>
+            <span className="a3s-tui-context">
+              {contextLabel}
+              <i aria-hidden="true">
+                <b />
+              </i>
+            </span>
+            <span className="a3s-tui-identity">
+              <b>{identity}</b>
+              <em>{branch}</em>
+              <em>{model}</em>
+            </span>
+          </footer>
+          {afterFooter}
+        </section>
+      </div>
+    );
+  },
+);

--- a/website/theme/components/CapabilityShowcase.tsx
+++ b/website/theme/components/CapabilityShowcase.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { A3sCodeTui } from './A3sCodeTui';
 
 type Locale = 'zh' | 'en';
 
@@ -16,6 +17,7 @@ type CapabilityStory = {
   eyebrow: string;
   title: Localized;
   body: Localized;
+  prompt: Localized;
   availability: Localized;
   tags: string[];
   stages: Localized[];
@@ -33,6 +35,10 @@ const sectionCopy = {
     pause: '暂停',
     replay: '重播',
     step: '阶段',
+    working: '正在执行能力流程',
+    mode: 'Default',
+    context: 'ctx:12%',
+    workspace: '~/workspace/a3s',
   },
   en: {
     eyebrow: 'A3S CODE / DISTINCTIVE CAPABILITIES',
@@ -45,6 +51,10 @@ const sectionCopy = {
     pause: 'Pause',
     replay: 'Replay',
     step: 'Stage',
+    working: 'Running capability flow',
+    mode: 'Default',
+    context: 'ctx:12%',
+    workspace: '~/workspace/a3s',
   },
 };
 
@@ -60,6 +70,10 @@ export const capabilityStories: CapabilityStory[] = [
     body: {
       zh: '需要确认的调用会在执行前暂停，并展示规范化参数。你可以只允许一次、保留精确的会话或项目授权，或者拒绝并说明原因。',
       en: 'Calls that need confirmation pause before execution and expose canonical arguments. Allow once, retain an exact session or project grant, or deny with a reason.',
+    },
+    prompt: {
+      zh: '测试通过后，将 main 分支推送到 origin',
+      en: 'Push main to origin after the tests pass',
     },
     availability: {
       zh: 'Default 模式 · 风险感知',
@@ -85,6 +99,10 @@ export const capabilityStories: CapabilityStory[] = [
       zh: '登录 A3S OS 后，通过一个按权限过滤的入口执行 list → search → describe → execute。模型无需把整个平台手册塞进上下文。',
       en: 'After A3S OS login, one permission-filtered endpoint runs list → search → describe → execute. The model never needs the whole platform manual in context.',
     },
+    prompt: {
+      zh: '部署发布知识包，并打开运行视图',
+      en: 'Deploy the release knowledge package and open its run view',
+    },
     availability: {
       zh: '登录后可用 · 权限过滤',
       en: 'Available after login · permission-filtered',
@@ -108,6 +126,10 @@ export const capabilityStories: CapabilityStory[] = [
     body: {
       zh: '登录后注册的 runtime 工具按 UUID 或名称解析 tool-kind Worker，提交 Function as a Service 批任务，流式呈现进度并聚合结果。',
       en: 'The login-gated runtime tool resolves a tool-kind worker by UUID or name, submits a Function-as-a-Service batch, streams progress, and aggregates results.',
+    },
+    prompt: {
+      zh: '并行检查 core、Node 和 Python 发布包',
+      en: 'Check the core, Node, and Python releases in parallel',
     },
     availability: {
       zh: '登录后注册 · 批量执行',
@@ -133,6 +155,10 @@ export const capabilityStories: CapabilityStory[] = [
       zh: '基于已保存文件提供符号、定义、声明、引用、实现与诊断。Agent 工具、/ide 和 Monaco 使用同一运行时，脏缓冲区不会伪装成已发布语义。',
       en: 'Saved files provide symbols, definitions, declarations, references, implementations, and diagnostics. Agent tools, /ide, and Monaco share the runtime; dirty buffers never masquerade as published semantics.',
     },
+    prompt: {
+      zh: '查找 RuntimeTool 的引用并汇总诊断',
+      en: 'Find RuntimeTool references and collect diagnostics',
+    },
     availability: {
       zh: 'Rust · TypeScript / JavaScript',
       en: 'Rust · TypeScript / JavaScript',
@@ -156,6 +182,10 @@ export const capabilityStories: CapabilityStory[] = [
     body: {
       zh: '本地 ctx 可用时，/ctx 会搜索跨工具、跨会话的索引。命中窗口可以一次性附加到下一条消息，也可以携带来源保存为长期记忆。',
       en: 'When the local ctx index is available, /ctx searches across tools and sessions. A hit can be attached once to the next turn or saved to long-term memory with provenance.',
+    },
+    prompt: {
+      zh: '/ctx RemoteUI view link',
+      en: '/ctx RemoteUI view link',
     },
     availability: {
       zh: '本地索引 · 跨会话 · 可追溯',
@@ -229,19 +259,27 @@ function StageRail({
   story: CapabilityStory;
 }) {
   return (
-    <ol className="a3s-capability-stage-rail">
-      {story.stages.map((item, index) => (
-        <li
-          className={
-            index < stage ? 'is-complete' : index === stage ? 'is-active' : ''
-          }
-          key={item.en}
-        >
-          <i aria-hidden="true">{index < stage ? '✓' : index + 1}</i>
-          <span>{value(item, locale)}</span>
-        </li>
-      ))}
-    </ol>
+    <section
+      aria-label={`${sectionCopy[locale].step} ${stage + 1} / 4`}
+      className="a3s-tui-plan a3s-capability-tui-plan"
+    >
+      <ol>
+        {story.stages.map((item, index) => {
+          const status =
+            index < stage ? 'done' : index === stage ? 'active' : 'pending';
+          const glyph =
+            status === 'done' ? '✔' : status === 'active' ? '◼' : '◻';
+
+          return (
+            <li className={`is-${status}`} key={item.en}>
+              <span aria-hidden="true">{index === 0 ? '⎿' : ''}</span>
+              <i aria-hidden="true">{glyph}</i>
+              <p>{value(item, locale)}</p>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
   );
 }
 
@@ -772,32 +810,38 @@ export function CapabilityShowcase({
           ))}
         </nav>
 
-        <div className="a3s-capability-player">
-          <header className="a3s-capability-player-bar">
-            <span>
-              <i />
-              <i />
-              <i />
-            </span>
-            <p>
-              <b>{labels.live}</b>
-              <small>
-                {story.index} / {story.eyebrow}
-              </small>
-            </p>
-            <button onClick={togglePlayback} type="button">
-              <i
-                className={isPlaying ? 'is-pause' : 'is-play'}
-                aria-hidden="true"
-              />
-              {isPlaying
-                ? labels.pause
-                : stage === 3
-                  ? labels.replay
-                  : labels.play}
-            </button>
-          </header>
-
+        <A3sCodeTui
+          activity={
+            isPlaying && isVisible ? (
+              <>
+                <i aria-hidden="true">✶</i>
+                <span>{labels.working}</span>
+                <small>
+                  ({labels.step} {String(stage + 1).padStart(2, '0')} / 04)
+                </small>
+              </>
+            ) : undefined
+          }
+          ariaLabel={`${story.eyebrow}: ${value(story.title, locale)}`}
+          beforeInput={
+            <StageRail locale={locale} stage={stage} story={story} />
+          }
+          className={`a3s-capability-player is-${story.key}`}
+          composerStatus="◇ high"
+          composerText={value(story.prompt, locale)}
+          contextLabel={labels.context}
+          isPlaying={isPlaying && isVisible}
+          modeLabel={labels.mode}
+          onPlayback={togglePlayback}
+          phase={`${story.key}-${stage + 1}`}
+          playbackLabel={
+            isPlaying ? labels.pause : stage === 3 ? labels.replay : labels.play
+          }
+          ref={hostRef}
+          showCursor={!reducedMotion}
+          surface={`capability-${story.key}`}
+          workspace={labels.workspace}
+        >
           <div className="a3s-capability-player-intro">
             <div>
               <span>{story.eyebrow}</span>
@@ -810,24 +854,27 @@ export function CapabilityShowcase({
             </small>
           </div>
 
-          <div className="a3s-capability-player-stage" key={story.key}>
-            <StageRail locale={locale} stage={stage} story={story} />
+          <p className="a3s-tui-meta a3s-capability-tui-meta">
+            <span>{labels.live}</span>
+            <i>·</i>
+            <span>{story.index} / 05</span>
+            {story.tags.map((tag) => (
+              <span className="a3s-capability-tui-tag" key={tag}>
+                <i>·</i>
+                {tag}
+              </span>
+            ))}
+          </p>
+
+          <div
+            className="a3s-tui-transcript a3s-capability-player-stage"
+            key={story.key}
+          >
             <div className="a3s-capability-scene-wrap">
               <CapabilityScene locale={locale} stage={stage} story={story} />
             </div>
           </div>
-
-          <footer className="a3s-capability-player-footer">
-            <span>
-              {labels.step} {String(stage + 1).padStart(2, '0')} / 04
-            </span>
-            <div>
-              {story.tags.map((tag) => (
-                <code key={tag}>{tag}</code>
-              ))}
-            </div>
-          </footer>
-        </div>
+        </A3sCodeTui>
       </div>
     </section>
   );

--- a/website/theme/components/TuiRuntimeDemo.tsx
+++ b/website/theme/components/TuiRuntimeDemo.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { A3sCodeTui, type A3sCodeTuiInputMode } from './A3sCodeTui';
 import type { HomeLabels } from './home-copy';
 
 const tuiDemoPhases = [
@@ -37,7 +38,6 @@ const tuiDemoIndex = {
   remoteui: tuiDemoPhases.indexOf('remoteui'),
   answer: tuiDemoPhases.indexOf('answer'),
 } as const;
-type TuiComposerMode = 'default' | 'shell' | 'research';
 type TuiDemoStatus = 'pending' | 'active' | 'done';
 const tuiDemoStatusGlyph: Record<TuiDemoStatus, string> = {
   pending: '◻',
@@ -116,7 +116,7 @@ export function RuntimeExecutionFlow({ labels }: { labels: HomeLabels }) {
   const composerDemos: Partial<
     Record<
       TuiDemoPhase,
-      { mode: TuiComposerMode; symbol: string; text: string }
+      { mode: A3sCodeTuiInputMode; symbol: string; text: string }
     >
   > = {
     slash: { mode: 'default', symbol: '❯', text: labels.tuiSlashInput },
@@ -320,224 +320,18 @@ export function RuntimeExecutionFlow({ labels }: { labels: HomeLabels }) {
   }
 
   return (
-    <div
-      className={[
-        'a3s-runtime-inspector',
-        'a3s-tui-player',
-        isRunning ? 'is-running' : '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      data-phase={active}
-      aria-label={labels.architectureAlt}
-      ref={playerRef}
-    >
-      <header className="a3s-tui-titlebar">
-        <span className="a3s-tui-window-dots" aria-hidden="true">
-          <i />
-          <i />
-          <i />
-        </span>
-        <div className="a3s-tui-title">
-          <b>a3s code</b>
-          <em>{labels.tuiWorkspace}</em>
-        </div>
-        <button
-          className={isRunning ? 'is-playing' : ''}
-          onClick={playFlow}
-          type="button"
-        >
-          <i aria-hidden="true" />
-          {prefersReducedMotion && !isRunning
-            ? labels.flowPlayOnce
-            : labels.flowReplay}
-        </button>
-      </header>
-
-      <section className="a3s-tui-terminal">
-        <div className="a3s-tui-welcome" aria-label="A3S Code">
-          <pre aria-hidden="true" className="a3s-tui-mascot">
-            {tuiMascot}
-          </pre>
-          <TuiWordmark />
-        </div>
-        <p className="a3s-tui-meta">
-          <span>a3s-code v6.6.0</span>
-          <i>·</i>
-          <span>openai/gpt-5</span>
-          <i>·</i>
-          <span>12 skills</span>
-          <i>·</i>
-          <span>{labels.tuiWorkspace}</span>
-        </p>
-        <p className="a3s-tui-tip">{labels.tuiTip}</p>
-
-        <div className="a3s-tui-transcript" aria-live="off">
-          {activeIndex > tuiDemoIndex.compose ? (
-            <article className="a3s-tui-entry a3s-tui-entry--user">
-              <span aria-hidden="true">›</span>
-              <div>
-                <small>{labels.tuiUser}</small>
-                <p>{labels.flowTask}</p>
-              </div>
-            </article>
-          ) : null}
-
-          {activeIndex >= tuiDemoIndex.artifact ? (
-            <article
-              className={[
-                'a3s-tui-artifact',
-                artifactIsPublished ? 'is-published' : 'is-publishing',
-                remoteUiIsReady ? 'is-ready' : '',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-            >
-              <div className="a3s-tui-artifact-meta">
-                <header>
-                  <span aria-hidden="true">◇</span>
-                  <strong>{labels.tuiArtifact}</strong>
-                  <small>
-                    {artifactIsPublished
-                      ? labels.tuiArtifactReady
-                      : labels.tuiArtifactWriting}
-                  </small>
-                </header>
-                <code>{labels.tuiArtifactPath}</code>
-                <span
-                  className={[
-                    'a3s-tui-open-view',
-                    activeIndex === tuiDemoIndex.remoteui ? 'is-opening' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  <i aria-hidden="true">↗</i>
-                  {artifactIsPublished
-                    ? labels.tuiOpenView
-                    : labels.tuiArtifactWriting}
-                  {artifactIsPublished ? <b>{labels.tuiRemoteUi}</b> : null}
-                </span>
-              </div>
-              <div
-                className={[
-                  'a3s-tui-remote-view',
-                  !artifactIsPublished
-                    ? 'is-preparing'
-                    : remoteUiIsReady
-                      ? 'is-ready'
-                      : 'is-streaming',
-                ].join(' ')}
-              >
-                <header>
-                  <span aria-hidden="true">●</span>
-                  <b>{labels.tuiRemoteUi}</b>
-                  <small>
-                    {!artifactIsPublished
-                      ? labels.tuiRemotePreparing
-                      : remoteUiIsReady
-                        ? labels.tuiRemoteReady
-                        : labels.tuiRemoteStreaming}
-                  </small>
-                </header>
-                <div>
-                  <strong>{labels.tuiReportTitle}</strong>
-                  <small>
-                    {remoteUiIsReady ? labels.tuiReportSummary : '···'}
-                  </small>
-                  <span aria-hidden="true">
-                    <i />
-                    <i />
-                    <i />
-                  </span>
-                </div>
-              </div>
-            </article>
-          ) : null}
-
-          {activeIndex >= tuiDemoIndex.answer ? (
-            <article className="a3s-tui-entry a3s-tui-entry--assistant">
-              <span aria-hidden="true">•</span>
-              <div>
-                <strong>{labels.tuiAssistant}</strong>
-                <p>{labels.tuiResponse}</p>
-              </div>
-            </article>
-          ) : null}
-
-          {inputMenuIsOpen ? (
-            <div
-              aria-hidden="true"
-              className={`a3s-tui-input-menu is-${active}`}
-            >
-              {active === 'mention' ? (
-                <strong>{labels.tuiFilePicker}</strong>
-              ) : null}
-              <ul>
-                {inputMenuItems.map(([label, detail], index) => (
-                  <li className={index === 0 ? 'is-selected' : ''} key={label}>
-                    <code>{label}</code>
-                    <span>{detail}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="a3s-tui-composer" data-input-mode={composerMode}>
-        <div className="a3s-tui-activity" aria-live="polite">
-          {isWorking ? (
-            <>
-              <i aria-hidden="true">✶</i>
-              <span>{labels.tuiWorking}</span>
-              <small>(00:04 · ↓ 1.2k tokens)</small>
-            </>
-          ) : null}
-        </div>
-        {activeIndex >= tuiDemoIndex.plan ? (
-          <section className="a3s-tui-plan" aria-label={labels.tuiPlan}>
-            <ol>
-              {planItems.map((item, index) => (
-                <li className={`is-${item.status}`} key={item.label}>
-                  <span aria-hidden="true">{index === 0 ? '⎿' : ''}</span>
-                  <i aria-hidden="true">{tuiDemoStatusGlyph[item.status]}</i>
-                  <p>{item.label}</p>
-                </li>
-              ))}
-            </ol>
-          </section>
-        ) : null}
-        <div className="a3s-tui-effort-rule">
-          <span>{composerStatus}</span>
-        </div>
-        <div className="a3s-tui-input">
-          <span aria-hidden="true">{composerSymbol}</span>
-          <p>
-            {typedComposerText}
-            <i aria-hidden="true" />
-          </p>
-        </div>
-        <div className="a3s-tui-input-rule" />
-        <footer className="a3s-tui-footer">
-          <span className="a3s-tui-mode">
-            <i aria-hidden="true">●</i>
-            {labels.tuiMode}
-          </span>
-          <span className="a3s-tui-context">
-            {labels.tuiContext}
-            <i aria-hidden="true">
-              <b />
-            </i>
-          </span>
-          <span className="a3s-tui-identity">
-            <b>a3s</b>
-            <em>git:(main)</em>
-            <em>gpt-5 (128k context)</em>
-          </span>
-        </footer>
-        {visibleSubagents.length > 0 ? (
+    <A3sCodeTui
+      activity={
+        isWorking ? (
+          <>
+            <i aria-hidden="true">✶</i>
+            <span>{labels.tuiWorking}</span>
+            <small>(00:04 · ↓ 1.2k tokens)</small>
+          </>
+        ) : undefined
+      }
+      afterFooter={
+        visibleSubagents.length > 0 ? (
           <section className="a3s-tui-agents" aria-label={labels.tuiSubagents}>
             <header>
               <span aria-hidden="true">•</span>
@@ -558,8 +352,169 @@ export function RuntimeExecutionFlow({ labels }: { labels: HomeLabels }) {
               ))}
             </div>
           </section>
+        ) : undefined
+      }
+      ariaLabel={labels.architectureAlt}
+      beforeInput={
+        activeIndex >= tuiDemoIndex.plan ? (
+          <section className="a3s-tui-plan" aria-label={labels.tuiPlan}>
+            <ol>
+              {planItems.map((item, index) => (
+                <li className={`is-${item.status}`} key={item.label}>
+                  <span aria-hidden="true">{index === 0 ? '⎿' : ''}</span>
+                  <i aria-hidden="true">{tuiDemoStatusGlyph[item.status]}</i>
+                  <p>{item.label}</p>
+                </li>
+              ))}
+            </ol>
+          </section>
+        ) : undefined
+      }
+      composerMode={composerMode}
+      composerStatus={composerStatus}
+      composerSymbol={composerSymbol}
+      composerText={typedComposerText}
+      contextLabel={labels.tuiContext}
+      isPlaying={isRunning}
+      modeLabel={labels.tuiMode}
+      onPlayback={playFlow}
+      phase={active}
+      playbackLabel={
+        prefersReducedMotion && !isRunning
+          ? labels.flowPlayOnce
+          : labels.flowReplay
+      }
+      ref={playerRef}
+      showCursor={!prefersReducedMotion}
+      surface="hero"
+      workspace={labels.tuiWorkspace}
+    >
+      <div className="a3s-tui-welcome" aria-label="A3S Code">
+        <pre aria-hidden="true" className="a3s-tui-mascot">
+          {tuiMascot}
+        </pre>
+        <TuiWordmark />
+      </div>
+      <p className="a3s-tui-meta">
+        <span>a3s-code v6.6.0</span>
+        <i>·</i>
+        <span>openai/gpt-5</span>
+        <i>·</i>
+        <span>12 skills</span>
+        <i>·</i>
+        <span>{labels.tuiWorkspace}</span>
+      </p>
+      <p className="a3s-tui-tip">{labels.tuiTip}</p>
+
+      <div className="a3s-tui-transcript" aria-live="off">
+        {activeIndex > tuiDemoIndex.compose ? (
+          <article className="a3s-tui-entry a3s-tui-entry--user">
+            <span aria-hidden="true">›</span>
+            <div>
+              <small>{labels.tuiUser}</small>
+              <p>{labels.flowTask}</p>
+            </div>
+          </article>
         ) : null}
-      </section>
-    </div>
+
+        {activeIndex >= tuiDemoIndex.artifact ? (
+          <article
+            className={[
+              'a3s-tui-artifact',
+              artifactIsPublished ? 'is-published' : 'is-publishing',
+              remoteUiIsReady ? 'is-ready' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <div className="a3s-tui-artifact-meta">
+              <header>
+                <span aria-hidden="true">◇</span>
+                <strong>{labels.tuiArtifact}</strong>
+                <small>
+                  {artifactIsPublished
+                    ? labels.tuiArtifactReady
+                    : labels.tuiArtifactWriting}
+                </small>
+              </header>
+              <code>{labels.tuiArtifactPath}</code>
+              <span
+                className={[
+                  'a3s-tui-open-view',
+                  activeIndex === tuiDemoIndex.remoteui ? 'is-opening' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <i aria-hidden="true">↗</i>
+                {artifactIsPublished
+                  ? labels.tuiOpenView
+                  : labels.tuiArtifactWriting}
+                {artifactIsPublished ? <b>{labels.tuiRemoteUi}</b> : null}
+              </span>
+            </div>
+            <div
+              className={[
+                'a3s-tui-remote-view',
+                !artifactIsPublished
+                  ? 'is-preparing'
+                  : remoteUiIsReady
+                    ? 'is-ready'
+                    : 'is-streaming',
+              ].join(' ')}
+            >
+              <header>
+                <span aria-hidden="true">●</span>
+                <b>{labels.tuiRemoteUi}</b>
+                <small>
+                  {!artifactIsPublished
+                    ? labels.tuiRemotePreparing
+                    : remoteUiIsReady
+                      ? labels.tuiRemoteReady
+                      : labels.tuiRemoteStreaming}
+                </small>
+              </header>
+              <div>
+                <strong>{labels.tuiReportTitle}</strong>
+                <small>
+                  {remoteUiIsReady ? labels.tuiReportSummary : '···'}
+                </small>
+                <span aria-hidden="true">
+                  <i />
+                  <i />
+                  <i />
+                </span>
+              </div>
+            </div>
+          </article>
+        ) : null}
+
+        {activeIndex >= tuiDemoIndex.answer ? (
+          <article className="a3s-tui-entry a3s-tui-entry--assistant">
+            <span aria-hidden="true">•</span>
+            <div>
+              <strong>{labels.tuiAssistant}</strong>
+              <p>{labels.tuiResponse}</p>
+            </div>
+          </article>
+        ) : null}
+
+        {inputMenuIsOpen ? (
+          <div aria-hidden="true" className={`a3s-tui-input-menu is-${active}`}>
+            {active === 'mention' ? (
+              <strong>{labels.tuiFilePicker}</strong>
+            ) : null}
+            <ul>
+              {inputMenuItems.map(([label, detail], index) => (
+                <li className={index === 0 ? 'is-selected' : ''} key={label}>
+                  <code>{label}</code>
+                  <span>{detail}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </A3sCodeTui>
   );
 }


### PR DESCRIPTION
## Summary
- extract the production A3S Code TUI shell shared by the hero and capability player
- render all five capability animations inside the same titlebar, terminal, composer, and footer
- remove the parallel dashboard-style player chrome and add a built-site TUI contract

## Validation
- npm run lint
- npm run build
- npm run check:site
- npm run format:check
- desktop zh/en visual QA
- 375px mobile visual QA with zero horizontal overflow
- reduced-motion QA with zero running animations