### PR TITLE
fix(core): default browser fallback to Chrome

### DIFF
--- a/.github/setup-workspace.sh
+++ b/.github/setup-workspace.sh
@@ -15,7 +15,7 @@ sed -i.bak \
   -e 's|a3s-memory = { version = "0.1.1", path = "../../memory" }|a3s-memory = "0.1.1"|' \
   -e 's|a3s-lane = { version = "0.5", path = "../../lane" }|a3s-lane = "0.5"|' \
   -e 's|a3s-lane = { version = "0.4", path = "../../lane" }|a3s-lane = "0.4"|' \
-  -e 's|a3s-search = { version = "2.1.0", path = "../../search", default-features = false }|a3s-search = { version = "2.1.0", default-features = false }|' \
+  -e 's|a3s-search = { version = "2.1.2", path = "../../search", default-features = false }|a3s-search = { version = "2.1.2", default-features = false }|' \
   -e 's|a3s-search = { version = "2.1.0", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "2.1.0", default-features = false, features = ["lightpanda"] }|' \
   -e 's|a3s-search = { version = "1.4.3", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "1.4.3", default-features = false, features = ["lightpanda"] }|' \
   -e 's|a3s-search = { version = "1.3.0", path = "../../search", default-features = false, features = \["lightpanda"\] }|a3s-search = { version = "1.3.0", default-features = false, features = ["lightpanda"] }|' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          default_tree="$(cargo tree -p a3s-code-core --no-default-features -e normal)"
-          if grep -q 'chromiumoxide' <<<"$default_tree"; then
-            echo "default Core must not compile the browser/CDP dependency stack" >&2
+          minimal_tree="$(cargo tree -p a3s-code-core --no-default-features -e normal)"
+          if grep -q 'chromiumoxide' <<<"$minimal_tree"; then
+            echo "minimal Core must not compile the browser/CDP dependency stack" >&2
             exit 1
           fi
+          default_tree="$(cargo tree -p a3s-code-core -e normal)"
+          grep -q 'chromiumoxide' <<<"$default_tree"
           headless_tree="$(cargo tree -p a3s-code-core --no-default-features --features headless-search -e normal)"
           grep -q 'chromiumoxide' <<<"$headless_tree"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Made browser-backed Google/Baidu search and the managed browser lifecycle API
-  opt-in behind the `headless-search` Cargo feature. Default Core embeddings
-  retain native API and HTTP/RSS `web_search` without compiling
-  `a3s-use-browser` or `chromiumoxide`; the Node and Python products explicitly
-  enable the feature to preserve their existing search surface.
+- Enabled the lazy browser-backed Google/Baidu tier by default with
+  Chrome/Chromium as the cross-platform backend. Native API and HTTP/RSS tiers
+  still run first and stop the cascade when their evidence is sufficient.
+  Minimal Rust embeddings can opt out with `default-features = false`;
+  Lightpanda remains an explicit alternative backend.
+- Made `web_search` fail closed when the completed cascade remains below its
+  generic quality floor. Successful JSON responses retain the existing array
+  contract; insufficient responses carry a typed diagnostic envelope, and
+  result rows expose their query-alignment score.
+- Shared search bulkheads, browser retry budgets, and identical-request
+  coalescing across delegated research contexts. Request-scoped proxies now
+  reach the lazy browser tier, and coalescing diagnostics are included in tool
+  metadata.
 
 ## [6.6.0] - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ background service share the same execution semantics without sharing a UI.
 
 ## Capability map
 
-The Core crate has no default Cargo features. Baseline behavior stays small;
-browser-backed search, cloud backends, serving, and telemetry are opt-in.
+The Core crate enables lazy Chrome/Chromium-backed search by default. Minimal
+embeddings can use `default-features = false`; cloud backends, serving, and
+telemetry remain opt-in.
 
 | Area | What is available | Activation |
 | --- | --- | --- |
@@ -131,7 +132,7 @@ browser-backed search, cloud backends, serving, and telemetry are opt-in.
 | Persistence | Atomic snapshots, run events, traces, artifacts, verification, checkpoints, and optional RL trajectories | Configured store and host policy |
 | State graph | Hash-linked events, typed objects and relations, optimistic patches, strict replay, forks, diffs, and Flow projection | Explicit application use |
 | Agent release contract | Bounded `.a3s/asset.acl` admission, canonical identity, provenance binding, and compatibility checks | Baseline admission API |
-| Headless web search | Browser-backed Google/Baidu engines and managed browser lifecycle APIs | Cargo feature `headless-search` |
+| Headless web search | Lazy Chrome/Chromium-backed Google/Baidu engines and managed browser lifecycle APIs; Lightpanda remains configurable | Default Cargo feature `headless-search`; disable with `default-features = false` |
 | S3 workspace | S3-compatible object backend | Cargo feature `s3` |
 | Filesystem agent server | Agent-directory serving and cron schedules | Cargo feature `serve` |
 | OpenTelemetry | OTLP export in addition to baseline `tracing` | Cargo feature `telemetry` |
@@ -211,7 +212,7 @@ the model.
 | Files and directories | Budgeted single/multi-file `read`, `write`, previewable CAS `edit`, `patch`, `ls`, order-selectable paginated `glob`, and mode-selectable `grep` |
 | Commands and source control | Bounded `bash` plus typed `git` operations, cancellation, and Unix process-group termination |
 | Code intelligence | `code_symbols`, `code_navigation`, and `code_diagnostics`; source reading and mutation remain in file tools |
-| Web evidence | Quality-gated native API → HTTP/RSS `web_search` with session circuits, plus bounded `web_fetch`, source normalization, and SSRF protections; the optional `headless-search` feature adds a lazy Google/Baidu tier |
+| Web evidence | Fail-closed native API → HTTP/RSS → lazy Chrome/Chromium `web_search` with quality gates, shared admission, circuits, and request coalescing; plus bounded `web_fetch`, source normalization, and SSRF protections |
 | Downloads | Workspace-confined binary `download` with strict range validation, bounded parallelism, retries, checksums, and atomic publication |
 | Composition | Safe `batch`, sandboxed QuickJS `program`, structured `generate_object`, `task`, and `parallel_task` |
 | Extensibility | `Skill`, `search_skills`, namespaced `mcp__<server>__<tool>`, and explicit `dynamic_workflow` |
@@ -383,9 +384,10 @@ go get github.com/A3S-Lab/Code/sdk/go/v6
 
 The native SDK crates explicitly enable the Core `headless-search`, `s3`, and
 `serve` features to preserve their complete product surface. Direct Rust
-embedders receive native API and HTTP/RSS search without a browser dependency
-unless they opt into `headless-search`. The pure-Go package uses the matching
-`a3s-code-go-bridge` release asset and requires no CGO. See the
+embedders receive the lazy Chrome/Chromium search tier by default and can omit
+the browser dependency stack with `default-features = false`. The pure-Go
+package uses the matching `a3s-code-go-bridge` release asset and requires no
+CGO. See the
 [Node.js](sdk/node/README.md), [Python](sdk/python/README.md), and
 [Go](sdk/go/README.md) guides for surface-specific examples and intentional API
 differences.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 a3s-common = { version = "0.1.1", path = "../../common" }
 a3s-memory = { version = "0.1.2", path = "../../memory" }
 a3s-lane = { version = "0.5", path = "../../lane" }
-a3s-search = { version = "2.1.0", path = "../../search", default-features = false }
+a3s-search = { version = "2.1.2", path = "../../search", default-features = false }
 a3s-flow = "0.4.3"
 
 # Async runtime
@@ -128,9 +128,11 @@ libc = "0.2"
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [features]
-default = []
+default = ["headless-search"]
 # Enable browser-backed Google and Baidu search plus managed browser lifecycle
-# APIs. HTTP/RSS and native API search remain available without this feature.
+# APIs. Chrome/Chromium is the runtime default; Lightpanda remains selectable
+# through configuration. HTTP/RSS and native API search remain available when
+# default features are disabled.
 headless-search = ["a3s-search/lightpanda"]
 # Enable OpenTelemetry OTLP export for traces and metrics.
 # When active, `TelemetryConfig::init()` sets up OTLP exporter + tracing subscriber.

--- a/core/src/config/search.rs
+++ b/core/src/config/search.rs
@@ -31,10 +31,10 @@ pub struct SearchConfig {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum BrowserBackend {
-    /// Chrome/Chromium headless browser.
+    /// Chrome/Chromium headless browser and the cross-platform default.
     #[default]
     Chrome,
-    /// Lightpanda headless browser.
+    /// Explicit Lightpanda backend (native Linux/macOS; WSL2 on Windows).
     Lightpanda,
 }
 

--- a/core/src/tools/builtin/web_search.rs
+++ b/core/src/tools/builtin/web_search.rs
@@ -10,8 +10,8 @@ use crate::tools::types::{Tool, ToolContext, ToolErrorKind, ToolOutput};
 use a3s_search::a3s_use_browser::{BrowserPool, BrowserPoolConfig, BrowserProvider};
 use a3s_search::proxy::ProxyConfig;
 use a3s_search::{
-    EngineFailure, Metrics, MetricsSnapshot, Search, SearchCascade, SearchQualityFloor,
-    SearchQuery, SearchResult, SearchResults,
+    EngineFailure, Metrics, MetricsSnapshot, Search, SearchCascade, SearchCoalescerSnapshot,
+    SearchQualityFloor, SearchQuery, SearchResult, SearchResults,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -81,8 +81,7 @@ impl WebSearchTool {
     /// to one invocation lets the cleanup guard deterministically close it on
     /// success, error, timeout, or caller cancellation.
     #[cfg(feature = "headless-search")]
-    fn create_pool(headless_config: Option<&HeadlessConfig>) -> Option<Arc<BrowserPool>> {
-        let config = headless_config?;
+    fn create_pool(config: &HeadlessConfig) -> Arc<BrowserPool> {
         let executable = config.browser_path.as_ref().map(std::path::PathBuf::from);
         let provider = match (config.backend, executable) {
             (BrowserBackend::Chrome, Some(path)) => BrowserProvider::ChromeExecutable(path),
@@ -99,7 +98,7 @@ impl WebSearchTool {
             launch_args: config.launch_args.clone(),
         };
 
-        Some(Arc::new(BrowserPool::new(pool_config)))
+        Arc::new(BrowserPool::new(pool_config))
     }
 }
 
@@ -168,6 +167,18 @@ fn managed_headless_config() -> Option<HeadlessConfig> {
     })
 }
 
+#[cfg(feature = "headless-search")]
+fn effective_headless_config(
+    configured: Option<&HeadlessConfig>,
+    proxy_url: Option<&str>,
+) -> Option<HeadlessConfig> {
+    let mut config = configured.cloned().or_else(managed_headless_config)?;
+    if let Some(proxy_url) = proxy_url {
+        config.proxy_url = Some(proxy_url.to_string());
+    }
+    Some(config)
+}
+
 fn search_result_json(result: &SearchResult, full_text_bytes: Option<usize>) -> serde_json::Value {
     let engines = sorted_search_engines(result);
     let safe_url = safe_search_result_url(result);
@@ -181,6 +192,7 @@ fn search_result_json(result: &SearchResult, full_text_bytes: Option<usize>) -> 
         "content": safe_content,
         "engines": engines,
         "score": result.score,
+        "query_match_score": result.query_match_score,
         "published_date": result.published_date,
     });
     if let (Some(maximum), Some(full_text)) = (full_text_bytes, result.full_text.as_deref()) {
@@ -208,6 +220,25 @@ fn bounded_json_search_results(
         break;
     }
     bounded
+}
+
+fn json_search_payload(
+    results: Vec<serde_json::Value>,
+    quality_met: bool,
+    quality: &a3s_search::SearchQuality,
+    quality_floor: &SearchQualityFloor,
+) -> serde_json::Value {
+    if quality_met {
+        serde_json::Value::Array(results)
+    } else {
+        serde_json::json!({
+            "status": "quality_not_met",
+            "message": "Search exhausted the available tiers without meeting the generic quality floor; reformulate the query before treating these candidates as evidence.",
+            "search_quality": quality,
+            "search_quality_floor": quality_floor,
+            "results": results,
+        })
+    }
 }
 
 fn safe_search_result_url(result: &SearchResult) -> String {
@@ -307,10 +338,23 @@ fn search_metrics_json(snapshot: &MetricsSnapshot) -> serde_json::Value {
     })
 }
 
+fn search_coalescer_json(snapshot: &SearchCoalescerSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "max_in_flight": snapshot.max_in_flight,
+        "in_flight": snapshot.in_flight,
+        "leader_requests": snapshot.leader_requests,
+        "shared_requests": snapshot.shared_requests,
+        "bypassed_requests": snapshot.bypassed_requests,
+        "abandoned_requests": snapshot.abandoned_requests,
+    })
+}
+
 fn tier_search(ctx: &ToolContext, metrics: Arc<Metrics>) -> Search {
     Search::new()
         .with_metrics(metrics)
         .with_circuit_breaker(ctx.search_circuit_breaker())
+        .with_bulkhead(ctx.search_bulkhead())
+        .with_request_coalescer(ctx.search_request_coalescer())
 }
 
 fn search_error_failure(engine: &str, error: &a3s_search::SearchError) -> EngineFailure {
@@ -678,15 +722,24 @@ impl Tool for WebSearchTool {
                         .with_transient(true),
                     );
                 } else {
-                    let headless_config = config
-                        .and_then(|config| config.headless.clone())
-                        .or_else(managed_headless_config);
-                    match Self::create_pool(headless_config.as_ref()) {
-                        Some(pool) => {
+                    let headless_config = effective_headless_config(
+                        config.and_then(|config| config.headless.as_ref()),
+                        proxy_url.as_deref(),
+                    );
+                    match headless_config {
+                        Some(headless_config) => {
+                            let pool = Self::create_pool(&headless_config);
                             let mut cleanup = BrowserPoolCleanup::new(Some(Arc::clone(&pool)));
                             let mut search = tier_search(ctx, Arc::clone(&search_metrics));
+                            let retry_budget = ctx.search_retry_budget();
                             for shortcut in &tier_plan.headless {
-                                if !add_headless_engine(&mut search, shortcut, &pool) {
+                                if !add_headless_engine(
+                                    &mut search,
+                                    shortcut,
+                                    &pool,
+                                    headless_config.backend,
+                                    &retry_budget,
+                                ) {
                                     results.add_failure(EngineFailure::new(
                                         shortcut,
                                         "unsupported_engine",
@@ -751,6 +804,7 @@ impl Tool for WebSearchTool {
         });
         let metrics = search_metrics.snapshot().await;
         let metrics_json = search_metrics_json(&metrics);
+        let coalescer_json = search_coalescer_json(&ctx.search_request_coalescer().snapshot());
 
         let items = search_results.items();
         let results: Vec<_> = items
@@ -787,7 +841,7 @@ impl Tool for WebSearchTool {
 
         if results.is_empty() {
             let metadata = serde_json::json!({
-                "status": if errors.is_empty() { "complete" } else { "failed" },
+                "status": if quality_met && errors.is_empty() { "complete" } else { "failed" },
                 "engine_selection_source": engine_selection_source,
                 "selected_engines": &selected_engines,
                 "engine_fallback": (tier_reports.len() > 1).then_some("quality_gated_tiers"),
@@ -798,6 +852,7 @@ impl Tool for WebSearchTool {
                 "search_tiers": &tier_reports,
                 "engine_outcomes": outcome_metadata(search_results.outcomes()),
                 "search_metrics": metrics_json,
+                "search_coalescing": coalescer_json,
                 "engine_errors": engine_errors,
                 "engine_failures": engine_failures,
             });
@@ -805,7 +860,7 @@ impl Tool for WebSearchTool {
                 "No results found for query: \"{}\"{}{}",
                 query_str, notice_note, error_note
             );
-            if errors.is_empty() {
+            if quality_met && errors.is_empty() {
                 return Ok(ToolOutput::success(message).with_metadata(metadata));
             }
             let mut output = ToolOutput::error(message).with_metadata(metadata);
@@ -832,7 +887,13 @@ impl Tool for WebSearchTool {
                 .map(str::to_string)
                 .collect::<Vec<_>>();
             (
-                serde_json::to_string_pretty(&json_results).unwrap_or_default(),
+                serde_json::to_string_pretty(&json_search_payload(
+                    json_results,
+                    quality_met,
+                    &final_quality,
+                    &quality_floor,
+                ))
+                .unwrap_or_default(),
                 source_anchors,
                 returned_result_count,
             )
@@ -860,9 +921,14 @@ impl Tool for WebSearchTool {
             (text, source_anchors, results.len())
         };
 
+        let tool_output = if quality_met {
+            ToolOutput::success(output)
+        } else {
+            ToolOutput::error(output)
+        };
         Ok(
-            ToolOutput::success(output).with_metadata(serde_json::json!({
-                "status": if errors.is_empty() { "complete" } else { "partial" },
+            tool_output.with_metadata(serde_json::json!({
+                "status": if !quality_met { "failed" } else if errors.is_empty() { "complete" } else { "partial" },
                 "engine_selection_source": engine_selection_source,
                 "selected_engines": &selected_engines,
                 "source_anchors": source_anchors,
@@ -874,6 +940,7 @@ impl Tool for WebSearchTool {
                 "search_tiers": &tier_reports,
                 "engine_outcomes": outcome_metadata(search_results.outcomes()),
                 "search_metrics": metrics_json,
+                "search_coalescing": coalescer_json,
                 "engine_errors": engine_errors,
                 "engine_failures": engine_failures,
                 "available_result_count": results.len(),

--- a/core/src/tools/builtin/web_search/engines.rs
+++ b/core/src/tools/builtin/web_search/engines.rs
@@ -1,5 +1,7 @@
 //! Search-engine registry, aliases, and construction.
 
+#[cfg(feature = "headless-search")]
+use crate::config::BrowserBackend;
 use a3s_search::engines::{
     BingChina, BingParser, BraveParser, DuckDuckGoParser, So360Parser, SogouParser, Wikipedia,
 };
@@ -8,7 +10,7 @@ use a3s_search::providers::BuiltinProvider;
 use a3s_search::{
     a3s_use_browser::BrowserPool,
     engines::{Baidu, Google},
-    BrowserFetcher, WaitStrategy,
+    BrowserFetcher, RetryBudget, WaitStrategy,
 };
 use a3s_search::{EngineFailure, HtmlEngine, HttpFetcher, Search, SearchError};
 use std::sync::Arc;
@@ -159,24 +161,61 @@ pub(super) fn add_headless_engine(
     search: &mut Search,
     shortcut: &str,
     pool: &Arc<BrowserPool>,
+    backend: BrowserBackend,
+    retry_budget: &RetryBudget,
 ) -> bool {
     match canonical_engine_shortcut(shortcut) {
         "g" => {
-            let fetcher = BrowserFetcher::new(Arc::clone(pool)).with_wait(WaitStrategy::Selector {
-                css: "div.g".to_string(),
-                timeout_ms: 5000,
-            });
+            let fetcher = BrowserFetcher::new(Arc::clone(pool))
+                .with_retry_budget(retry_budget.clone())
+                .with_wait(headless_wait_strategy(backend, "div.g"));
             search.add_engine(Google::new(Arc::new(fetcher)));
             true
         }
         "baidu" => {
-            let fetcher = BrowserFetcher::new(Arc::clone(pool)).with_wait(WaitStrategy::Selector {
-                css: "div.c-container".to_string(),
-                timeout_ms: 5000,
-            });
+            let fetcher = BrowserFetcher::new(Arc::clone(pool))
+                .with_retry_budget(retry_budget.clone())
+                .with_wait(headless_wait_strategy(backend, "div.c-container"));
             search.add_engine(Baidu::new(Arc::new(fetcher)));
             true
         }
         _ => false,
+    }
+}
+
+#[cfg(feature = "headless-search")]
+fn headless_wait_strategy(backend: BrowserBackend, selector: &str) -> WaitStrategy {
+    if backend.is_lightpanda() {
+        WaitStrategy::Load
+    } else {
+        WaitStrategy::Selector {
+            css: selector.to_string(),
+            timeout_ms: 5000,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "headless-search"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrome_keeps_selector_waits() {
+        let wait = headless_wait_strategy(BrowserBackend::Chrome, "main.result");
+        assert!(matches!(
+            wait,
+            WaitStrategy::Selector {
+                css,
+                timeout_ms: 5000
+            } if css == "main.result"
+        ));
+    }
+
+    #[test]
+    fn lightpanda_uses_supported_load_wait() {
+        assert!(matches!(
+            headless_wait_strategy(BrowserBackend::Lightpanda, "main.result"),
+            WaitStrategy::Load
+        ));
     }
 }

--- a/core/src/tools/builtin/web_search/tests.rs
+++ b/core/src/tools/builtin/web_search/tests.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 #[tokio::test]
 async fn headless_browser_pool_is_scoped_to_one_tool_execution() {
     let config = HeadlessConfig::default();
-    let first = WebSearchTool::create_pool(Some(&config)).expect("first pool");
-    let second = WebSearchTool::create_pool(Some(&config)).expect("second pool");
+    let first = WebSearchTool::create_pool(&config);
+    let second = WebSearchTool::create_pool(&config);
 
     assert!(
         !Arc::ptr_eq(&first, &second),
@@ -22,7 +22,7 @@ async fn headless_browser_pool_is_scoped_to_one_tool_execution() {
 #[tokio::test]
 async fn dropped_cleanup_guard_schedules_background_shutdown() {
     let config = HeadlessConfig::default();
-    let pool = WebSearchTool::create_pool(Some(&config)).expect("pool");
+    let pool = WebSearchTool::create_pool(&config);
     drop(BrowserPoolCleanup::new(Some(Arc::clone(&pool))));
 
     tokio::task::yield_now().await;
@@ -30,6 +30,31 @@ async fn dropped_cleanup_guard_schedules_background_shutdown() {
     assert!(
         error.message.contains("shut down"),
         "dropping a cancelled tool future must schedule pool shutdown: {error:?}"
+    );
+}
+
+#[cfg(feature = "headless-search")]
+#[test]
+fn default_headless_backend_is_cross_platform_chrome() {
+    assert_eq!(HeadlessConfig::default().backend, BrowserBackend::Chrome);
+}
+
+#[cfg(feature = "headless-search")]
+#[test]
+fn request_proxy_is_applied_to_the_headless_tier() {
+    let configured = HeadlessConfig {
+        proxy_url: Some("http://configured.example:8080".to_string()),
+        ..HeadlessConfig::default()
+    };
+
+    let effective =
+        effective_headless_config(Some(&configured), Some("socks5://request.example:1080"))
+            .expect("configured headless runtime");
+
+    assert_eq!(effective.backend, BrowserBackend::Chrome);
+    assert_eq!(
+        effective.proxy_url.as_deref(),
+        Some("socks5://request.example:1080")
     );
 }
 
@@ -51,6 +76,77 @@ fn latest_search_metrics_are_exposed_as_stable_metadata() {
     assert_eq!(metadata["transient_failure_rate"], 100.0);
     assert_eq!(metadata["error_counts"]["timeout"], 1);
     assert_eq!(metadata["latency_p99_ms"], 30);
+}
+
+#[test]
+fn latest_request_coalescing_state_is_exposed_as_stable_metadata() {
+    let mut snapshot = a3s_search::SearchCoalescerSnapshot::default();
+    snapshot.max_in_flight = 128;
+    snapshot.in_flight = 2;
+    snapshot.leader_requests = 7;
+    snapshot.shared_requests = 5;
+    snapshot.bypassed_requests = 1;
+    snapshot.abandoned_requests = 1;
+
+    let metadata = search_coalescer_json(&snapshot);
+
+    assert_eq!(metadata["max_in_flight"], 128);
+    assert_eq!(metadata["in_flight"], 2);
+    assert_eq!(metadata["leader_requests"], 7);
+    assert_eq!(metadata["shared_requests"], 5);
+    assert_eq!(metadata["bypassed_requests"], 1);
+    assert_eq!(metadata["abandoned_requests"], 1);
+}
+
+struct CoalescingProbeEngine {
+    config: a3s_search::EngineConfig,
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl a3s_search::Engine for CoalescingProbeEngine {
+    fn config(&self) -> &a3s_search::EngineConfig {
+        &self.config
+    }
+
+    async fn search(
+        &self,
+        query: &a3s_search::SearchQuery,
+    ) -> a3s_search::Result<Vec<a3s_search::SearchResult>> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        Ok(vec![a3s_search::SearchResult::new(
+            "https://example.test/coalesced",
+            query.query.clone(),
+            "shared result",
+        )])
+    }
+}
+
+#[tokio::test]
+async fn tier_searches_share_the_session_request_coalescer() {
+    let context = ToolContext::new(PathBuf::from("."));
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut first = tier_search(&context, Arc::new(Metrics::new()));
+    let mut second = tier_search(&context, Arc::new(Metrics::new()));
+    for search in [&mut first, &mut second] {
+        search.add_engine(CoalescingProbeEngine {
+            config: a3s_search::EngineConfig {
+                name: "Coalescing Probe".to_string(),
+                shortcut: "coalescing_probe".to_string(),
+                ..a3s_search::EngineConfig::default()
+            },
+            calls: Arc::clone(&calls),
+        });
+    }
+    let query = SearchQuery::new("same concurrent request");
+
+    let (first_result, second_result) =
+        tokio::join!(first.search(query.clone()), second.search(query));
+
+    assert!(first_result.is_ok());
+    assert!(second_result.is_ok());
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 }
 
 fn search_config(engines: HashMap<String, SearchEngineConfig>) -> SearchConfig {
@@ -730,13 +826,32 @@ fn test_add_headless_engine_valid() {
     let pool_config = BrowserPoolConfig::default();
     let pool = Arc::new(BrowserPool::new(pool_config));
 
-    assert!(add_headless_engine(&mut search, "google", &pool));
+    let retry_budget = a3s_search::RetryBudget::default();
+    assert!(add_headless_engine(
+        &mut search,
+        "google",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
     assert_eq!(search.engine_count(), 1);
 
-    assert!(add_headless_engine(&mut search, "baidu", &pool));
+    assert!(add_headless_engine(
+        &mut search,
+        "baidu",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
     assert_eq!(search.engine_count(), 2);
 
-    assert!(!add_headless_engine(&mut search, "bing_cn", &pool));
+    assert!(!add_headless_engine(
+        &mut search,
+        "bing_cn",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
     assert_eq!(search.engine_count(), 2);
 }
 
@@ -747,7 +862,14 @@ fn test_add_headless_engine_aliases() {
     let pool_config = BrowserPoolConfig::default();
     let pool = Arc::new(BrowserPool::new(pool_config));
 
-    assert!(add_headless_engine(&mut search, "g", &pool));
+    let retry_budget = a3s_search::RetryBudget::default();
+    assert!(add_headless_engine(
+        &mut search,
+        "g",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
     assert_eq!(search.engine_count(), 1);
 }
 
@@ -758,8 +880,21 @@ fn test_add_headless_engine_unknown() {
     let pool_config = BrowserPoolConfig::default();
     let pool = Arc::new(BrowserPool::new(pool_config));
 
-    assert!(!add_headless_engine(&mut search, "ddg", &pool));
-    assert!(!add_headless_engine(&mut search, "nonexistent", &pool));
+    let retry_budget = a3s_search::RetryBudget::default();
+    assert!(!add_headless_engine(
+        &mut search,
+        "ddg",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
+    assert!(!add_headless_engine(
+        &mut search,
+        "nonexistent",
+        &pool,
+        BrowserBackend::Chrome,
+        &retry_budget,
+    ));
 }
 
 #[tokio::test]
@@ -826,7 +961,7 @@ fn test_web_search_schema_has_all_valid_fields() {
 
 #[test]
 fn json_search_result_preserves_published_date() {
-    let result = SearchResult::new(
+    let mut result = SearchResult::new(
             "https://result-user:result-password@example.com/release?tracking=secret#fragment",
             "Release notes https://title-user:title-password@example.com/title?title_token=secret#title-fragment",
             "Current release evidence at https://content-user:content-password@example.com/evidence?content_token=secret#content-fragment.",
@@ -834,10 +969,12 @@ fn json_search_result_preserves_published_date() {
         .with_engine("ddg", 2)
         .with_engine("brave", 1)
         .with_published_date("2026-07-11");
+    result.query_match_score = Some(0.875);
 
     let json = search_result_json(&result, None);
 
     assert_eq!(json["published_date"], "2026-07-11");
+    assert_eq!(json["query_match_score"], 0.875);
     assert_eq!(json["url"], "https://example.com/release");
     assert_eq!(json["title"], "Release notes https://example.com/title");
     assert_eq!(
@@ -863,6 +1000,47 @@ fn json_search_result_preserves_published_date() {
             "leaked {secret}: {serialized}"
         );
     }
+}
+
+#[test]
+fn json_search_payload_preserves_the_array_contract_when_quality_is_met() {
+    let mut quality = a3s_search::SearchQuality::default();
+    quality.usable_result_count = 1;
+    quality.unique_host_count = 1;
+    quality.contributing_engine_count = 1;
+    quality.aligned_result_count = 1;
+    quality.mean_query_match = 1.0;
+    let floor = SearchQualityFloor::for_limit(1);
+    let results = vec![serde_json::json!({
+        "title": "Portable evidence",
+        "url": "https://example.test/evidence"
+    })];
+
+    let payload = json_search_payload(results.clone(), true, &quality, &floor);
+
+    assert_eq!(payload, serde_json::Value::Array(results));
+}
+
+#[test]
+fn json_search_payload_is_diagnostic_and_fail_closed_below_quality_floor() {
+    let quality = a3s_search::SearchQuality::default();
+    let floor = SearchQualityFloor::for_limit(1);
+    assert!(!floor.is_met(&quality), "an empty result set cannot pass");
+
+    let payload = json_search_payload(
+        vec![serde_json::json!({
+            "title": "Weak candidate",
+            "url": "https://example.test/candidate"
+        })],
+        false,
+        &quality,
+        &floor,
+    );
+
+    assert_eq!(payload["status"], "quality_not_met");
+    assert_eq!(payload["search_quality"]["usable_result_count"], 0);
+    assert_eq!(payload["search_quality_floor"]["min_usable_results"], 1);
+    assert_eq!(payload["results"].as_array().map(Vec::len), Some(1));
 }
 
 #[test]

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -108,6 +108,14 @@ pub struct TaskExecutor {
     mcp_managers: Vec<Arc<McpManager>>,
     /// Parent capabilities to inherit into child runs.
     parent_context: Option<crate::child_run::ChildRunContext>,
+    /// Search configuration captured from the invoking parent context.
+    search_config: Option<Arc<crate::config::SearchConfig>>,
+    /// Agent-scoped search admission shared with delegated child runs.
+    search_bulkhead: Option<a3s_search::Bulkhead>,
+    /// Agent-scoped headless retry allowance shared with delegated child runs.
+    search_retry_budget: Option<a3s_search::RetryBudget>,
+    /// Parent-session request flights shared with delegated child runs.
+    search_request_coalescer: Option<a3s_search::SearchCoalescer>,
     /// Optional lifetime boundary inherited from the session that created this
     /// executor. Keeping it on the executor prevents cached workflow/executor
     /// handles from starting new child runs after their session is closed.
@@ -135,6 +143,10 @@ impl TaskExecutor {
             workspace,
             mcp_managers: Vec::new(),
             parent_context: None,
+            search_config: None,
+            search_bulkhead: None,
+            search_retry_budget: None,
+            search_request_coalescer: None,
             parent_cancellation: None,
             max_parallel_tasks: crate::agent::DEFAULT_MAX_PARALLEL_TASKS,
             parallel_permits: Arc::new(tokio::sync::Semaphore::new(
@@ -167,6 +179,10 @@ impl TaskExecutor {
             workspace,
             mcp_managers,
             parent_context: None,
+            search_config: None,
+            search_bulkhead: None,
+            search_retry_budget: None,
+            search_request_coalescer: None,
             parent_cancellation: None,
             max_parallel_tasks: crate::agent::DEFAULT_MAX_PARALLEL_TASKS,
             parallel_permits: Arc::new(tokio::sync::Semaphore::new(
@@ -188,14 +204,42 @@ impl TaskExecutor {
     }
 
     fn scoped_for_invocation(self: &Arc<Self>, ctx: &ToolContext) -> Arc<Self> {
-        if !ctx.has_run_governance() {
-            return Arc::clone(self);
-        }
         let mut scoped = self.as_ref().clone();
-        scoped.parent_context = scoped.parent_context.take().map(|parent| {
-            parent.with_run_governance(ctx.run_permission_checker(), ctx.run_confirmation_manager())
-        });
+        scoped.search_config = ctx.search_config.clone();
+        scoped.search_bulkhead = Some(ctx.search_bulkhead());
+        scoped.search_retry_budget = Some(ctx.search_retry_budget());
+        scoped.search_request_coalescer = Some(ctx.search_request_coalescer());
+        if ctx.has_run_governance() {
+            scoped.parent_context = scoped.parent_context.take().map(|parent| {
+                parent.with_run_governance(
+                    ctx.run_permission_checker(),
+                    ctx.run_confirmation_manager(),
+                )
+            });
+        }
         Arc::new(scoped)
+    }
+
+    fn child_tool_context(
+        &self,
+        session_id: String,
+        cancellation: CancellationToken,
+    ) -> ToolContext {
+        let mut context = ToolContext::new(PathBuf::from(&self.workspace))
+            .with_session_id(session_id)
+            .with_cancellation(cancellation);
+        if let (Some(bulkhead), Some(retry_budget)) =
+            (&self.search_bulkhead, &self.search_retry_budget)
+        {
+            context = context.with_search_runtime(bulkhead.clone(), retry_budget.clone());
+        }
+        if let Some(search_config) = &self.search_config {
+            context = context.with_search_config(search_config.as_ref().clone());
+        }
+        if let Some(coalescer) = &self.search_request_coalescer {
+            context = context.with_search_request_coalescer(coalescer.clone());
+        }
+        context
     }
 
     /// Bind every run started by this executor to a parent lifetime.
@@ -411,9 +455,7 @@ impl TaskExecutor {
         let cancel_token = parent_cancellation
             .map(CancellationToken::child_token)
             .unwrap_or_default();
-        let mut tool_context = ToolContext::new(PathBuf::from(&self.workspace))
-            .with_session_id(session_id.clone())
-            .with_cancellation(cancel_token.clone());
+        let mut tool_context = self.child_tool_context(session_id.clone(), cancel_token.clone());
         if let Some(ref parent_ctx) = self.parent_context {
             if let Some(ref services) = parent_ctx.workspace_services {
                 tool_context = tool_context.with_workspace_services(Arc::clone(services));

--- a/core/src/tools/task/tests.rs
+++ b/core/src/tools/task/tests.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+struct DelegatedCoalescingEngine {
+    config: a3s_search::EngineConfig,
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl a3s_search::Engine for DelegatedCoalescingEngine {
+    fn config(&self) -> &a3s_search::EngineConfig {
+        &self.config
+    }
+
+    async fn search(
+        &self,
+        query: &a3s_search::SearchQuery,
+    ) -> a3s_search::Result<Vec<a3s_search::SearchResult>> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        Ok(vec![a3s_search::SearchResult::new(
+            "https://example.test/delegated",
+            query.query.clone(),
+            "shared delegated result",
+        )])
+    }
+}
+
 #[test]
 fn test_task_params_deserialize() {
     let json = r#"{
@@ -58,6 +83,107 @@ fn test_task_params_all_fields() {
     assert_eq!(params.prompt, "Do everything");
     assert!(params.background);
     assert_eq!(params.max_steps, Some(20));
+}
+
+#[tokio::test]
+async fn delegated_context_inherits_search_limits_and_flights_but_gets_a_fresh_circuit() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let executor = Arc::new(TaskExecutor::new(
+        Arc::new(AgentRegistry::new()),
+        Arc::new(StaticLlmClient::new("done")),
+        workspace.path().to_string_lossy().to_string(),
+    ));
+    let bulkhead = a3s_search::Bulkhead::new(a3s_search::BulkheadConfig {
+        max_concurrent: 1,
+        max_queued: 0,
+        max_queue_wait: std::time::Duration::ZERO,
+    });
+    let retry_budget = a3s_search::RetryBudget::new(a3s_search::RetryBudgetConfig {
+        capacity: 1,
+        retry_cost: 1,
+        success_credit: 0,
+    });
+    let search_config = crate::config::SearchConfig {
+        timeout: 17,
+        health: Some(crate::config::SearchHealthConfig {
+            max_failures: 1,
+            suspend_seconds: 60,
+        }),
+        engines: std::collections::HashMap::new(),
+        headless: None,
+    };
+    let parent = ToolContext::new(workspace.path().to_path_buf())
+        .with_session_id("parent-session")
+        .with_search_config(search_config)
+        .with_search_runtime(bulkhead, retry_budget);
+    let scoped = executor.scoped_for_invocation(&parent);
+    let child = scoped.child_tool_context("child-session".to_string(), CancellationToken::new());
+
+    assert_eq!(
+        child.search_config.as_ref().map(|config| config.timeout),
+        Some(17)
+    );
+
+    let _permit = parent
+        .search_bulkhead()
+        .acquire("shared-engine")
+        .await
+        .expect("parent should acquire shared capacity");
+    assert_eq!(
+        child
+            .search_bulkhead()
+            .acquire("shared-engine")
+            .await
+            .expect_err("child must observe parent capacity"),
+        a3s_search::BulkheadRejection::Saturated
+    );
+
+    assert!(parent.search_retry_budget().try_acquire_retry());
+    assert!(!child.search_retry_budget().try_acquire_retry());
+
+    parent
+        .search_circuit_breaker()
+        .acquire("failing-engine")
+        .expect("parent probe")
+        .record_failure(&a3s_search::EngineFailure::new(
+            "Failing Engine",
+            "provider_unavailable",
+            "synthetic failure",
+        ));
+    assert!(parent
+        .search_circuit_breaker()
+        .acquire("failing-engine")
+        .is_err());
+    assert!(child
+        .search_circuit_breaker()
+        .acquire("failing-engine")
+        .is_ok());
+
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut parent_search =
+        a3s_search::Search::new().with_request_coalescer(parent.search_request_coalescer());
+    let mut child_search =
+        a3s_search::Search::new().with_request_coalescer(child.search_request_coalescer());
+    for search in [&mut parent_search, &mut child_search] {
+        search.add_engine(DelegatedCoalescingEngine {
+            config: a3s_search::EngineConfig {
+                name: "Delegated Coalescing".to_string(),
+                shortcut: "delegated_coalescing".to_string(),
+                ..a3s_search::EngineConfig::default()
+            },
+            calls: Arc::clone(&calls),
+        });
+    }
+    let query = a3s_search::SearchQuery::new("same delegated request");
+
+    let (parent_result, child_result) = tokio::join!(
+        parent_search.search(query.clone()),
+        child_search.search(query),
+    );
+
+    assert!(parent_result.is_ok());
+    assert!(child_result.is_ok());
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 }
 
 #[test]

--- a/core/src/tools/types.rs
+++ b/core/src/tools/types.rs
@@ -220,6 +220,12 @@ pub struct ToolContext {
     /// Session-scoped search circuit state shared by cloned tool contexts.
     pub(crate) search_circuit_breaker: a3s_search::CircuitBreaker,
     search_circuit_scope: Option<String>,
+    /// Agent-scoped per-engine admission shared by cloned tool contexts.
+    search_bulkhead: a3s_search::Bulkhead,
+    /// Agent-scoped retry allowance shared across browser requests.
+    search_retry_budget: a3s_search::RetryBudget,
+    /// Session-scoped identical-request flights shared by cloned tool contexts.
+    search_request_coalescer: a3s_search::SearchCoalescer,
     /// Optional sandbox for routing `bash` tool execution through A3S Box.
     pub sandbox: Option<std::sync::Arc<dyn crate::sandbox::BashSandbox>>,
     /// Optional command environment overrides for subprocess-based tools.
@@ -363,6 +369,9 @@ impl ToolContext {
             search_config: None,
             search_circuit_breaker: search_circuit_breaker(None),
             search_circuit_scope: None,
+            search_bulkhead: a3s_search::Bulkhead::default(),
+            search_retry_budget: a3s_search::RetryBudget::default(),
+            search_request_coalescer: a3s_search::SearchCoalescer::default(),
             sandbox: None,
             command_env: None,
             workspace_services: crate::workspace::WorkspaceServices::local(workspace),
@@ -385,6 +394,7 @@ impl ToolContext {
         let session_id = session_id.into();
         if self.search_circuit_scope.as_deref() != Some(session_id.as_str()) {
             self.search_circuit_breaker = search_circuit_breaker(self.search_config.as_deref());
+            self.search_request_coalescer = a3s_search::SearchCoalescer::default();
             self.search_circuit_scope = Some(session_id.clone());
         }
         self.session_id = Some(session_id);
@@ -422,12 +432,43 @@ impl ToolContext {
     /// Set the search configuration
     pub fn with_search_config(mut self, config: crate::config::SearchConfig) -> Self {
         self.search_circuit_breaker = search_circuit_breaker(Some(&config));
+        self.search_request_coalescer = a3s_search::SearchCoalescer::default();
         self.search_config = Some(Arc::new(config));
         self
     }
 
     pub(crate) fn search_circuit_breaker(&self) -> a3s_search::CircuitBreaker {
         self.search_circuit_breaker.clone()
+    }
+
+    pub(crate) fn search_bulkhead(&self) -> a3s_search::Bulkhead {
+        self.search_bulkhead.clone()
+    }
+
+    pub(crate) fn with_search_runtime(
+        mut self,
+        bulkhead: a3s_search::Bulkhead,
+        retry_budget: a3s_search::RetryBudget,
+    ) -> Self {
+        self.search_bulkhead = bulkhead;
+        self.search_retry_budget = retry_budget;
+        self
+    }
+
+    pub(crate) fn search_retry_budget(&self) -> a3s_search::RetryBudget {
+        self.search_retry_budget.clone()
+    }
+
+    pub(crate) fn with_search_request_coalescer(
+        mut self,
+        coalescer: a3s_search::SearchCoalescer,
+    ) -> Self {
+        self.search_request_coalescer = coalescer;
+        self
+    }
+
+    pub(crate) fn search_request_coalescer(&self) -> a3s_search::SearchCoalescer {
+        self.search_request_coalescer.clone()
     }
 
     /// Set a sandbox executor for the `bash` tool.

--- a/sdk/node/generated.d.ts
+++ b/sdk/node/generated.d.ts
@@ -666,7 +666,7 @@ export interface SearchEngineConfig {
 export const enum BrowserBackend {
   /** Chrome/Chromium headless. */
   Chrome = 0,
-  /** Lightpanda headless browser (Linux/macOS only). */
+  /** Lightpanda headless browser (native Linux/macOS; WSL2 on Windows hosts). */
   Lightpanda = 1
 }
 /** Headless browser configuration. */

--- a/sdk/node/src/search_config.rs
+++ b/sdk/node/src/search_config.rs
@@ -29,7 +29,7 @@ impl From<SearchEngineConfig> for RustSearchEngineConfig {
 pub enum BrowserBackend {
     /// Chrome/Chromium headless.
     Chrome,
-    /// Lightpanda headless browser (Linux/macOS only).
+    /// Lightpanda headless browser (native Linux/macOS; WSL2 on Windows hosts).
     Lightpanda,
 }
 

--- a/sdk/python/src/search_config.rs
+++ b/sdk/python/src/search_config.rs
@@ -92,7 +92,7 @@ impl From<PySearchHealthConfig> for RustSearchHealthConfig {
 pub(super) enum PyBrowserBackend {
     /// Chrome/Chromium headless.
     Chrome,
-    /// Lightpanda headless browser (Linux/macOS only).
+    /// Lightpanda headless browser (native Linux/macOS; WSL2 on Windows hosts).
     Lightpanda,
 }
 


### PR DESCRIPTION
## Summary

- enable the lazy browser search tier by default with Chrome/Chromium as the cross-platform runtime backend
- preserve the API -> HTTP/RSS -> browser cascade so Chrome starts only when earlier evidence is insufficient
- keep Lightpanda as an explicit configured alternative and retain a browser-free no-default-features build
- fail closed below the generic quality floor, expose query-alignment diagnostics, and share bulkheads, retry budgets, and identical-request flights with delegated research tasks
- pass request proxies through to the browser tier without query-, provider-, language-, or domain-specific exceptions

## Validation

- cargo fmt --all -- --check
- cargo clippy -p a3s-code-core --locked --lib -- -D warnings
- default web_search tests against crates.io a3s-search 2.1.2: 50 passed, 3 ignored external-network probes
- no-default-features web_search tests: 41 passed, 3 ignored external-network probes
- all-features web_search tests: 50 passed, 3 ignored external-network probes
- delegated search-runtime inheritance/coalescing test passed
- default dependency tree contains Chromium; no-default-features tree does not
- SDK API and event protocol alignment checks passed