### PR TITLE
feat(context): bind exact cognitive package generations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Force LF line endings for prompt files to ensure cross-platform string matching
 prompts/*.md text eol=lf
+core/tests/fixtures/agentic-ontology/r0-cross-project-v1/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the Rust-host `CognitiveContextSession` boundary for one exact A3S Use
+  cognitive-package generation. Typed requests and cited Markdown responses
+  retain package/version, lifecycle generation, capability snapshot, Knowledge
+  surface, content, source, and citation digests under strict item/byte bounds.
+- Persisted cognitive-package bindings in session snapshots and added the
+  `cognitive_context_bound` runtime/event-protocol record so restart and replay
+  retain the same generation identity.
+
+### Changed
+
+- Cognitive-package-bound turns now fail closed on provider or identity drift,
+  require the same host-injected binding on resume, suppress personal-memory
+  recall, and reject general RAG/graph providers instead of using them as a
+  fallback.
+
 ## [6.8.0] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ telemetry remain opt-in.
 | Governed tools | Files, search, shell, Git, web, structured generation, batch, program, Skills, MCP, and delegation | Exposed only when workspace and policy allow |
 | Code intelligence | Saved-file symbols, definitions, declarations, references, implementations, diagnostics, revisions, and stale-state metadata | Host-selected local workspace |
 | Context and memory | Ranked context, repeated compaction, three-tier memory, typed stores, recall, extraction, relations, and pruning | Host-selected and configurable |
+| Cognitive packages | Exact A3S Use generation binding, host-injected cited Markdown provider, bounded source verification, restart checks, and fail-closed retrieval | Rust host injects `CognitiveContextSession`; Code never installs or resolves packages |
 | Model adapters | Anthropic, Zhipu, OpenAI-compatible APIs, and custom `LlmClient` implementations | Configuration or host injection |
 | Structured output | Native provider formats or schema-validated prompt, partial parse, and repair fallback | Baseline |
 | MCP and Skills | Isolated MCP transports plus filesystem, registry, inline, and live session Skills | Configuration or live registration |
@@ -201,6 +202,32 @@ async fn main() -> a3s_code_core::Result<()> {
 Typed session options accept custom model clients, context providers, memory
 stores, session stores, workspace backends, security providers, confirmation
 providers, permission checkers, and other host-owned extensions.
+
+### Bind one exact cognitive package
+
+`CognitiveContextSession` is the dedicated boundary for Agentic Ontology
+cognitive packages. The embedding host obtains and retains the A3S Use lease,
+then injects a provider together with the reviewed package, lifecycle
+generation, capability snapshot, and Knowledge-surface digests:
+
+```rust,ignore
+use a3s_code_core::{CognitiveContextSession, SessionOptions};
+
+// `binding` is reconstructed from the exact A3S Use capability snapshot.
+// `use_provider` implements CognitiveContextProvider and performs cited
+// search -> bounded Markdown read through the host-owned generation lease.
+let cognitive = CognitiveContextSession::new(binding, use_provider)?;
+let options = SessionOptions::new().with_cognitive_context(cognitive);
+```
+
+Code repeats the complete binding in every provider request, validates source
+and citation digests before prompt injection, persists the binding in
+`SessionSnapshotV1`, and emits `cognitive_context_bound` into the ordinary run
+event stream. A resumed session requires the host to inject the same binding.
+Provider failure, generation drift, a missing citation, or an attempt to add a
+general RAG/graph fallback aborts the turn; personal memory is not recalled for
+a cognitive-package-bound turn. Registry lookup, installation, lifecycle,
+package files, and the human-review ontology graph remain outside Code.
 
 ## Tools that respect the workspace
 

--- a/core/src/agent.rs
+++ b/core/src/agent.rs
@@ -445,6 +445,13 @@ pub enum AgentEvent {
         total_tokens: usize,
     },
 
+    /// One run is using the exact cognitive-package generation retained by
+    /// the surrounding session snapshot.
+    #[serde(rename = "cognitive_context_bound")]
+    CognitiveContextBound {
+        binding: crate::cognitive_context::CognitivePackageBindingV1,
+    },
+
     // ========================================================================
     // a3s-lane integration events
     // ========================================================================

--- a/core/src/agent/loop_runtime.rs
+++ b/core/src/agent/loop_runtime.rs
@@ -98,7 +98,7 @@ impl AgentLoop {
                 session_id,
                 &event_tx,
             )
-            .await;
+            .await?;
         let effective_prompt = turn_context.effective_prompt.as_str();
         let augmented_system = turn_context.augmented_system;
 

--- a/core/src/agent/tests.rs
+++ b/core/src/agent/tests.rs
@@ -3093,7 +3093,7 @@ async fn test_agent_build_augmented_system_prompt() {
     let agent = AgentLoop::new(mock_client, tool_executor, test_tool_context(), config);
 
     // Test building augmented prompt
-    let context_results = agent.resolve_context("test", None).await;
+    let context_results = agent.resolve_context("test", None).await.unwrap();
     let augmented = agent.build_augmented_system_prompt(&context_results);
 
     let augmented_str = augmented.unwrap();

--- a/core/src/agent/turn_context.rs
+++ b/core/src/agent/turn_context.rs
@@ -1,6 +1,7 @@
 use super::{context_perception, project_context, AgentEvent, AgentLoop};
 use crate::context::{
-    ContextAssembler, ContextAssembly, ContextItem, ContextQuery, ContextResult, ContextType,
+    ContextAssembler, ContextAssembly, ContextItem, ContextProviderFailureMode, ContextQuery,
+    ContextResult, ContextType,
 };
 use crate::hooks::{
     HookEvent, HookResult, IntentDetectionEvent, PreContextPerceptionEvent, PrePromptEvent,
@@ -21,7 +22,7 @@ impl AgentLoop {
         message_count: usize,
         session_id: Option<&str>,
         event_tx: &Option<mpsc::Sender<AgentEvent>>,
-    ) -> TurnContext {
+    ) -> anyhow::Result<TurnContext> {
         let built_system_prompt = Some(effective_system_prompt.to_string());
         let effective_prompt = self
             .fire_pre_prompt(
@@ -37,23 +38,35 @@ impl AgentLoop {
             sp.taint_input(&effective_prompt);
         }
 
+        if let Some(binding) = self.cognitive_package_binding() {
+            if let Some(tx) = event_tx {
+                tx.send(AgentEvent::CognitiveContextBound {
+                    binding: binding.clone(),
+                })
+                .await
+                .ok();
+            }
+        }
+
         let mut context_results = self
             .resolve_prompt_context(&effective_prompt, session_id, event_tx)
-            .await;
-        self.recall_memory_context(&effective_prompt, &mut context_results, event_tx)
-            .await;
+            .await?;
+        if self.cognitive_package_binding().is_none() {
+            self.recall_memory_context(&effective_prompt, &mut context_results, event_tx)
+                .await;
+        }
 
         let context_assembly = self.assemble_context_results(&context_results);
         self.emit_context_resolved(&context_assembly, event_tx)
             .await;
 
-        TurnContext {
+        Ok(TurnContext {
             augmented_system: self.build_augmented_system_prompt_with_base(
                 effective_system_prompt,
                 &context_assembly,
             ),
             effective_prompt,
-        }
+        })
     }
 
     async fn resolve_prompt_context(
@@ -61,9 +74,9 @@ impl AgentLoop {
         effective_prompt: &str,
         session_id: Option<&str>,
         event_tx: &Option<mpsc::Sender<AgentEvent>>,
-    ) -> Vec<ContextResult> {
+    ) -> anyhow::Result<Vec<ContextResult>> {
         if self.config.context_providers.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         if let Some(tx) = event_tx {
@@ -118,7 +131,12 @@ impl AgentLoop {
             HookResult::Continue(_) => self.resolve_context(effective_prompt, session_id).await,
             HookResult::Block(_) => {
                 tracing::info!("Context perception blocked by hook");
-                Vec::new()
+                if self.cognitive_package_binding().is_some() {
+                    anyhow::bail!(
+                        "required exact-generation cognitive context was blocked; refusing an ungrounded fallback"
+                    );
+                }
+                Ok(Vec::new())
             }
             _ => self.resolve_context(effective_prompt, session_id).await,
         }
@@ -199,9 +217,9 @@ impl AgentLoop {
         &self,
         prompt: &str,
         session_id: Option<&str>,
-    ) -> Vec<ContextResult> {
+    ) -> anyhow::Result<Vec<ContextResult>> {
         if self.config.context_providers.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let query = ContextQuery::new(prompt).with_session_id(session_id.unwrap_or(""));
@@ -213,22 +231,39 @@ impl AgentLoop {
             .map(|p| p.query(&query));
         let outcomes = join_all(futures).await;
 
-        outcomes
-            .into_iter()
-            .enumerate()
-            .filter_map(|(i, r)| match r {
-                Ok(result) if !result.is_empty() => Some(result),
-                Ok(_) => None,
-                Err(e) => {
+        let mut results = Vec::new();
+        for (index, outcome) in outcomes.into_iter().enumerate() {
+            match outcome {
+                Ok(result) if !result.is_empty() => results.push(result),
+                Ok(_) => {}
+                Err(error)
+                    if self.config.context_providers[index].failure_mode()
+                        == ContextProviderFailureMode::FailClosed =>
+                {
+                    anyhow::bail!(
+                        "required context provider '{}' failed closed: {error:#}",
+                        self.config.context_providers[index].name()
+                    );
+                }
+                Err(error) => {
                     tracing::warn!(
                         "Context provider '{}' failed: {}",
-                        self.config.context_providers[i].name(),
-                        e
+                        self.config.context_providers[index].name(),
+                        error
                     );
-                    None
                 }
-            })
-            .collect()
+            }
+        }
+        Ok(results)
+    }
+
+    fn cognitive_package_binding(
+        &self,
+    ) -> Option<&crate::cognitive_context::CognitivePackageBindingV1> {
+        self.config
+            .context_providers
+            .iter()
+            .find_map(|provider| provider.cognitive_package_binding())
     }
 
     /// Detect if context perception is needed based on user prompt.

--- a/core/src/agent_api.rs
+++ b/core/src/agent_api.rs
@@ -195,6 +195,12 @@ pub struct SessionOptions {
     pub llm_client: Option<Arc<dyn crate::llm::LlmClient>>,
     /// Optional context providers for RAG
     pub context_providers: Vec<Arc<dyn crate::context::ContextProvider>>,
+    /// One exact-generation cognitive package supplied by the embedding host.
+    ///
+    /// This is separate from general-purpose RAG providers: Code persists the
+    /// immutable package binding and treats provider failure as fatal. The host
+    /// retains A3S Use lease, Registry, installation, and lifecycle authority.
+    pub cognitive_context: Option<crate::cognitive_context::CognitiveContextSession>,
     /// Optional confirmation manager for HITL
     pub confirmation_manager: Option<Arc<dyn crate::hitl::ConfirmationProvider>>,
     /// Optional confirmation policy (will be used to create ConfirmationManager if confirmation_manager is not set)
@@ -405,6 +411,8 @@ pub struct AgentSession {
     tool_executor: Arc<ToolExecutor>,
     tool_context: ToolContext,
     config: AgentConfig,
+    /// Host provider plus the durable exact-generation package binding.
+    cognitive_context: Option<crate::cognitive_context::CognitiveContextSession>,
     workspace: PathBuf,
     /// Unique session identifier.
     session_id: String,

--- a/core/src/agent_api/agent_sessions.rs
+++ b/core/src/agent_api/agent_sessions.rs
@@ -622,7 +622,7 @@ async fn build_resumed_session(
     let snapshot = session_persistence::load_session_snapshot(&store, session_id).await?;
     let data = &snapshot.session;
     options = options.with_session_store(Arc::clone(&store));
-    let mut opts = session_persistence::apply_persisted_runtime_options(options, data);
+    let mut opts = session_persistence::apply_persisted_runtime_options(options, data)?;
     session_persistence::ensure_artifact_restore_capacity(&mut opts, &snapshot);
     let opts = session_builder::prepare_session_options(agent, opts);
     let workspace = data.config.workspace.clone();

--- a/core/src/agent_api/capabilities.rs
+++ b/core/src/agent_api/capabilities.rs
@@ -263,6 +263,9 @@ fn build_context_providers(
     skill_registry: Arc<SkillRegistry>,
 ) -> Vec<Arc<dyn ContextProvider>> {
     let mut providers = opts.context_providers.clone();
+    if let Some(cognitive_context) = &opts.cognitive_context {
+        providers.push(Arc::new(cognitive_context.clone()));
+    }
     push_agents_md_context(&mut providers, workspace);
     push_skill_catalog_context(&mut providers, skill_registry);
     providers

--- a/core/src/agent_api/session_builder.rs
+++ b/core/src/agent_api/session_builder.rs
@@ -236,6 +236,7 @@ fn finish_agent_session(
         tool_context,
         memory: config.memory.clone(),
         config,
+        cognitive_context: opts.cognitive_context.clone(),
         workspace: canonical,
         session_id,
         history: Arc::new(RwLock::new(Vec::new())),

--- a/core/src/agent_api/session_config.rs
+++ b/core/src/agent_api/session_config.rs
@@ -236,6 +236,31 @@ fn validate_session_options(options: &SessionOptions) -> Result<String> {
         });
     }
     if options
+        .context_providers
+        .iter()
+        .any(|provider| provider.cognitive_package_binding().is_some())
+    {
+        return Err(CodeError::SessionConfiguration {
+            field: "cognitive_context",
+            message: "typed cognitive providers must be installed with with_cognitive_context so their exact binding is persisted".to_string(),
+        });
+    }
+    if let Some(context) = &options.cognitive_context {
+        context
+            .binding()
+            .validate()
+            .map_err(|error| CodeError::SessionConfiguration {
+                field: "cognitive_context",
+                message: error.to_string(),
+            })?;
+        if !options.context_providers.is_empty() {
+            return Err(CodeError::SessionConfiguration {
+                field: "cognitive_context",
+                message: "general-purpose context providers cannot accompany an exact cognitive package; workspace instructions and skills remain available through Code-owned providers".to_string(),
+            });
+        }
+    }
+    if options
         .auto_compact_threshold
         .is_some_and(|value| !value.is_finite() || !(0.0..=1.0).contains(&value))
     {

--- a/core/src/agent_api/session_facade.rs
+++ b/core/src/agent_api/session_facade.rs
@@ -5,6 +5,13 @@ impl std::fmt::Debug for AgentSession {
         f.debug_struct("AgentSession")
             .field("session_id", &self.session_id)
             .field("workspace", &self.workspace.display().to_string())
+            .field(
+                "cognitive_package_binding",
+                &self
+                    .cognitive_context
+                    .as_ref()
+                    .map(crate::cognitive_context::CognitiveContextSession::binding),
+            )
             .field("auto_save", &self.auto_save)
             .finish()
     }
@@ -79,6 +86,15 @@ impl AgentSession {
     /// this session's events, if any.
     pub fn correlation_id(&self) -> Option<&str> {
         self.correlation_id.as_deref()
+    }
+
+    /// Return the exact cognitive-package generation bound to this session.
+    pub fn cognitive_package_binding(
+        &self,
+    ) -> Option<&crate::cognitive_context::CognitivePackageBindingV1> {
+        self.cognitive_context
+            .as_ref()
+            .map(crate::cognitive_context::CognitiveContextSession::binding)
     }
 
     /// Proactively close the session and release its in-flight work.

--- a/core/src/agent_api/session_options.rs
+++ b/core/src/agent_api/session_options.rs
@@ -23,6 +23,7 @@ impl std::fmt::Debug for SessionOptions {
             .field("security_provider", &self.security_provider.is_some())
             .field("llm_client", &self.llm_client.is_some())
             .field("context_providers", &self.context_providers.len())
+            .field("cognitive_context", &self.cognitive_context)
             .field("confirmation_manager", &self.confirmation_manager.is_some())
             .field("permission_checker", &self.permission_checker.is_some())
             .field("permission_policy", &self.permission_policy.is_some())
@@ -156,6 +157,20 @@ impl SessionOptions {
         provider: Arc<dyn crate::context::ContextProvider>,
     ) -> Self {
         self.context_providers.push(provider);
+        self
+    }
+
+    /// Bind this session to one exact A3S Use cognitive-package generation.
+    ///
+    /// The supplied runtime value contains a serializable immutable binding
+    /// and a host-owned provider. On restart the host must inject the same
+    /// binding again; Code never resolves `latest`, opens a package path, or
+    /// substitutes graph/personal-memory context.
+    pub fn with_cognitive_context(
+        mut self,
+        context: crate::cognitive_context::CognitiveContextSession,
+    ) -> Self {
+        self.cognitive_context = Some(context);
         self
     }
 

--- a/core/src/agent_api/session_persistence.rs
+++ b/core/src/agent_api/session_persistence.rs
@@ -103,6 +103,7 @@ pub(super) struct SessionPersistenceContext {
     principal: Option<String>,
     agent_template_id: Option<String>,
     correlation_id: Option<String>,
+    cognitive_package_binding: Option<crate::cognitive_context::CognitivePackageBindingV1>,
     auto_save: bool,
 }
 
@@ -125,6 +126,10 @@ impl SessionPersistenceContext {
             principal: session.principal.clone(),
             agent_template_id: session.agent_template_id.clone(),
             correlation_id: session.correlation_id.clone(),
+            cognitive_package_binding: session
+                .cognitive_context
+                .as_ref()
+                .map(|context| context.binding().clone()),
             auto_save: session.auto_save,
         }
     }
@@ -156,6 +161,7 @@ impl SessionPersistenceContext {
             principal: self.principal.as_deref(),
             agent_template_id: self.agent_template_id.as_deref(),
             correlation_id: self.correlation_id.as_deref(),
+            cognitive_package_binding: self.cognitive_package_binding.as_ref(),
             seed,
         })
         .await;
@@ -236,7 +242,7 @@ pub(super) async fn load_session_snapshot(
 pub(super) fn apply_persisted_runtime_options(
     mut opts: SessionOptions,
     data: &SessionData,
-) -> SessionOptions {
+) -> Result<SessionOptions> {
     let model_was_explicit = opts.model.is_some();
     opts.session_id = Some(data.id.clone());
 
@@ -287,7 +293,33 @@ pub(super) fn apply_persisted_runtime_options(
         opts.correlation_id = data.correlation_id.clone();
     }
 
-    opts
+    match (
+        data.cognitive_package_binding.as_ref(),
+        opts.cognitive_context.as_ref(),
+    ) {
+        (Some(persisted), Some(injected)) if injected.binding() == persisted => {}
+        (Some(_), Some(_)) => {
+            return Err(CodeError::SessionConfiguration {
+                field: "cognitive_context",
+                message: "resume provider binding differs from the exact cognitive package retained by the session snapshot".to_string(),
+            });
+        }
+        (Some(_), None) => {
+            return Err(CodeError::SessionConfiguration {
+                field: "cognitive_context",
+                message: "resuming a cognitive-package session requires the host to re-inject a provider for the persisted exact generation".to_string(),
+            });
+        }
+        (None, Some(_)) => {
+            return Err(CodeError::SessionConfiguration {
+                field: "cognitive_context",
+                message: "an existing unbound session cannot acquire a cognitive package during resume; create a new bound session".to_string(),
+            });
+        }
+        (None, None) => {}
+    }
+
+    Ok(opts)
 }
 
 pub(super) fn ensure_artifact_restore_capacity(
@@ -350,6 +382,7 @@ struct SessionDataSnapshotInput<'a> {
     principal: Option<&'a str>,
     agent_template_id: Option<&'a str>,
     correlation_id: Option<&'a str>,
+    cognitive_package_binding: Option<&'a crate::cognitive_context::CognitivePackageBindingV1>,
     seed: SessionPersistenceSeed,
 }
 
@@ -382,6 +415,7 @@ async fn build_session_data_snapshot(input: SessionDataSnapshotInput<'_>) -> Ses
         principal: None,
         agent_template_id: None,
         correlation_id: None,
+        cognitive_package_binding: None,
     });
 
     data.id = input.session_id.to_string();
@@ -410,6 +444,7 @@ async fn build_session_data_snapshot(input: SessionDataSnapshotInput<'_>) -> Ses
     data.principal = input.principal.map(str::to_string);
     data.agent_template_id = input.agent_template_id.map(str::to_string);
     data.correlation_id = input.correlation_id.map(str::to_string);
+    data.cognitive_package_binding = input.cognitive_package_binding.cloned();
     data
 }
 
@@ -556,6 +591,7 @@ mod tests {
             principal: None,
             agent_template_id: None,
             correlation_id: None,
+            cognitive_package_binding: None,
         }
     }
 
@@ -732,7 +768,7 @@ mod tests {
     #[test]
     fn persisted_runtime_options_prefer_llm_config() {
         let data = persisted_data(Some("anthropic/old"), Some(("openai", "gpt-4o")));
-        let opts = apply_persisted_runtime_options(SessionOptions::new(), &data);
+        let opts = apply_persisted_runtime_options(SessionOptions::new(), &data).unwrap();
         assert_eq!(opts.session_id.as_deref(), Some("session-1"));
         assert_eq!(opts.model.as_deref(), Some("openai/gpt-4o"));
     }
@@ -740,7 +776,7 @@ mod tests {
     #[test]
     fn persisted_runtime_options_fall_back_to_model_name() {
         let data = persisted_data(Some("openai/gpt-4o"), None);
-        let opts = apply_persisted_runtime_options(SessionOptions::new(), &data);
+        let opts = apply_persisted_runtime_options(SessionOptions::new(), &data).unwrap();
         assert_eq!(opts.model.as_deref(), Some("openai/gpt-4o"));
     }
 
@@ -749,19 +785,21 @@ mod tests {
         let mut data = persisted_data(Some("openai/gpt-4o"), None);
         data.config.max_context_length = 128_000;
 
-        let restored = apply_persisted_runtime_options(SessionOptions::new(), &data);
+        let restored = apply_persisted_runtime_options(SessionOptions::new(), &data).unwrap();
         assert_eq!(restored.max_context_tokens, Some(128_000));
 
         let switched = apply_persisted_runtime_options(
             SessionOptions::new().with_model("anthropic/claude"),
             &data,
-        );
+        )
+        .unwrap();
         assert_eq!(switched.max_context_tokens, None);
 
         let overridden = apply_persisted_runtime_options(
             SessionOptions::new().with_max_context_tokens(64_000),
             &data,
-        );
+        )
+        .unwrap();
         assert_eq!(overridden.max_context_tokens, Some(64_000));
     }
 
@@ -797,6 +835,7 @@ mod tests {
             principal: None,
             agent_template_id: None,
             correlation_id: None,
+            cognitive_package_binding: None,
             auto_save: false,
         };
 
@@ -870,6 +909,7 @@ mod tests {
             principal: None,
             agent_template_id: None,
             correlation_id: None,
+            cognitive_package_binding: None,
             auto_save: false,
         };
 

--- a/core/src/agent_api/tests.rs
+++ b/core/src/agent_api/tests.rs
@@ -229,6 +229,28 @@ struct CapturingContextProvider {
     session_ids: std::sync::Mutex<Vec<Option<String>>>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum TestCognitiveProviderMode {
+    Valid,
+    DriftGeneration,
+    Fail,
+}
+
+#[derive(Debug)]
+struct TestCognitiveProvider {
+    mode: TestCognitiveProviderMode,
+    requests: std::sync::Mutex<Vec<crate::cognitive_context::CognitiveContextRequestV1>>,
+}
+
+impl TestCognitiveProvider {
+    fn new(mode: TestCognitiveProviderMode) -> Self {
+        Self {
+            mode,
+            requests: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
 #[derive(Default)]
 struct TestWorkspaceFs {
     files: std::sync::RwLock<std::collections::HashMap<String, String>>,
@@ -342,6 +364,90 @@ impl crate::context::ContextProvider for CapturingContextProvider {
             .push(query.session_id.clone());
         Ok(crate::context::ContextResult::new(self.name()))
     }
+}
+
+#[async_trait::async_trait]
+impl crate::cognitive_context::CognitiveContextProvider for TestCognitiveProvider {
+    fn name(&self) -> &str {
+        "test-a3s-use-cognitive-package"
+    }
+
+    async fn query(
+        &self,
+        request: &crate::cognitive_context::CognitiveContextRequestV1,
+    ) -> crate::cognitive_context::CognitiveContextResult<
+        crate::cognitive_context::CognitiveContextResponseV1,
+    > {
+        self.requests.lock().unwrap().push(request.clone());
+        if matches!(self.mode, TestCognitiveProviderMode::Fail) {
+            return Err(crate::cognitive_context::CognitiveContextError::Provider(
+                "exact generation lease is unavailable".to_string(),
+            ));
+        }
+
+        let citation = crate::cognitive_context::CognitiveKnowledgeCitationV1::new(
+            &request.binding,
+            "concepts/retry-policy.md",
+            "Retry policy",
+            vec![
+                "sha256:ce8af6b5fb9a69bc2de147dbb0fd8754c9e1b555a96002878560dd9f8914db73"
+                    .to_string(),
+            ],
+        )?;
+        let document = crate::cognitive_context::CognitiveContextDocumentV1::new(
+            citation,
+            "Retry only before an observable side effect.",
+        )?;
+        let mut response = crate::cognitive_context::CognitiveContextResponseV1::new(
+            request,
+            vec![document],
+            false,
+        )?;
+        if matches!(self.mode, TestCognitiveProviderMode::DriftGeneration) {
+            response.binding.lifecycle_generation += 1;
+        }
+        Ok(response)
+    }
+}
+
+fn test_cognitive_binding() -> crate::cognitive_context::CognitivePackageBindingV1 {
+    let generation_digest =
+        "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20";
+    let knowledge = crate::cognitive_context::CognitiveKnowledgeBindingV1::new(
+        "domain-knowledge",
+        "0.2",
+        "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+        7,
+        generation_digest,
+    )
+    .unwrap();
+    crate::cognitive_context::CognitivePackageBindingV1::new(
+        "contra-sense/handbook",
+        "0.1.0",
+        7,
+        generation_digest,
+        "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+        knowledge,
+        crate::cognitive_context::CognitiveContextLimits::default(),
+    )
+    .unwrap()
+}
+
+fn test_cognitive_context(
+    mode: TestCognitiveProviderMode,
+) -> (
+    crate::cognitive_context::CognitiveContextSession,
+    Arc<TestCognitiveProvider>,
+) {
+    let provider = Arc::new(TestCognitiveProvider::new(mode));
+    let provider_port: Arc<dyn crate::cognitive_context::CognitiveContextProvider> =
+        provider.clone();
+    let context = crate::cognitive_context::CognitiveContextSession::new(
+        test_cognitive_binding(),
+        provider_port,
+    )
+    .unwrap();
+    (context, provider)
 }
 
 #[async_trait::async_trait]
@@ -6775,4 +6881,225 @@ async fn blank_session_id_returns_typed_configuration_error() {
             ..
         }
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cognitive_package_binding_is_persisted_and_retained_by_run_events() {
+    let store = Arc::new(crate::store::MemorySessionStore::new());
+    let agent = Agent::from_config(test_config()).await.unwrap();
+    let (cognitive_context, provider) = test_cognitive_context(TestCognitiveProviderMode::Valid);
+    let expected = cognitive_context.binding().clone();
+    let opts = SessionOptions::new()
+        .with_session_id("cognitive-session")
+        .with_session_store(store.clone())
+        .with_llm_client(Arc::new(StaticStreamingClient::new("grounded response")))
+        .with_planning(false)
+        .with_cognitive_context(cognitive_context);
+    let session = agent
+        .session_async("/tmp/test-cognitive-session", Some(opts))
+        .await
+        .unwrap();
+
+    assert_eq!(session.cognitive_package_binding(), Some(&expected));
+    session
+        .send("What is the retry policy?", None)
+        .await
+        .unwrap();
+    session.save().await.unwrap();
+
+    let requests = provider.requests.lock().unwrap().clone();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].session_id, "cognitive-session");
+    assert_eq!(requests[0].binding, expected);
+
+    let snapshot = store
+        .load_snapshot("cognitive-session")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        snapshot.session.cognitive_package_binding.as_ref(),
+        Some(&expected)
+    );
+    let bound_events = snapshot
+        .run_records
+        .iter()
+        .flat_map(|record| &record.events)
+        .filter_map(|record| match &record.event {
+            AgentEvent::CognitiveContextBound { binding } => Some(binding),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(bound_events, vec![&expected]);
+    assert!(!snapshot
+        .run_records
+        .iter()
+        .flat_map(|record| &record.events)
+        .any(|record| matches!(record.event, AgentEvent::MemoryRecalled { .. })));
+    snapshot.validate_for_session("cognitive-session").unwrap();
+
+    let mut tampered = snapshot.clone();
+    let event_binding = tampered
+        .run_records
+        .iter_mut()
+        .flat_map(|record| &mut record.events)
+        .find_map(|record| match &mut record.event {
+            AgentEvent::CognitiveContextBound { binding } => Some(binding),
+            _ => None,
+        })
+        .unwrap();
+    event_binding.limits.max_results -= 1;
+    assert!(tampered.validate_for_session("cognitive-session").is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cognitive_provider_failure_and_generation_drift_fail_closed_without_fallback() {
+    for (session_id, mode) in [
+        (
+            "cognitive-provider-failure",
+            TestCognitiveProviderMode::Fail,
+        ),
+        (
+            "cognitive-provider-drift",
+            TestCognitiveProviderMode::DriftGeneration,
+        ),
+    ] {
+        let agent = Agent::from_config(test_config()).await.unwrap();
+        let (cognitive_context, _) = test_cognitive_context(mode);
+        let opts = SessionOptions::new()
+            .with_session_id(session_id)
+            .with_llm_client(Arc::new(StaticStreamingClient::new(
+                "this response must never be reached",
+            )))
+            .with_planning(false)
+            .with_cognitive_context(cognitive_context);
+        let session = agent
+            .session_async(format!("/tmp/{session_id}"), Some(opts))
+            .await
+            .unwrap();
+
+        let error = session
+            .send("Use the package evidence", None)
+            .await
+            .expect_err("required cognitive context must not be omitted");
+        assert!(error.to_string().contains("failed closed"), "{error:#}");
+        let records = session.run_store.records().await;
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].snapshot.status, crate::run::RunStatus::Failed);
+        assert!(records[0]
+            .events
+            .iter()
+            .any(|record| matches!(record.event, AgentEvent::CognitiveContextBound { .. })));
+        assert!(!records[0].events.iter().any(|record| matches!(
+            record.event,
+            AgentEvent::MemoryRecalled { .. } | AgentEvent::End { .. }
+        )));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cognitive_session_rejects_general_rag_or_graph_provider_fallback() {
+    let agent = Agent::from_config(test_config()).await.unwrap();
+    let (cognitive_context, _) = test_cognitive_context(TestCognitiveProviderMode::Valid);
+    let error = agent
+        .session_async(
+            "/tmp/test-cognitive-no-generic-fallback",
+            Some(
+                SessionOptions::new()
+                    .with_session_id("cognitive-no-generic-fallback")
+                    .with_llm_client(Arc::new(StaticStreamingClient::new("unused")))
+                    .with_cognitive_context(cognitive_context)
+                    .with_context_provider(Arc::new(CapturingContextProvider::default())),
+            ),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::error::CodeError::SessionConfiguration {
+            field: "cognitive_context",
+            ..
+        }
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cognitive_session_resume_requires_the_same_host_injected_binding() {
+    let store = Arc::new(crate::store::MemorySessionStore::new());
+    let agent = Agent::from_config(test_config()).await.unwrap();
+    let (cognitive_context, _) = test_cognitive_context(TestCognitiveProviderMode::Valid);
+    let expected = cognitive_context.binding().clone();
+    let session = agent
+        .session_async(
+            "/tmp/test-cognitive-resume",
+            Some(
+                SessionOptions::new()
+                    .with_session_id("cognitive-resume")
+                    .with_session_store(store.clone())
+                    .with_llm_client(Arc::new(StaticStreamingClient::new("unused")))
+                    .with_cognitive_context(cognitive_context),
+            ),
+        )
+        .await
+        .unwrap();
+    session.save().await.unwrap();
+    session.close().await;
+    drop(session);
+
+    let missing = agent
+        .resume_session_async(
+            "cognitive-resume",
+            SessionOptions::new()
+                .with_session_store(store.clone())
+                .with_llm_client(Arc::new(StaticStreamingClient::new("unused"))),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        missing,
+        crate::error::CodeError::SessionConfiguration {
+            field: "cognitive_context",
+            ..
+        }
+    ));
+
+    let mut different_binding = expected.clone();
+    different_binding.limits.max_results -= 1;
+    different_binding.validate().unwrap();
+    let drift_provider: Arc<dyn crate::cognitive_context::CognitiveContextProvider> =
+        Arc::new(TestCognitiveProvider::new(TestCognitiveProviderMode::Valid));
+    let drift_context =
+        crate::cognitive_context::CognitiveContextSession::new(different_binding, drift_provider)
+            .unwrap();
+    let drift = agent
+        .resume_session_async(
+            "cognitive-resume",
+            SessionOptions::new()
+                .with_session_store(store.clone())
+                .with_llm_client(Arc::new(StaticStreamingClient::new("unused")))
+                .with_cognitive_context(drift_context),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        drift,
+        crate::error::CodeError::SessionConfiguration {
+            field: "cognitive_context",
+            ..
+        }
+    ));
+
+    let (exact_context, _) = test_cognitive_context(TestCognitiveProviderMode::Valid);
+    let resumed = agent
+        .resume_session_async(
+            "cognitive-resume",
+            SessionOptions::new()
+                .with_session_store(store)
+                .with_llm_client(Arc::new(StaticStreamingClient::new("unused")))
+                .with_cognitive_context(exact_context),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resumed.cognitive_package_binding(), Some(&expected));
 }

--- a/core/src/cognitive_context.rs
+++ b/core/src/cognitive_context.rs
@@ -1,0 +1,873 @@
+//! Exact-generation cognitive-package context injected by an embedding host.
+//!
+//! A3S Code deliberately does not install packages, resolve Registry state, or
+//! choose a "latest" generation. The host supplies a provider and one complete
+//! immutable binding obtained from A3S Use. Every request and response repeats
+//! that binding, and Code validates cited, bounded Markdown before it can enter
+//! the model context.
+
+use crate::context::{
+    ContextItem, ContextProvider, ContextProviderFailureMode, ContextQuery, ContextResult,
+    ContextType,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::sync::Arc;
+use thiserror::Error;
+
+pub const COGNITIVE_PACKAGE_BINDING_SCHEMA: &str = "a3s.code.cognitive-package-session-binding.v1";
+pub const COGNITIVE_KNOWLEDGE_BINDING_SCHEMA: &str =
+    "agentic.ontology.r0-knowledge-lease-binding.v1";
+pub const COGNITIVE_CONTEXT_REQUEST_SCHEMA: &str = "a3s.code.cognitive-context-request.v1";
+pub const COGNITIVE_CONTEXT_RESPONSE_SCHEMA: &str = "a3s.code.cognitive-context-response.v1";
+pub const COGNITIVE_CONTEXT_REQUEST_DIGEST_DOMAIN: &str = "a3s.code.cognitive-context-request.v1";
+pub const OKF_KNOWLEDGE_SEARCH_REQUEST_SCHEMA: &str = "a3s.use.okf-knowledge-search-request.v1";
+pub const OKF_KNOWLEDGE_READ_REQUEST_SCHEMA: &str = "a3s.use.okf-knowledge-read-request.v1";
+pub const OKF_KNOWLEDGE_CITATION_SCHEMA: &str = "a3s.use.okf-knowledge-citation.v1";
+pub const COGNITIVE_CITATION_METADATA: &str = "a3s.cognitive.citation";
+pub const COGNITIVE_PACKAGE_BINDING_METADATA: &str = "a3s.cognitive.package_binding";
+
+const CAPABILITY_SNAPSHOT_DIGEST_DOMAIN: &str = "a3s.use.capability-snapshot.v1";
+const CANONICAL_DIGEST_PREFIX: &[u8] = b"agentic-ontology-canonical-v1\0";
+const MAX_QUERY_BYTES: usize = 4 * 1024;
+const MAX_PROVIDER_NAME_BYTES: usize = 128;
+const MAX_PACKAGE_VERSION_BYTES: usize = 128;
+const MAX_SURFACE_ID_BYTES: usize = 256;
+const MAX_FORMAT_VERSION_BYTES: usize = 64;
+const MAX_DOCUMENT_PATH_BYTES: usize = 512;
+const MAX_HEADING_BYTES: usize = 128;
+const MAX_EVIDENCE_IDS: usize = 256;
+const MAX_CONTEXT_RESULTS: usize = 4;
+const MAX_CONTEXT_DOCUMENT_BYTES: usize = 6 * 1024;
+const MAX_CONTEXT_TOTAL_BYTES: usize = 6 * 1024;
+
+/// Validation failures at the Code-owned cognitive context boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CognitiveContextError {
+    #[error("invalid cognitive package binding: {0}")]
+    InvalidBinding(String),
+    #[error("invalid cognitive context limits: {0}")]
+    InvalidLimits(String),
+    #[error("invalid cognitive context request: {0}")]
+    InvalidRequest(String),
+    #[error("cognitive context provider failed: {0}")]
+    Provider(String),
+    #[error("cognitive context response drifted: {0}")]
+    ResponseDrift(String),
+}
+
+pub type CognitiveContextResult<T> = std::result::Result<T, CognitiveContextError>;
+
+/// Exact A3S Use Knowledge surface visible to this Code session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveKnowledgeBindingV1 {
+    pub schema: String,
+    pub surface_id: String,
+    pub format_version: String,
+    pub content_digest: String,
+    pub search_schema: String,
+    pub read_schema: String,
+    pub citation_schema: String,
+    pub lifecycle_generation: u64,
+    pub generation_digest: String,
+}
+
+impl CognitiveKnowledgeBindingV1 {
+    pub fn new(
+        surface_id: impl Into<String>,
+        format_version: impl Into<String>,
+        content_digest: impl Into<String>,
+        lifecycle_generation: u64,
+        generation_digest: impl Into<String>,
+    ) -> CognitiveContextResult<Self> {
+        let binding = Self {
+            schema: COGNITIVE_KNOWLEDGE_BINDING_SCHEMA.to_string(),
+            surface_id: surface_id.into(),
+            format_version: format_version.into(),
+            content_digest: content_digest.into(),
+            search_schema: OKF_KNOWLEDGE_SEARCH_REQUEST_SCHEMA.to_string(),
+            read_schema: OKF_KNOWLEDGE_READ_REQUEST_SCHEMA.to_string(),
+            citation_schema: OKF_KNOWLEDGE_CITATION_SCHEMA.to_string(),
+            lifecycle_generation,
+            generation_digest: generation_digest.into(),
+        };
+        binding.validate()?;
+        Ok(binding)
+    }
+
+    pub fn validate(&self) -> CognitiveContextResult<()> {
+        if self.schema != COGNITIVE_KNOWLEDGE_BINDING_SCHEMA
+            || self.search_schema != OKF_KNOWLEDGE_SEARCH_REQUEST_SCHEMA
+            || self.read_schema != OKF_KNOWLEDGE_READ_REQUEST_SCHEMA
+            || self.citation_schema != OKF_KNOWLEDGE_CITATION_SCHEMA
+        {
+            return Err(invalid_binding(
+                "Knowledge schema negotiation is not the exact R0 typed search/read/citation contract",
+            ));
+        }
+        if !valid_machine_id(&self.surface_id, MAX_SURFACE_ID_BYTES) {
+            return Err(invalid_binding("Knowledge surface id is invalid"));
+        }
+        if !valid_plain_value(&self.format_version, MAX_FORMAT_VERSION_BYTES) {
+            return Err(invalid_binding("Knowledge format version is invalid"));
+        }
+        if self.lifecycle_generation == 0 {
+            return Err(invalid_binding(
+                "lifecycle generation must be an exact non-zero generation",
+            ));
+        }
+        if !valid_sha256(&self.content_digest) || !valid_sha256(&self.generation_digest) {
+            return Err(invalid_binding(
+                "Knowledge content and generation identities must be SHA-256 digests",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Prompt-injection bounds frozen into the durable session binding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveContextLimits {
+    pub max_results: usize,
+    pub max_document_bytes: usize,
+    pub max_total_bytes: usize,
+}
+
+impl CognitiveContextLimits {
+    pub fn new(
+        max_results: usize,
+        max_document_bytes: usize,
+        max_total_bytes: usize,
+    ) -> CognitiveContextResult<Self> {
+        let limits = Self {
+            max_results,
+            max_document_bytes,
+            max_total_bytes,
+        };
+        limits.validate()?;
+        Ok(limits)
+    }
+
+    pub fn validate(&self) -> CognitiveContextResult<()> {
+        if self.max_results == 0 || self.max_results > MAX_CONTEXT_RESULTS {
+            return Err(CognitiveContextError::InvalidLimits(format!(
+                "max_results must be between 1 and {MAX_CONTEXT_RESULTS}"
+            )));
+        }
+        if self.max_document_bytes == 0 || self.max_document_bytes > MAX_CONTEXT_DOCUMENT_BYTES {
+            return Err(CognitiveContextError::InvalidLimits(format!(
+                "max_document_bytes must be between 1 and {MAX_CONTEXT_DOCUMENT_BYTES}"
+            )));
+        }
+        if self.max_total_bytes == 0 || self.max_total_bytes > MAX_CONTEXT_TOTAL_BYTES {
+            return Err(CognitiveContextError::InvalidLimits(format!(
+                "max_total_bytes must be between 1 and {MAX_CONTEXT_TOTAL_BYTES}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Default for CognitiveContextLimits {
+    fn default() -> Self {
+        Self {
+            max_results: MAX_CONTEXT_RESULTS,
+            max_document_bytes: MAX_CONTEXT_DOCUMENT_BYTES,
+            max_total_bytes: MAX_CONTEXT_TOTAL_BYTES,
+        }
+    }
+}
+
+/// Durable exact-generation identity attached to one A3S Code session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitivePackageBindingV1 {
+    pub schema: String,
+    pub package_id: String,
+    pub package_version: String,
+    pub lifecycle_generation: u64,
+    pub generation_digest: String,
+    pub capability_snapshot_digest: String,
+    pub knowledge: CognitiveKnowledgeBindingV1,
+    pub limits: CognitiveContextLimits,
+}
+
+impl CognitivePackageBindingV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        package_id: impl Into<String>,
+        package_version: impl Into<String>,
+        lifecycle_generation: u64,
+        generation_digest: impl Into<String>,
+        capability_snapshot_digest: impl Into<String>,
+        knowledge: CognitiveKnowledgeBindingV1,
+        limits: CognitiveContextLimits,
+    ) -> CognitiveContextResult<Self> {
+        let binding = Self {
+            schema: COGNITIVE_PACKAGE_BINDING_SCHEMA.to_string(),
+            package_id: package_id.into(),
+            package_version: package_version.into(),
+            lifecycle_generation,
+            generation_digest: generation_digest.into(),
+            capability_snapshot_digest: capability_snapshot_digest.into(),
+            knowledge,
+            limits,
+        };
+        binding.validate()?;
+        Ok(binding)
+    }
+
+    pub fn validate(&self) -> CognitiveContextResult<()> {
+        if self.schema != COGNITIVE_PACKAGE_BINDING_SCHEMA {
+            return Err(invalid_binding("session binding schema is unsupported"));
+        }
+        if !valid_package_id(&self.package_id) {
+            return Err(invalid_binding(
+                "package id must be a canonical publisher/name identity",
+            ));
+        }
+        if !valid_plain_value(&self.package_version, MAX_PACKAGE_VERSION_BYTES) {
+            return Err(invalid_binding("package version is invalid"));
+        }
+        if self.lifecycle_generation == 0 {
+            return Err(invalid_binding(
+                "lifecycle generation must be an exact non-zero generation",
+            ));
+        }
+        if !valid_sha256(&self.generation_digest) || !valid_sha256(&self.capability_snapshot_digest)
+        {
+            return Err(invalid_binding(
+                "generation and capability snapshot identities must be SHA-256 digests",
+            ));
+        }
+        self.knowledge.validate()?;
+        self.limits.validate()?;
+        if self.knowledge.lifecycle_generation != self.lifecycle_generation
+            || self.knowledge.generation_digest != self.generation_digest
+        {
+            return Err(invalid_binding(
+                "Knowledge surface belongs to a different lifecycle generation",
+            ));
+        }
+        let expected = capability_snapshot_digest(self)?;
+        if self.capability_snapshot_digest != expected {
+            return Err(invalid_binding(
+                "capability snapshot digest does not bind this package, generation, and Knowledge surface",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// One exact request from Code to the host-injected cognitive provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveContextRequestV1 {
+    pub schema: String,
+    pub session_id: String,
+    pub query: String,
+    pub binding: CognitivePackageBindingV1,
+    pub request_digest: String,
+}
+
+impl CognitiveContextRequestV1 {
+    pub fn new(
+        session_id: impl Into<String>,
+        query: impl Into<String>,
+        binding: CognitivePackageBindingV1,
+    ) -> CognitiveContextResult<Self> {
+        let mut request = Self {
+            schema: COGNITIVE_CONTEXT_REQUEST_SCHEMA.to_string(),
+            session_id: session_id.into(),
+            query: query.into(),
+            binding,
+            request_digest: String::new(),
+        };
+        request.request_digest = request.digest()?;
+        request.validate()?;
+        Ok(request)
+    }
+
+    pub fn validate(&self) -> CognitiveContextResult<()> {
+        self.binding.validate()?;
+        if self.schema != COGNITIVE_CONTEXT_REQUEST_SCHEMA
+            || !valid_machine_id(&self.session_id, 256)
+            || self.query.trim() != self.query
+            || self.query.is_empty()
+            || self.query.len() > MAX_QUERY_BYTES
+            || self
+                .query
+                .chars()
+                .any(|character| character.is_control() && !matches!(character, '\n' | '\t'))
+        {
+            return Err(CognitiveContextError::InvalidRequest(
+                "request schema, session, or query is invalid or unbounded".to_string(),
+            ));
+        }
+        if self.request_digest != self.digest()? {
+            return Err(CognitiveContextError::InvalidRequest(
+                "request digest does not bind the exact query and session generation".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn digest(&self) -> CognitiveContextResult<String> {
+        canonical_digest(
+            COGNITIVE_CONTEXT_REQUEST_DIGEST_DOMAIN,
+            &(
+                self.schema.as_str(),
+                self.session_id.as_str(),
+                self.query.as_str(),
+                &self.binding,
+            ),
+        )
+    }
+}
+
+/// Use-owned citation projected into the cross-project R0 carrier.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveKnowledgeCitationV1 {
+    pub schema: String,
+    pub package_id: String,
+    pub package_version: String,
+    pub lifecycle_generation: u64,
+    pub generation_digest: String,
+    pub surface_id: String,
+    pub content_digest: String,
+    pub document_path: String,
+    pub heading: String,
+    pub evidence_ids: Vec<String>,
+    pub citation_digest: String,
+}
+
+impl CognitiveKnowledgeCitationV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        binding: &CognitivePackageBindingV1,
+        document_path: impl Into<String>,
+        heading: impl Into<String>,
+        evidence_ids: Vec<String>,
+    ) -> CognitiveContextResult<Self> {
+        let mut citation = Self {
+            schema: OKF_KNOWLEDGE_CITATION_SCHEMA.to_string(),
+            package_id: binding.package_id.clone(),
+            package_version: binding.package_version.clone(),
+            lifecycle_generation: binding.lifecycle_generation,
+            generation_digest: binding.generation_digest.clone(),
+            surface_id: binding.knowledge.surface_id.clone(),
+            content_digest: binding.knowledge.content_digest.clone(),
+            document_path: document_path.into(),
+            heading: heading.into(),
+            evidence_ids,
+            citation_digest: String::new(),
+        };
+        citation.citation_digest = citation.digest()?;
+        citation.validate_for(binding)?;
+        Ok(citation)
+    }
+
+    pub fn validate_for(&self, binding: &CognitivePackageBindingV1) -> CognitiveContextResult<()> {
+        binding.validate()?;
+        if self.schema != OKF_KNOWLEDGE_CITATION_SCHEMA
+            || self.package_id != binding.package_id
+            || self.package_version != binding.package_version
+            || self.lifecycle_generation != binding.lifecycle_generation
+            || self.generation_digest != binding.generation_digest
+            || self.surface_id != binding.knowledge.surface_id
+            || self.content_digest != binding.knowledge.content_digest
+        {
+            return Err(response_drift(
+                "citation does not belong to the session's exact package generation and Knowledge surface",
+            ));
+        }
+        if !valid_markdown_path(&self.document_path)
+            || self.heading.trim() != self.heading
+            || self.heading.is_empty()
+            || self.heading.len() > MAX_HEADING_BYTES
+            || self.heading.chars().any(char::is_control)
+            || self.evidence_ids.is_empty()
+            || self.evidence_ids.len() > MAX_EVIDENCE_IDS
+            || !self.evidence_ids.iter().all(|value| valid_sha256(value))
+            || !self.evidence_ids.windows(2).all(|pair| pair[0] < pair[1])
+        {
+            return Err(response_drift(
+                "citation path, heading, or canonical evidence identity set is invalid",
+            ));
+        }
+        if self.citation_digest != self.digest()? {
+            return Err(response_drift("citation digest was substituted"));
+        }
+        Ok(())
+    }
+
+    fn digest(&self) -> CognitiveContextResult<String> {
+        canonical_digest(
+            OKF_KNOWLEDGE_CITATION_SCHEMA,
+            &(
+                self.package_id.as_str(),
+                self.package_version.as_str(),
+                self.lifecycle_generation,
+                &self.generation_digest,
+                self.surface_id.as_str(),
+                self.content_digest.as_str(),
+                self.document_path.as_str(),
+                self.heading.as_str(),
+                &self.evidence_ids,
+            ),
+        )
+    }
+}
+
+/// One complete bounded Markdown read and its unchanged citation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveContextDocumentV1 {
+    pub citation: CognitiveKnowledgeCitationV1,
+    pub source_digest: String,
+    pub content: String,
+    pub byte_count: usize,
+}
+
+impl CognitiveContextDocumentV1 {
+    pub fn new(
+        citation: CognitiveKnowledgeCitationV1,
+        content: impl Into<String>,
+    ) -> CognitiveContextResult<Self> {
+        let content = content.into();
+        let document = Self {
+            citation,
+            source_digest: sha256(content.as_bytes()),
+            byte_count: content.len(),
+            content,
+        };
+        if document.content.is_empty() {
+            return Err(response_drift("cognitive document is empty"));
+        }
+        Ok(document)
+    }
+
+    fn validate_for(&self, request: &CognitiveContextRequestV1) -> CognitiveContextResult<()> {
+        self.citation.validate_for(&request.binding)?;
+        if self.content.is_empty()
+            || self.byte_count != self.content.len()
+            || self.byte_count > request.binding.limits.max_document_bytes
+            || !valid_sha256(&self.source_digest)
+            || self.source_digest != sha256(self.content.as_bytes())
+        {
+            return Err(response_drift(
+                "document bytes do not match the cited bounded source read",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Exact response that Code validates before converting it to prompt context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CognitiveContextResponseV1 {
+    pub schema: String,
+    pub request_digest: String,
+    pub binding: CognitivePackageBindingV1,
+    pub documents: Vec<CognitiveContextDocumentV1>,
+    pub truncated: bool,
+}
+
+impl CognitiveContextResponseV1 {
+    pub fn new(
+        request: &CognitiveContextRequestV1,
+        documents: Vec<CognitiveContextDocumentV1>,
+        truncated: bool,
+    ) -> CognitiveContextResult<Self> {
+        let response = Self {
+            schema: COGNITIVE_CONTEXT_RESPONSE_SCHEMA.to_string(),
+            request_digest: request.request_digest.clone(),
+            binding: request.binding.clone(),
+            documents,
+            truncated,
+        };
+        response.validate_for(request)?;
+        Ok(response)
+    }
+
+    pub fn validate_for(&self, request: &CognitiveContextRequestV1) -> CognitiveContextResult<()> {
+        request.validate()?;
+        self.binding.validate()?;
+        if self.schema != COGNITIVE_CONTEXT_RESPONSE_SCHEMA
+            || self.request_digest != request.request_digest
+            || self.binding != request.binding
+            || self.documents.is_empty()
+            || self.documents.len() > request.binding.limits.max_results
+        {
+            return Err(response_drift(
+                "response schema, request, generation, or result count drifted",
+            ));
+        }
+
+        let mut total_bytes = 0usize;
+        let mut citations = HashSet::with_capacity(self.documents.len());
+        for document in &self.documents {
+            document.validate_for(request)?;
+            total_bytes = total_bytes
+                .checked_add(document.byte_count)
+                .ok_or_else(|| {
+                    response_drift("response byte accounting overflowed its bounded integer")
+                })?;
+            if !citations.insert(document.citation.citation_digest.as_str()) {
+                return Err(response_drift("response repeats a cited document"));
+            }
+        }
+        if total_bytes > request.binding.limits.max_total_bytes {
+            return Err(response_drift(
+                "response exceeds the session's total cognitive context byte bound",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Host port. Implementations typically hold an A3S Use exact-generation
+/// Knowledge lease; Code sees only bounded cited reads and never the Registry,
+/// package filesystem, ontology graph, or a personal-memory fallback.
+#[async_trait::async_trait]
+pub trait CognitiveContextProvider: Send + Sync {
+    fn name(&self) -> &str;
+
+    async fn query(
+        &self,
+        request: &CognitiveContextRequestV1,
+    ) -> CognitiveContextResult<CognitiveContextResponseV1>;
+}
+
+/// Runtime pairing of one durable binding with one non-serializable host port.
+#[derive(Clone)]
+pub struct CognitiveContextSession {
+    binding: CognitivePackageBindingV1,
+    provider: Arc<dyn CognitiveContextProvider>,
+}
+
+impl std::fmt::Debug for CognitiveContextSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CognitiveContextSession")
+            .field("binding", &self.binding)
+            .field("provider", &self.provider.name())
+            .finish()
+    }
+}
+
+impl CognitiveContextSession {
+    pub fn new(
+        binding: CognitivePackageBindingV1,
+        provider: Arc<dyn CognitiveContextProvider>,
+    ) -> CognitiveContextResult<Self> {
+        binding.validate()?;
+        if !valid_plain_value(provider.name(), MAX_PROVIDER_NAME_BYTES) {
+            return Err(CognitiveContextError::Provider(
+                "provider name is empty, unbounded, or contains control characters".to_string(),
+            ));
+        }
+        Ok(Self { binding, provider })
+    }
+
+    pub fn binding(&self) -> &CognitivePackageBindingV1 {
+        &self.binding
+    }
+
+    pub fn provider_name(&self) -> &str {
+        self.provider.name()
+    }
+}
+
+#[async_trait::async_trait]
+impl ContextProvider for CognitiveContextSession {
+    fn name(&self) -> &str {
+        self.provider.name()
+    }
+
+    fn failure_mode(&self) -> ContextProviderFailureMode {
+        ContextProviderFailureMode::FailClosed
+    }
+
+    fn cognitive_package_binding(&self) -> Option<&CognitivePackageBindingV1> {
+        Some(&self.binding)
+    }
+
+    async fn query(&self, query: &ContextQuery) -> anyhow::Result<ContextResult> {
+        if !query.context_types.is_empty() && !query.context_types.contains(&ContextType::Resource)
+        {
+            return Err(CognitiveContextError::InvalidRequest(
+                "cognitive packages expose cited resources only".to_string(),
+            )
+            .into());
+        }
+        let session_id = query.session_id.as_deref().unwrap_or_default();
+        let request =
+            CognitiveContextRequestV1::new(session_id, query.query.clone(), self.binding.clone())?;
+        let response = self.provider.query(&request).await?;
+        response.validate_for(&request)?;
+
+        let mut result = ContextResult::new(self.provider.name());
+        result.truncated = response.truncated;
+        for (position, document) in response.documents.into_iter().enumerate() {
+            let citation_json = serde_json::to_value(&document.citation)?;
+            let binding_json = serde_json::to_value(&self.binding)?;
+            let source_digest = document.source_digest.clone();
+            let rendered = format!(
+                "[cognitive citation={} document={} heading={}]\n\n{}",
+                document.citation.citation_digest,
+                document.citation.document_path,
+                document.citation.heading,
+                document.content
+            );
+            let token_count = rendered.len().div_ceil(4).max(1);
+            let relevance = (1.0_f32 - (position as f32 * 0.02)).max(0.9);
+            result.add_item(
+                ContextItem::new(
+                    document.citation.citation_digest.clone(),
+                    ContextType::Resource,
+                    rendered,
+                )
+                .with_source(format!(
+                    "a3s-use://citation/{}",
+                    document
+                        .citation
+                        .citation_digest
+                        .strip_prefix("sha256:")
+                        .unwrap_or(&document.citation.citation_digest)
+                ))
+                .with_metadata(COGNITIVE_CITATION_METADATA, citation_json)
+                .with_metadata(COGNITIVE_PACKAGE_BINDING_METADATA, binding_json)
+                .with_metadata("a3s.cognitive.source_digest", source_digest.into())
+                .with_provenance("a3s-use-cognitive-package")
+                .with_priority(1.0)
+                .with_trust(1.0)
+                .with_freshness(1.0)
+                .with_relevance(relevance)
+                .with_token_count(token_count),
+            );
+        }
+        Ok(result)
+    }
+}
+
+fn capability_snapshot_digest(
+    binding: &CognitivePackageBindingV1,
+) -> CognitiveContextResult<String> {
+    canonical_digest(
+        CAPABILITY_SNAPSHOT_DIGEST_DOMAIN,
+        &(
+            binding.package_id.as_str(),
+            binding.package_version.as_str(),
+            binding.lifecycle_generation,
+            &binding.generation_digest,
+            binding.knowledge.surface_id.as_str(),
+            binding.knowledge.format_version.as_str(),
+            binding.knowledge.content_digest.as_str(),
+        ),
+    )
+}
+
+fn canonical_digest<T: Serialize + ?Sized>(
+    domain: &str,
+    value: &T,
+) -> CognitiveContextResult<String> {
+    let encoded = serde_json::to_vec(value).map_err(|error| {
+        CognitiveContextError::InvalidBinding(format!(
+            "canonical identity could not be serialized: {error}"
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(CANONICAL_DIGEST_PREFIX);
+    hasher.update((domain.len() as u64).to_be_bytes());
+    hasher.update(domain.as_bytes());
+    hasher.update((encoded.len() as u64).to_be_bytes());
+    hasher.update(encoded);
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn invalid_binding(message: impl Into<String>) -> CognitiveContextError {
+    CognitiveContextError::InvalidBinding(message.into())
+}
+
+fn response_drift(message: impl Into<String>) -> CognitiveContextError {
+    CognitiveContextError::ResponseDrift(message.into())
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|digest| {
+        digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    })
+}
+
+fn valid_machine_id(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.is_ascii()
+        && value
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b':' | b'/' | b'@')
+        })
+}
+
+fn valid_plain_value(value: &str, max_bytes: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_bytes
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+}
+
+fn valid_package_id(value: &str) -> bool {
+    value.split_once('/').is_some_and(|(publisher, name)| {
+        !publisher.is_empty()
+            && !name.is_empty()
+            && [publisher, name].into_iter().all(|segment| {
+                segment.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'-' | b'_')
+                })
+            })
+    })
+}
+
+fn valid_markdown_path(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_DOCUMENT_PATH_BYTES
+        && value.ends_with(".md")
+        && !value.starts_with('/')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control)
+        && value
+            .split('/')
+            .all(|component| !component.is_empty() && !matches!(component, "." | ".."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(byte: u8) -> String {
+        format!("sha256:{}", format!("{byte:02x}").repeat(32))
+    }
+
+    fn binding() -> CognitivePackageBindingV1 {
+        let knowledge =
+            CognitiveKnowledgeBindingV1::new("domain-knowledge", "0.2", digest(1), 7, digest(2))
+                .unwrap();
+        let mut binding = CognitivePackageBindingV1 {
+            schema: COGNITIVE_PACKAGE_BINDING_SCHEMA.to_string(),
+            package_id: "contra-sense/handbook".to_string(),
+            package_version: "0.1.0".to_string(),
+            lifecycle_generation: 7,
+            generation_digest: digest(2),
+            capability_snapshot_digest: String::new(),
+            knowledge,
+            limits: CognitiveContextLimits::default(),
+        };
+        binding.capability_snapshot_digest = capability_snapshot_digest(&binding).unwrap();
+        binding.validate().unwrap();
+        binding
+    }
+
+    fn response(request: &CognitiveContextRequestV1) -> CognitiveContextResponseV1 {
+        let citation = CognitiveKnowledgeCitationV1::new(
+            &request.binding,
+            "concepts/retry-policy.md",
+            "Retry policy",
+            vec![digest(3)],
+        )
+        .unwrap();
+        let document = CognitiveContextDocumentV1::new(
+            citation,
+            "Retry only before an observable side effect.",
+        )
+        .unwrap();
+        CognitiveContextResponseV1::new(request, vec![document], false).unwrap()
+    }
+
+    #[test]
+    fn exact_binding_rejects_latest_and_capability_drift() {
+        let mut unpinned = binding();
+        unpinned.lifecycle_generation = 0;
+        unpinned.knowledge.lifecycle_generation = 0;
+        assert!(matches!(
+            unpinned.validate(),
+            Err(CognitiveContextError::InvalidBinding(_))
+        ));
+
+        let mut drifted = binding();
+        drifted.knowledge.content_digest = digest(9);
+        assert!(matches!(
+            drifted.validate(),
+            Err(CognitiveContextError::InvalidBinding(_))
+        ));
+    }
+
+    #[test]
+    fn response_rejects_generation_citation_and_source_drift() {
+        let request = CognitiveContextRequestV1::new("session-1", "retry", binding()).unwrap();
+
+        let mut generation = response(&request);
+        generation.binding.lifecycle_generation += 1;
+        assert!(matches!(
+            generation.validate_for(&request),
+            Err(CognitiveContextError::ResponseDrift(_))
+                | Err(CognitiveContextError::InvalidBinding(_))
+        ));
+
+        let mut citation = response(&request);
+        citation.documents[0].citation.heading = "Substituted".to_string();
+        assert!(matches!(
+            citation.validate_for(&request),
+            Err(CognitiveContextError::ResponseDrift(_))
+        ));
+
+        let mut source = response(&request);
+        source.documents[0].content.push_str(" changed");
+        source.documents[0].byte_count = source.documents[0].content.len();
+        assert!(matches!(
+            source.validate_for(&request),
+            Err(CognitiveContextError::ResponseDrift(_))
+        ));
+    }
+
+    #[test]
+    fn response_rejects_empty_duplicate_and_unbounded_documents() {
+        let request = CognitiveContextRequestV1::new("session-1", "retry", binding()).unwrap();
+        assert!(CognitiveContextResponseV1::new(&request, Vec::new(), false).is_err());
+
+        let valid = response(&request);
+        let duplicate = vec![valid.documents[0].clone(), valid.documents[0].clone()];
+        assert!(CognitiveContextResponseV1::new(&request, duplicate, false).is_err());
+
+        let citation = CognitiveKnowledgeCitationV1::new(
+            &request.binding,
+            "concepts/large.md",
+            "Large",
+            vec![digest(4)],
+        )
+        .unwrap();
+        let large = CognitiveContextDocumentV1::new(
+            citation,
+            "x".repeat(request.binding.limits.max_document_bytes + 1),
+        )
+        .unwrap();
+        assert!(CognitiveContextResponseV1::new(&request, vec![large], false).is_err());
+    }
+}

--- a/core/src/context/mod.rs
+++ b/core/src/context/mod.rs
@@ -328,6 +328,19 @@ pub struct ContextResult {
     pub truncated: bool,
 }
 
+/// Runtime behavior when one context provider returns an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ContextProviderFailureMode {
+    /// Preserve the existing general-purpose RAG behavior: log and omit the
+    /// failed provider while other sources may continue.
+    #[default]
+    BestEffort,
+    /// Abort the turn. Used by exact-generation cognitive packages so a
+    /// provider failure cannot silently fall back to memory, graph data, or an
+    /// unpinned package.
+    FailClosed,
+}
+
 impl ContextResult {
     /// Create a new empty result
     pub fn new(provider: impl Into<String>) -> Self {
@@ -365,6 +378,22 @@ impl ContextResult {
 pub trait ContextProvider: Send + Sync {
     /// Provider name (used for identification and logging)
     fn name(&self) -> &str;
+
+    /// Whether provider failure may be omitted or must abort the turn.
+    fn failure_mode(&self) -> ContextProviderFailureMode {
+        ContextProviderFailureMode::BestEffort
+    }
+
+    /// Exact cognitive-package identity, when this is Code's typed adapter.
+    ///
+    /// Hosts must install such an adapter through
+    /// [`SessionOptions::with_cognitive_context`](crate::SessionOptions::with_cognitive_context)
+    /// so the same value is persisted in the session snapshot.
+    fn cognitive_package_binding(
+        &self,
+    ) -> Option<&crate::cognitive_context::CognitivePackageBindingV1> {
+        None
+    }
 
     /// Query the provider for relevant context
     async fn query(&self, query: &ContextQuery) -> anyhow::Result<ContextResult>;

--- a/core/src/event_protocol.rs
+++ b/core/src/event_protocol.rs
@@ -69,6 +69,7 @@ define_agent_event_types_v1! {
     PermissionDenied => PERMISSION_DENIED = "permission_denied",
     ContextResolving => CONTEXT_RESOLVING = "context_resolving",
     ContextResolved => CONTEXT_RESOLVED = "context_resolved",
+    CognitiveContextBound => COGNITIVE_CONTEXT_BOUND = "cognitive_context_bound",
     CommandDeadLettered => COMMAND_DEAD_LETTERED = "command_dead_lettered",
     CommandRetry => COMMAND_RETRY = "command_retry",
     QueueAlert => QUEUE_ALERT = "queue_alert",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod agent_protocol_host;
 pub mod budget;
 pub(crate) mod child_run;
 pub mod code_intelligence;
+pub mod cognitive_context;
 pub mod commands;
 pub(crate) mod compaction;
 pub mod config;
@@ -163,6 +164,16 @@ pub use code_intelligence::{
     CodeIntelligenceStatus, CodeLocation, CodePosition, CodeQueryResult, CodeRange, CodeSymbolKind,
     DocumentRevision, DocumentSnapshot, DocumentSymbol, LanguageId, LocalCodeIntelligence,
     NavigationKind, SymbolInformation, WorkspaceCodeIntelligence,
+};
+pub use cognitive_context::{
+    CognitiveContextDocumentV1, CognitiveContextError, CognitiveContextLimits,
+    CognitiveContextProvider, CognitiveContextRequestV1, CognitiveContextResponseV1,
+    CognitiveContextResult, CognitiveContextSession, CognitiveKnowledgeBindingV1,
+    CognitiveKnowledgeCitationV1, CognitivePackageBindingV1,
+    COGNITIVE_CONTEXT_REQUEST_DIGEST_DOMAIN, COGNITIVE_CONTEXT_REQUEST_SCHEMA,
+    COGNITIVE_CONTEXT_RESPONSE_SCHEMA, COGNITIVE_KNOWLEDGE_BINDING_SCHEMA,
+    COGNITIVE_PACKAGE_BINDING_SCHEMA, OKF_KNOWLEDGE_CITATION_SCHEMA,
+    OKF_KNOWLEDGE_READ_REQUEST_SCHEMA, OKF_KNOWLEDGE_SEARCH_REQUEST_SCHEMA,
 };
 pub use config::{
     AutoDelegationConfig, CodeConfig, ModelConfig, ModelCost, ModelLimit, ModelModalities,

--- a/core/src/store/session_data.rs
+++ b/core/src/store/session_data.rs
@@ -214,6 +214,14 @@ pub struct SessionData {
     /// in the host's observability pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub correlation_id: Option<String>,
+
+    /// Exact A3S Use cognitive-package generation bound to this session.
+    ///
+    /// The provider/lease is intentionally not serialized. A resume host must
+    /// inject a provider with this byte-equivalent binding; Code never resolves
+    /// a replacement or `latest` generation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cognitive_package_binding: Option<crate::cognitive_context::CognitivePackageBindingV1>,
 }
 
 /// Serializable LLM configuration

--- a/core/src/store/session_snapshot.rs
+++ b/core/src/store/session_snapshot.rs
@@ -121,6 +121,14 @@ impl SessionSnapshotV1 {
     /// retained length. It must, however, remain a valid next-sequence cursor
     /// for every retained event.
     pub fn validate_invariants(&self) -> Result<()> {
+        if let Some(binding) = &self.session.cognitive_package_binding {
+            binding.validate().map_err(|error| {
+                anyhow::anyhow!(
+                    "session snapshot {:?} has an invalid cognitive package binding: {error}",
+                    self.session.id
+                )
+            })?;
+        }
         let mut run_ids = HashSet::with_capacity(self.run_records.len());
 
         for (run_index, record) in self.run_records.iter().enumerate() {
@@ -158,6 +166,23 @@ impl SessionSnapshotV1 {
                     }
                 }
                 previous_sequence = Some(event.sequence);
+                if let crate::agent::AgentEvent::CognitiveContextBound { binding } = &event.event {
+                    match &self.session.cognitive_package_binding {
+                        Some(expected) if expected == binding => {}
+                        Some(_) => bail!(
+                            "run {:?} event {} carries a cognitive generation different from session {:?}",
+                            run_id,
+                            event_index,
+                            self.session.id
+                        ),
+                        None => bail!(
+                            "run {:?} event {} carries cognitive context but session {:?} is unbound",
+                            run_id,
+                            event_index,
+                            self.session.id
+                        ),
+                    }
+                }
             }
 
             if let Some(max_sequence) = previous_sequence {

--- a/core/src/store/tests.rs
+++ b/core/src/store/tests.rs
@@ -79,6 +79,7 @@ fn create_test_session_data() -> SessionData {
         principal: None,
         agent_template_id: None,
         correlation_id: None,
+        cognitive_package_binding: None,
         total_cost: 0.0,
         model_name: None,
         cost_records: Vec::new(),

--- a/core/tests/event_protocol_v1.rs
+++ b/core/tests/event_protocol_v1.rs
@@ -2,7 +2,8 @@ use a3s_code_core::planning::{AgentGoal, Complexity, ExecutionPlan, TaskStatus};
 use a3s_code_core::queue::SessionLane;
 use a3s_code_core::verification::VerificationSummary;
 use a3s_code_core::{
-    run_event_envelope_v1, AgentEvent, AgentEventProjectionV1, EventEnvelopeV1, TokenUsage,
+    run_event_envelope_v1, AgentEvent, AgentEventProjectionV1, CognitiveContextLimits,
+    CognitiveKnowledgeBindingV1, CognitivePackageBindingV1, EventEnvelopeV1, TokenUsage,
     AGENT_EVENT_TYPES_V1,
 };
 use serde_json::json;
@@ -26,6 +27,29 @@ fn case(
         payload_key,
         payload_value,
     }
+}
+
+fn cognitive_binding() -> CognitivePackageBindingV1 {
+    let generation_digest =
+        "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20";
+    let knowledge = CognitiveKnowledgeBindingV1::new(
+        "domain-knowledge",
+        "0.2",
+        "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+        7,
+        generation_digest,
+    )
+    .unwrap();
+    CognitivePackageBindingV1::new(
+        "contra-sense/handbook",
+        "0.1.0",
+        7,
+        generation_digest,
+        "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+        knowledge,
+        CognitiveContextLimits::default(),
+    )
+    .unwrap()
 }
 
 fn representative_events() -> Vec<EventCase> {
@@ -238,6 +262,14 @@ fn representative_events() -> Vec<EventCase> {
             },
             "total_items",
             json!(3),
+        ),
+        case(
+            "cognitive_context_bound",
+            AgentEvent::CognitiveContextBound {
+                binding: cognitive_binding(),
+            },
+            "binding",
+            serde_json::to_value(cognitive_binding()).unwrap(),
         ),
         case(
             "command_dead_lettered",

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/README.md
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/README.md
@@ -1,0 +1,61 @@
+# R0 cross-project contract fixtures
+
+This data-only package freezes the first Agentic Ontology -> A3S Use -> A3S
+Code -> A3S Cloud integration boundary. It does not grant package lifecycle,
+Knowledge, Agent, tenant, publication, or authorization authority.
+
+## Ownership
+
+- Agentic Ontology owns the candidate handoff and this integration projection.
+- A3S Use owns the reviewed lock, Registry generation, installed receipt,
+  Knowledge capability projection, and exact-generation search/read behavior.
+- A3S Code owns the Agent release, session, run, events, result, and task proof.
+- A3S Cloud owns organization, Workspace, immutable release, execution, and
+  audit identities.
+
+Every runtime must resolve and revalidate the referenced state from its own
+authority. A digest in this package is evidence identity, not authority to
+perform the referenced operation. No consumer may replace an exact identity
+with local `latest` state.
+
+## Canonical fixtures
+
+- `a3s-use-handoff.valid.json` is a real, revision-bound compiler handoff.
+- `plugin-package-lock.json`, `registry-snapshot.json`,
+  `extension-receipt.json`, and `a3s-use-generation-receipt.json` freeze the
+  exact reviewed A3S Use generation evidence.
+- `knowledge-lease-binding.json`, `capability-snapshot.json`, and
+  `knowledge-citation.json` freeze the minimum Agent-facing OKF search/read and
+  citation projection. They expose no internal `GraphProjection` or source
+  repository.
+- `code-run-identity.json`, `code-session-binding.json`, and
+  `code-task-result.json` freeze the exact Code session/run and task proof
+  fields.
+- `cloud-audit-link.json` connects the candidate, generation, execution, and
+  task proof without merging their owners.
+- `r0-cross-project.valid.json` is the complete accepted projection.
+
+The `*.drift*.json` and `*.unknown-field.json` files are intentionally invalid.
+Consumers must reject handoff digest, lifecycle generation, Code run, Cloud
+task proof, and closed-schema drift.
+
+## Digest rules
+
+Agentic Ontology canonical digests use SHA-256 over:
+
+1. `agentic-ontology-canonical-v1\0`;
+2. the big-endian `u64` byte length of the ASCII domain and the domain bytes;
+3. the big-endian `u64` byte length of compact deterministic JSON and those
+   JSON bytes.
+
+A3S Use lock, Registry snapshot, and extension receipt digests use the owning
+Use contract's canonical JSON rules. `manifest.json` records the raw SHA-256
+and byte length of every other package file. Its `packageDigest` uses the
+Agentic Ontology canonical algorithm with domain
+`agentic.ontology.r0-contract-fixture-package.v1` over the ordered `files`
+array.
+
+All four repositories vendor this directory byte-for-byte and pin the raw
+`manifest.json` digest in their conformance test. Changes require a new
+versioned package or an explicitly reviewed compatible fixture update across
+all four consumers.

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-generation-receipt.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-generation-receipt.json
@@ -1,0 +1,47 @@
+{
+  "schema": "agentic.ontology.a3s-use-generation-receipt.v1",
+  "issuer": "a3s-use",
+  "hostTarget": "darwin-arm64",
+  "useVersion": "0.3.0",
+  "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+  "package": {
+    "name": "handbook",
+    "publisher": "contra-sense"
+  },
+  "version": "0.1.0",
+  "revision": {
+    "generation": 1,
+    "referenceDigest": "sha256:7afef23f602009096a853a28ad581abbab3d55f155a9f11c383a0827661aa619",
+    "revisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "schema": "agentic.ontology.knowledge-revision-ref.v1",
+    "scope": {
+      "authorityGeneration": 1,
+      "organizationId": "test-org",
+      "revision": 1,
+      "scopeDigest": "sha256:dd55078071b6525e01d5052f1e532fa5eeb0357336a7e26b5985fbb5bf5f880c",
+      "scopeId": "handbook",
+      "workspaceId": "compiler-tests"
+    }
+  },
+  "draftDigest": "sha256:95178701b9bfe1cd89bbba9ba0afecd0b2ad9414fd79ae754bb7df9044cb56d5",
+  "channel": "stable",
+  "lifecycleGeneration": 7,
+  "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+  "registryGeneration": 9,
+  "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2",
+  "closure": [
+    {
+      "packageId": "contra-sense/handbook",
+      "version": "0.1.0",
+      "lifecycleGeneration": 7,
+      "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+      "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+      "catalogDigest": "sha256:430b6bea7e6d9e6677e563373f736037b5c7575a2b427adb81198b02fec30b2d",
+      "extensionReceiptDigest": "sha256:c679fa6417f32ce6b04f2567b31c90e561063df513876ea7b4cd4b11380f7437",
+      "registryName": "fixture",
+      "trustRootDigest": "sha256:4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2"
+    }
+  ],
+  "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+  "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-handoff.drift.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-handoff.drift.json
@@ -1,0 +1,46 @@
+{
+  "approvalDigest": "sha256:3898c93d35bda1ee12481abab11eaf00c23a46eb355947edd192a4789e6bb5ca",
+  "blueprintDigest": "sha256:d6e310ee60ca8f514b2a1af6a275babb43b6ea32b39be5f337b9d3bf7ecafbd2",
+  "compilerPackageDigest": "sha256:d0fd0d366bbc628847e8de05bed273441bcf51f15a00b310d39206a2bb23e232",
+  "dependencies": [],
+  "draftDigest": "sha256:95178701b9bfe1cd89bbba9ba0afecd0b2ad9414fd79ae754bb7df9044cb56d5",
+  "expandedBytes": 13805,
+  "fileCount": 10,
+  "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+  "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+  "package": {
+    "name": "handbook",
+    "publisher": "contra-sense"
+  },
+  "project": "handbook",
+  "requestedChannel": "stable",
+  "requiresUse": ">=0.3.0, <0.4.0",
+  "revision": {
+    "generation": 1,
+    "referenceDigest": "sha256:7afef23f602009096a853a28ad581abbab3d55f155a9f11c383a0827661aa619",
+    "revisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "schema": "agentic.ontology.knowledge-revision-ref.v1",
+    "scope": {
+      "authorityGeneration": 1,
+      "organizationId": "test-org",
+      "revision": 1,
+      "scopeDigest": "sha256:dd55078071b6525e01d5052f1e532fa5eeb0357336a7e26b5985fbb5bf5f880c",
+      "scopeId": "handbook",
+      "workspaceId": "compiler-tests"
+    }
+  },
+  "revisionActivationReceiptDigest": "sha256:19538e263e4229e81b409f8229edc5b5486da844b252745780ff7e2103da25c0",
+  "route": "handbook",
+  "schema": "agentic.ontology.a3s-use-handoff.v1",
+  "scope": {
+    "authorityGeneration": 1,
+    "organizationId": "test-org",
+    "revision": 1,
+    "scopeDigest": "sha256:dd55078071b6525e01d5052f1e532fa5eeb0357336a7e26b5985fbb5bf5f880c",
+    "scopeId": "handbook",
+    "workspaceId": "compiler-tests"
+  },
+  "surfaceGraphDigest": "sha256:e6e8c26ab51262e61bbf6abd5b0644c74e43478f0fe830b65954586444ce7a22",
+  "usePackageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+  "version": "0.2.0"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-handoff.valid.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/a3s-use-handoff.valid.json
@@ -1,0 +1,46 @@
+{
+  "schema": "agentic.ontology.a3s-use-handoff.v1",
+  "project": "handbook",
+  "scope": {
+    "organizationId": "test-org",
+    "workspaceId": "compiler-tests",
+    "authorityGeneration": 1,
+    "scopeId": "handbook",
+    "revision": 1,
+    "scopeDigest": "sha256:dd55078071b6525e01d5052f1e532fa5eeb0357336a7e26b5985fbb5bf5f880c"
+  },
+  "package": {
+    "publisher": "contra-sense",
+    "name": "handbook"
+  },
+  "version": "0.1.0",
+  "route": "handbook",
+  "requiresUse": ">=0.3.0, <0.4.0",
+  "dependencies": [],
+  "requestedChannel": "stable",
+  "revision": {
+    "schema": "agentic.ontology.knowledge-revision-ref.v1",
+    "scope": {
+      "organizationId": "test-org",
+      "workspaceId": "compiler-tests",
+      "authorityGeneration": 1,
+      "scopeId": "handbook",
+      "revision": 1,
+      "scopeDigest": "sha256:dd55078071b6525e01d5052f1e532fa5eeb0357336a7e26b5985fbb5bf5f880c"
+    },
+    "generation": 1,
+    "revisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "referenceDigest": "sha256:7afef23f602009096a853a28ad581abbab3d55f155a9f11c383a0827661aa619"
+  },
+  "draftDigest": "sha256:95178701b9bfe1cd89bbba9ba0afecd0b2ad9414fd79ae754bb7df9044cb56d5",
+  "approvalDigest": "sha256:3898c93d35bda1ee12481abab11eaf00c23a46eb355947edd192a4789e6bb5ca",
+  "revisionActivationReceiptDigest": "sha256:19538e263e4229e81b409f8229edc5b5486da844b252745780ff7e2103da25c0",
+  "blueprintDigest": "sha256:d6e310ee60ca8f514b2a1af6a275babb43b6ea32b39be5f337b9d3bf7ecafbd2",
+  "surfaceGraphDigest": "sha256:e6e8c26ab51262e61bbf6abd5b0644c74e43478f0fe830b65954586444ce7a22",
+  "compilerPackageDigest": "sha256:d0fd0d366bbc628847e8de05bed273441bcf51f15a00b310d39206a2bb23e232",
+  "usePackageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+  "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+  "fileCount": 10,
+  "expandedBytes": 13805,
+  "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/capability-snapshot.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/capability-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+  "lifecycleGeneration": 7,
+  "packageId": "contra-sense/handbook",
+  "packageVersion": "0.1.0",
+  "schema": "a3s.use.capability-snapshot.v1",
+  "snapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+  "surfaces": [
+    {
+      "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+      "formatVersion": "0.2",
+      "id": "domain-knowledge",
+      "kind": "okf"
+    }
+  ]
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/cloud-audit-link.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/cloud-audit-link.json
@@ -1,0 +1,11 @@
+{
+  "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+  "organizationId": "018f4f86-0000-7000-8000-000000000001",
+  "workspaceId": "018f4f86-0000-7000-8000-000000000002",
+  "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+  "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+  "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+  "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+  "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+  "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-run-identity.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-run-identity.json
@@ -1,0 +1,7 @@
+{
+  "agent_release_identity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+  "protocol": "a3s.code.agent.v1",
+  "run_id": "run-execution-018f4f86-attempt-1",
+  "schema": "a3s.code.agent-run-identity.v1",
+  "session_id": "conversation-018f4f86"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-session-binding.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-session-binding.json
@@ -1,0 +1,17 @@
+{
+  "schema": "agentic.ontology.r0-code-session-binding.v1",
+  "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1",
+  "agentProtocol": "a3s.code.agent.v1",
+  "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+  "sessionId": "conversation-018f4f86",
+  "runId": "run-execution-018f4f86-attempt-1",
+  "packageId": "contra-sense/handbook",
+  "packageVersion": "0.1.0",
+  "lifecycleGeneration": 7,
+  "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+  "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+  "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+  "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+  "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+  "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-task-result.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/code-task-result.json
@@ -1,0 +1,8 @@
+{
+  "citationDigests": [
+    "sha256:1c188e092ae62c5b07aee0c5015c4a728ecf5422ce1d7ee4d71c35b963851a4d"
+  ],
+  "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+  "schema": "a3s.code.agent-task-result.v1",
+  "text": "Retry only before an observable side effect."
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/extension-receipt.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/extension-receipt.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": 3,
+  "packageId": "contra-sense/handbook",
+  "componentId": "use/contra-sense/handbook",
+  "route": "handbook",
+  "version": "0.1.0",
+  "packageRoot": "packages/contra-sense/handbook/lifecycle-7-e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+  "manifestSha256": "986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+  "packageSha256": "e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+  "trust": "registry-tuf",
+  "registry": {
+    "registryName": "fixture",
+    "registryUrl": "https://registry.example.test/",
+    "rootSha256": "4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2",
+    "rootVersion": 1,
+    "timestampVersion": 2,
+    "snapshotVersion": 3,
+    "targetsVersion": 4,
+    "packageId": "contra-sense/handbook",
+    "version": "0.1.0",
+    "channel": "stable",
+    "target": "darwin-arm64",
+    "targetName": "extensions/contra-sense/handbook/0.1.0/stable/darwin-arm64/handbook.tar.gz",
+    "archiveName": "handbook.tar.gz",
+    "length": 1,
+    "sha256": "0eb3e36bfb24dcd9bb1d1bece1531216b59539a8fde17ee80224af0653c92aa3"
+  },
+  "verifiedCatalog": {
+    "record": {
+      "schema": "a3s.use.plugin-catalog.v3",
+      "packageId": "contra-sense/handbook",
+      "displayName": "handbook",
+      "description": "Grounded handbook cognition.",
+      "publisher": "contra-sense",
+      "keywords": [
+        "knowledge"
+      ],
+      "categories": [
+        "knowledge"
+      ],
+      "version": "0.1.0",
+      "channel": "stable",
+      "requiresUse": ">=0.3.0, <0.4.0",
+      "target": "darwin-arm64",
+      "surfaces": [
+        {
+          "kind": "okf",
+          "id": "domain-knowledge",
+          "optional": false,
+          "okfBundle": {
+            "schema": "a3s.use.okf-bundle.v1",
+            "formatVersion": "0.2",
+            "root": "okf/domain-knowledge",
+            "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+            "conceptCount": 2,
+            "fileCount": 3,
+            "expandedBytes": 1231,
+            "limits": {
+              "maxFiles": 256,
+              "maxConcepts": 64,
+              "maxExpandedBytes": 67108864,
+              "maxDocumentBytes": 1048576,
+              "maxLinksPerDocument": 2048
+            }
+          }
+        },
+        {
+          "kind": "skill",
+          "id": "use-domain-knowledge",
+          "optional": false,
+          "requires": [
+            {
+              "kind": "okf",
+              "id": "domain-knowledge"
+            }
+          ]
+        }
+      ],
+      "permissionCeiling": {
+        "schema": "a3s.use.plugin-permissions.v1",
+        "surfaces": []
+      },
+      "permissionCeilingDigest": "sha256:c0eafc8598409c9fd30b035350a7b15f6c61086cd6210a40dc88cc355f6747d5",
+      "archive": {
+        "targetName": "extensions/contra-sense/handbook/0.1.0/stable/darwin-arm64/handbook.tar.gz",
+        "length": 1,
+        "sha256": "sha256:0eb3e36bfb24dcd9bb1d1bece1531216b59539a8fde17ee80224af0653c92aa3"
+      },
+      "package": {
+        "expandedBytes": 13805,
+        "fileCount": 10,
+        "sha256": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+        "manifestSha256": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147"
+      },
+      "license": "MIT",
+      "repository": "https://github.com/contra-sense/handbook",
+      "availability": {
+        "state": "available"
+      }
+    },
+    "provenance": {
+      "registryName": "fixture",
+      "registryUrl": "https://registry.example.test/",
+      "rootSha256": "sha256:4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2",
+      "rootVersion": 1,
+      "timestampVersion": 2,
+      "snapshotVersion": 3,
+      "targetsVersion": 4,
+      "catalogRecordDigest": "sha256:1fc74f49692e022c330922661c5b4bb43124489c890c2cc8019f0107441e8f13"
+    }
+  },
+  "installedAtUnix": 1786320000,
+  "enabled": true,
+  "lifecycleGeneration": 7
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/knowledge-citation.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/knowledge-citation.json
@@ -1,0 +1,15 @@
+{
+  "citationDigest": "sha256:1c188e092ae62c5b07aee0c5015c4a728ecf5422ce1d7ee4d71c35b963851a4d",
+  "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+  "documentPath": "concepts/retry-policy.md",
+  "evidenceIds": [
+    "sha256:ce8af6b5fb9a69bc2de147dbb0fd8754c9e1b555a96002878560dd9f8914db73"
+  ],
+  "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+  "heading": "Retry policy",
+  "lifecycleGeneration": 7,
+  "packageId": "contra-sense/handbook",
+  "packageVersion": "0.1.0",
+  "schema": "a3s.use.okf-knowledge-citation.v1",
+  "surfaceId": "domain-knowledge"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/knowledge-lease-binding.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/knowledge-lease-binding.json
@@ -1,0 +1,11 @@
+{
+  "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+  "surfaceId": "domain-knowledge",
+  "formatVersion": "0.2",
+  "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+  "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+  "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+  "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+  "lifecycleGeneration": 7,
+  "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/plugin-package-lock.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/plugin-package-lock.json
@@ -1,0 +1,97 @@
+{
+  "schema": "a3s.use.plugin-package-lock.v1",
+  "rootPackageId": "contra-sense/handbook",
+  "host": {
+    "target": "darwin-arm64",
+    "useVersion": "0.3.0"
+  },
+  "packages": [
+    {
+      "catalog": {
+        "record": {
+          "schema": "a3s.use.plugin-catalog.v3",
+          "packageId": "contra-sense/handbook",
+          "displayName": "handbook",
+          "description": "Grounded handbook cognition.",
+          "publisher": "contra-sense",
+          "keywords": [
+            "knowledge"
+          ],
+          "categories": [
+            "knowledge"
+          ],
+          "version": "0.1.0",
+          "channel": "stable",
+          "requiresUse": ">=0.3.0, <0.4.0",
+          "target": "darwin-arm64",
+          "surfaces": [
+            {
+              "kind": "okf",
+              "id": "domain-knowledge",
+              "optional": false,
+              "okfBundle": {
+                "schema": "a3s.use.okf-bundle.v1",
+                "formatVersion": "0.2",
+                "root": "okf/domain-knowledge",
+                "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+                "conceptCount": 2,
+                "fileCount": 3,
+                "expandedBytes": 1231,
+                "limits": {
+                  "maxFiles": 256,
+                  "maxConcepts": 64,
+                  "maxExpandedBytes": 67108864,
+                  "maxDocumentBytes": 1048576,
+                  "maxLinksPerDocument": 2048
+                }
+              }
+            },
+            {
+              "kind": "skill",
+              "id": "use-domain-knowledge",
+              "optional": false,
+              "requires": [
+                {
+                  "kind": "okf",
+                  "id": "domain-knowledge"
+                }
+              ]
+            }
+          ],
+          "permissionCeiling": {
+            "schema": "a3s.use.plugin-permissions.v1",
+            "surfaces": []
+          },
+          "permissionCeilingDigest": "sha256:c0eafc8598409c9fd30b035350a7b15f6c61086cd6210a40dc88cc355f6747d5",
+          "archive": {
+            "targetName": "extensions/contra-sense/handbook/0.1.0/stable/darwin-arm64/handbook.tar.gz",
+            "length": 1,
+            "sha256": "sha256:0eb3e36bfb24dcd9bb1d1bece1531216b59539a8fde17ee80224af0653c92aa3"
+          },
+          "package": {
+            "expandedBytes": 13805,
+            "fileCount": 10,
+            "sha256": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+            "manifestSha256": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147"
+          },
+          "license": "MIT",
+          "repository": "https://github.com/contra-sense/handbook",
+          "availability": {
+            "state": "available"
+          }
+        },
+        "provenance": {
+          "registryName": "fixture",
+          "registryUrl": "https://registry.example.test/",
+          "rootSha256": "sha256:4813494d137e1631bba301d5acab6e7bb7aa74ce1185d456565ef51d737677b2",
+          "rootVersion": 1,
+          "timestampVersion": 2,
+          "snapshotVersion": 3,
+          "targetsVersion": 4,
+          "catalogRecordDigest": "sha256:1fc74f49692e022c330922661c5b4bb43124489c890c2cc8019f0107441e8f13"
+        }
+      },
+      "dependencies": []
+    }
+  ]
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-cloud-task-proof.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-cloud-task-proof.json
@@ -1,0 +1,67 @@
+{
+  "candidate": {
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "requestedChannel": "stable"
+  },
+  "cloud": {
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "taskProofDigest": "sha256:fc73521d53f66043721d9bd63da3410b95b698de6f023ba6deea17d3bf43d257",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002"
+  },
+  "code": {
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "runId": "run-execution-018f4f86-attempt-1",
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "sessionId": "conversation-018f4f86",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130",
+  "generation": {
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "hostTarget": "darwin-arm64",
+    "issuer": "a3s-use",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "packageVersion": "0.1.0",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2"
+  },
+  "knowledge": {
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "formatVersion": "0.2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "surfaceId": "domain-knowledge"
+  },
+  "schema": "agentic.ontology.r0-cross-project-contract.v1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-generation.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-generation.json
@@ -1,0 +1,67 @@
+{
+  "candidate": {
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "requestedChannel": "stable"
+  },
+  "cloud": {
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002"
+  },
+  "code": {
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "runId": "run-execution-018f4f86-attempt-1",
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "sessionId": "conversation-018f4f86",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130",
+  "generation": {
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "hostTarget": "darwin-arm64",
+    "issuer": "a3s-use",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "packageVersion": "0.1.0",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2"
+  },
+  "knowledge": {
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "formatVersion": "0.2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 8,
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "surfaceId": "domain-knowledge"
+  },
+  "schema": "agentic.ontology.r0-cross-project-contract.v1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-handoff-digest.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-handoff-digest.json
@@ -1,0 +1,67 @@
+{
+  "candidate": {
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "requestedChannel": "stable"
+  },
+  "cloud": {
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002"
+  },
+  "code": {
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "runId": "run-execution-018f4f86-attempt-1",
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "sessionId": "conversation-018f4f86",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130",
+  "generation": {
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "handoffDigest": "sha256:36101cf3dd9080c3f2aa898dfab75b9b8869cd0e1c4c3a0c8d65fa61ffd1c949",
+    "hostTarget": "darwin-arm64",
+    "issuer": "a3s-use",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "packageVersion": "0.1.0",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2"
+  },
+  "knowledge": {
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "formatVersion": "0.2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "surfaceId": "domain-knowledge"
+  },
+  "schema": "agentic.ontology.r0-cross-project-contract.v1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-session.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.drift-session.json
@@ -1,0 +1,67 @@
+{
+  "candidate": {
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "requestedChannel": "stable"
+  },
+  "cloud": {
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002"
+  },
+  "code": {
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "runId": "run-execution-018f4f86-attempt-2",
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "sessionId": "conversation-018f4f86",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130",
+  "generation": {
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "hostTarget": "darwin-arm64",
+    "issuer": "a3s-use",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "packageVersion": "0.1.0",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2"
+  },
+  "knowledge": {
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "formatVersion": "0.2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "surfaceId": "domain-knowledge"
+  },
+  "schema": "agentic.ontology.r0-cross-project-contract.v1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.unknown-field.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.unknown-field.json
@@ -1,0 +1,68 @@
+{
+  "ambientLatest": true,
+  "candidate": {
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "requestedChannel": "stable"
+  },
+  "cloud": {
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002"
+  },
+  "code": {
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "runId": "run-execution-018f4f86-attempt-1",
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "sessionId": "conversation-018f4f86",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130",
+  "generation": {
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "hostTarget": "darwin-arm64",
+    "issuer": "a3s-use",
+    "lifecycleGeneration": 7,
+    "packageId": "contra-sense/handbook",
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "packageVersion": "0.1.0",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2"
+  },
+  "knowledge": {
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "formatVersion": "0.2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "lifecycleGeneration": 7,
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "surfaceId": "domain-knowledge"
+  },
+  "schema": "agentic.ontology.r0-cross-project-contract.v1"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.valid.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/r0-cross-project.valid.json
@@ -1,0 +1,67 @@
+{
+  "schema": "agentic.ontology.r0-cross-project-contract.v1",
+  "candidate": {
+    "handoffSchema": "agentic.ontology.a3s-use-handoff.v1",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "knowledgeRevisionDigest": "sha256:a9062f672f407b4dad0eb417a23a61e5230bef7b5081f02bdf7c25129b3bad47",
+    "packageDigest": "sha256:e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+    "manifestDigest": "sha256:986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+    "requestedChannel": "stable"
+  },
+  "generation": {
+    "receiptSchema": "agentic.ontology.a3s-use-generation-receipt.v1",
+    "receiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "issuer": "a3s-use",
+    "hostTarget": "darwin-arm64",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "lifecycleGeneration": 7,
+    "packageLockDigest": "sha256:3c82b7aa9e743d4b31647522c9ece185aae0512a5ffe2caa09eedc7094e5aba0",
+    "registryGeneration": 9,
+    "registrySnapshotDigest": "sha256:d6651ddd64e5047aede35da3b31cc035b2eea3eec65a4df79659e65e066dfea2",
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20"
+  },
+  "knowledge": {
+    "schema": "agentic.ontology.r0-knowledge-lease-binding.v1",
+    "surfaceId": "domain-knowledge",
+    "formatVersion": "0.2",
+    "contentDigest": "sha256:1def786da6d190b7b3ce0176e71d99ff1cac3f8c8cc7c0f8b76a893c544e7a90",
+    "searchSchema": "a3s.use.okf-knowledge-search-request.v1",
+    "readSchema": "a3s.use.okf-knowledge-read-request.v1",
+    "citationSchema": "a3s.use.okf-knowledge-citation.v1",
+    "lifecycleGeneration": 7,
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20"
+  },
+  "code": {
+    "schema": "agentic.ontology.r0-code-session-binding.v1",
+    "taskProofSchema": "agentic.ontology.r0-code-task-proof.v1",
+    "agentProtocol": "a3s.code.agent.v1",
+    "agentReleaseIdentity": "sha256:4be0c29b983f7b2fe0caed9c670aff2bd27b904c9ebc461a3de1dc3168289e8a",
+    "sessionId": "conversation-018f4f86",
+    "runId": "run-execution-018f4f86-attempt-1",
+    "packageId": "contra-sense/handbook",
+    "packageVersion": "0.1.0",
+    "lifecycleGeneration": 7,
+    "generationDigest": "sha256:aa0beeb62f1b7b21bf70f21e6f0e858a1e4b720d313f0907209b5b9dad2eeb20",
+    "capabilitySnapshotDigest": "sha256:1e0f0a0162f5b290887ade8886af69fbba4548c863df026178e3550c77813455",
+    "commandReceiptDigest": "sha256:e1cb762543082588aac9797c50fdfc8ad9a78f2007b4ebc10fd69e3f8c91cfea",
+    "eventStreamDigest": "sha256:054fa992c9036e244b190ce374254d5cee7626a2ae21ed57a72866fe38fa82f0",
+    "resultDigest": "sha256:32926710ce39d5993da5095340b121144cb473147698a9b4c63defcbc67b411b",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e"
+  },
+  "cloud": {
+    "schema": "agentic.ontology.r0-cloud-audit-link.v1",
+    "organizationId": "018f4f86-0000-7000-8000-000000000001",
+    "workspaceId": "018f4f86-0000-7000-8000-000000000002",
+    "packageReleaseId": "018f4f86-0000-7000-8000-000000000003",
+    "agentExecutionId": "018f4f86-0000-7000-8000-000000000004",
+    "handoffDigest": "sha256:c92f8bfdb4435ceeeeb76f32d89edf054782e9a7f286e1aa9a9647a0513ff779",
+    "generationReceiptDigest": "sha256:c121af75cfff61274980ba78757db9bdcbafedae59efba846f691e3c65167cb1",
+    "taskProofDigest": "sha256:2c8adb3f4d86f36b82d2ad74ff370dcb3d7920ac2cb26efd909193d8272c6b3e",
+    "auditDigest": "sha256:a0784bec8384d8c681b29436c4e61ccefa85be1143f92b7b6e2389bbcf0e66c5"
+  },
+  "contractDigest": "sha256:4d882dc21334d873d6dcde1a758baba2548d8f5bc159d184d90b7b8f41e6d130"
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/registry-snapshot.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/fixtures/registry-snapshot.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "generation": 9,
+  "routes": [
+    {
+      "packageId": "contra-sense/handbook",
+      "componentId": "use/contra-sense/handbook",
+      "route": "handbook",
+      "version": "0.1.0",
+      "packageRoot": "packages/contra-sense/handbook/lifecycle-7-e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+      "manifestSha256": "986fa67c3a77d47898a6d5267c9108816510641974855e1ce0225d2d3e2d6147",
+      "packageSha256": "e8cffdfa8b638fe2f1dc3db85a6e16ba850d3236766a63acbda167bdfe1f8ecc",
+      "lifecycleGeneration": 7,
+      "enabled": true,
+      "surfaces": [
+        "okf",
+        "skill"
+      ]
+    }
+  ]
+}

--- a/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/manifest.json
+++ b/core/tests/fixtures/agentic-ontology/r0-cross-project-v1/manifest.json
@@ -1,0 +1,130 @@
+{
+  "schema": "agentic.ontology.r0-contract-fixture-manifest.v1",
+  "package": "r0-cross-project-v1",
+  "contractSchema": "agentic.ontology.r0-cross-project-contract.v1",
+  "components": [
+    {
+      "component": "a3s-cloud-contracts",
+      "version": "0.1.0",
+      "boundary": "agentic.ontology.r0-cloud-audit-link.v1"
+    },
+    {
+      "component": "a3s-code-core",
+      "version": "6.8.0",
+      "boundary": "a3s.code.agent.v1"
+    },
+    {
+      "component": "a3s-use",
+      "version": "0.3.0",
+      "boundary": "agentic.ontology.a3s-use-generation-receipt.v1"
+    },
+    {
+      "component": "agentic-ontology-a3s",
+      "version": "0.1.0",
+      "boundary": "agentic.ontology.r0-cross-project-contract.v1"
+    }
+  ],
+  "packageDigest": "sha256:63c86b457c79a8ec153ecf5d13485cdbf4cff8e15c074614775197d7c0206016",
+  "files": [
+    {
+      "path": "README.md",
+      "bytes": 2862,
+      "sha256": "sha256:85e3d70949fd0d0ffb627f4cfb9b3ab6f1dcb807e5c6d52918680dba7766a524"
+    },
+    {
+      "path": "fixtures/a3s-use-generation-receipt.json",
+      "bytes": 2137,
+      "sha256": "sha256:58b8177372a817b8c18460e03f861b2deb56523a36ccc4ae01aad805591aecfb"
+    },
+    {
+      "path": "fixtures/a3s-use-handoff.drift.json",
+      "bytes": 2045,
+      "sha256": "sha256:9cdee5482eb4f8beb4ee0e57bcebe7e5aa5076de3e40334e29f2fac82e36d09b"
+    },
+    {
+      "path": "fixtures/a3s-use-handoff.valid.json",
+      "bytes": 2045,
+      "sha256": "sha256:7dfa9b3800e135d3c9bce6d11d88935eb1f69482e327100d4d135bef350c3eb7"
+    },
+    {
+      "path": "fixtures/capability-snapshot.json",
+      "bytes": 551,
+      "sha256": "sha256:ed2ffc5952a67fd67aee92b56c90c28407f2ea492c432e834c8bac956cc93484"
+    },
+    {
+      "path": "fixtures/cloud-audit-link.json",
+      "bytes": 685,
+      "sha256": "sha256:2d909de5de135b38ed1d92ea4b8f1315d3a004f7c9d061e027495319d80cffd2"
+    },
+    {
+      "path": "fixtures/code-run-identity.json",
+      "bytes": 276,
+      "sha256": "sha256:183c2417d5b67553e14bf1ed8cadb31fc3427621cfd4f49f6052bcae344c6002"
+    },
+    {
+      "path": "fixtures/code-session-binding.json",
+      "bytes": 1040,
+      "sha256": "sha256:1abdc80079507b5270c0774f41be07ff34fb617b696cef2ee87c3fc8410415e7"
+    },
+    {
+      "path": "fixtures/code-task-result.json",
+      "bytes": 305,
+      "sha256": "sha256:82851da64a935e46f23acf1b7aac92b6e586782ee83562c5f32b141a143325a8"
+    },
+    {
+      "path": "fixtures/extension-receipt.json",
+      "bytes": 3985,
+      "sha256": "sha256:b79f54dd9b0b02d679975208b9cd23599f6c3e19e7d934cd7996e6b47b6f2c9f"
+    },
+    {
+      "path": "fixtures/knowledge-citation.json",
+      "bytes": 647,
+      "sha256": "sha256:3c0f763defbaaf42f0ad6913f8d6950849b1bc34ee9d9508477042ece3f5848a"
+    },
+    {
+      "path": "fixtures/knowledge-lease-binding.json",
+      "bytes": 520,
+      "sha256": "sha256:b1755b6c5a7789bd179cc3d99d2b1273c175aa320f9a225f99dbbe577094d990"
+    },
+    {
+      "path": "fixtures/plugin-package-lock.json",
+      "bytes": 3327,
+      "sha256": "sha256:048440edf978d680bcc0fcfbc8247ccecf2bbdca8829656cd798ee5b7a4ca8d6"
+    },
+    {
+      "path": "fixtures/r0-cross-project.drift-cloud-task-proof.json",
+      "bytes": 3878,
+      "sha256": "sha256:586cb77daf5d1f06a2a060bdc3a4585b2e80b34040408e711862b3492cee8d98"
+    },
+    {
+      "path": "fixtures/r0-cross-project.drift-generation.json",
+      "bytes": 3878,
+      "sha256": "sha256:b8a2066025fa0b3c57d9b038c6115ddbbb7c38dad18c6639b010a29f0af0fecd"
+    },
+    {
+      "path": "fixtures/r0-cross-project.drift-handoff-digest.json",
+      "bytes": 3878,
+      "sha256": "sha256:7e7c6fefb34db9a4cec89269552d537b6e699e0f737dd17ce008a2520ed3daff"
+    },
+    {
+      "path": "fixtures/r0-cross-project.drift-session.json",
+      "bytes": 3878,
+      "sha256": "sha256:5f74fd8a58b276768f85e1cc96ea7e44d165ed62902e33c4ee4f0ce7a7c38572"
+    },
+    {
+      "path": "fixtures/r0-cross-project.unknown-field.json",
+      "bytes": 3903,
+      "sha256": "sha256:99533ec14ff3d609c368c338e1d28a2256f9e905898074908b54dde5c3324a94"
+    },
+    {
+      "path": "fixtures/r0-cross-project.valid.json",
+      "bytes": 3878,
+      "sha256": "sha256:0a7b2b538851d0b8611e32bc21a53ad33c3e3573d2019e71003e3f29394628fd"
+    },
+    {
+      "path": "fixtures/registry-snapshot.json",
+      "bytes": 651,
+      "sha256": "sha256:859470630d3689febef60205045e024e8ac2bdbc4e95960c6011cbe8e7e00877"
+    }
+  ]
+}

--- a/core/tests/r0_cross_project_contract.rs
+++ b/core/tests/r0_cross_project_contract.rs
@@ -1,0 +1,227 @@
+mod r0_cross_project_support;
+
+use std::path::Path;
+
+use a3s_code_core::{
+    AgentProtocolRunIdentityV1, CognitiveContextLimits, CognitiveKnowledgeBindingV1,
+    CognitiveKnowledgeCitationV1, CognitivePackageBindingV1,
+};
+use r0_cross_project_support::{
+    canonical_digest, read_fixture, verify_fixture_package, CodeBinding, Contract, ContractError,
+    KnowledgeBinding,
+};
+use serde::Deserialize;
+
+const FIXTURE_ROOT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/agentic-ontology/r0-cross-project-v1"
+);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilitySnapshotFixture {
+    schema: String,
+    package_id: String,
+    package_version: String,
+    lifecycle_generation: u64,
+    generation_digest: String,
+    surfaces: Vec<CapabilitySurfaceFixture>,
+    snapshot_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CapabilitySurfaceFixture {
+    kind: String,
+    id: String,
+    format_version: String,
+    content_digest: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TaskResultFixture {
+    schema: String,
+    text: String,
+    citation_digests: Vec<String>,
+    result_digest: String,
+}
+
+#[test]
+fn code_accepts_the_pinned_package_and_rejects_all_contract_drift() {
+    let root = Path::new(FIXTURE_ROOT);
+    verify_fixture_package(root).unwrap();
+    Contract::parse(&read_fixture(root, "fixtures/r0-cross-project.valid.json")).unwrap();
+
+    for (path, expected) in [
+        (
+            "fixtures/r0-cross-project.unknown-field.json",
+            ContractError::Invalid,
+        ),
+        (
+            "fixtures/r0-cross-project.drift-handoff-digest.json",
+            ContractError::BindingMismatch,
+        ),
+        (
+            "fixtures/r0-cross-project.drift-generation.json",
+            ContractError::BindingMismatch,
+        ),
+        (
+            "fixtures/r0-cross-project.drift-session.json",
+            ContractError::DigestMismatch,
+        ),
+        (
+            "fixtures/r0-cross-project.drift-cloud-task-proof.json",
+            ContractError::BindingMismatch,
+        ),
+    ] {
+        assert_eq!(
+            Contract::parse(&read_fixture(root, path)).unwrap_err(),
+            expected,
+            "{path}"
+        );
+    }
+}
+
+#[test]
+fn code_owns_and_validates_the_exact_agent_run_identity() {
+    let root = Path::new(FIXTURE_ROOT);
+    let contract =
+        Contract::parse(&read_fixture(root, "fixtures/r0-cross-project.valid.json")).unwrap();
+    let code: CodeBinding = read_json(root, "fixtures/code-session-binding.json");
+    assert_eq!(code, contract.code);
+    let identity: AgentProtocolRunIdentityV1 = read_json(root, "fixtures/code-run-identity.json");
+    identity.validate().unwrap();
+    assert_eq!(identity.protocol, code.agent_protocol);
+    assert_eq!(identity.agent_release_identity, code.agent_release_identity);
+    assert_eq!(identity.session_id, code.session_id);
+    assert_eq!(identity.run_id, code.run_id);
+
+    let mut another_run = identity.clone();
+    another_run.run_id = "run-execution-018f4f86-attempt-2".into();
+    another_run.validate().unwrap();
+    assert_ne!(another_run.run_id, code.run_id);
+    assert_eq!(
+        Contract::parse(&read_fixture(
+            root,
+            "fixtures/r0-cross-project.drift-session.json"
+        ))
+        .unwrap_err(),
+        ContractError::DigestMismatch
+    );
+}
+
+#[test]
+fn code_binds_one_use_generation_capability_and_cited_result() {
+    let root = Path::new(FIXTURE_ROOT);
+    let contract =
+        Contract::parse(&read_fixture(root, "fixtures/r0-cross-project.valid.json")).unwrap();
+    let knowledge: KnowledgeBinding = read_json(root, "fixtures/knowledge-lease-binding.json");
+    assert_eq!(knowledge, contract.knowledge);
+    let runtime_knowledge: CognitiveKnowledgeBindingV1 =
+        read_json(root, "fixtures/knowledge-lease-binding.json");
+    runtime_knowledge.validate().unwrap();
+    let capability: CapabilitySnapshotFixture =
+        read_json(root, "fixtures/capability-snapshot.json");
+    assert_eq!(capability.schema, "a3s.use.capability-snapshot.v1");
+    assert_eq!(capability.package_id, contract.code.package_id);
+    assert_eq!(capability.package_version, contract.code.package_version);
+    assert_eq!(
+        capability.lifecycle_generation,
+        contract.code.lifecycle_generation
+    );
+    assert_eq!(
+        capability.generation_digest,
+        contract.code.generation_digest
+    );
+    assert_eq!(capability.surfaces.len(), 1);
+    let surface = &capability.surfaces[0];
+    assert_eq!(surface.kind, "okf");
+    assert_eq!(surface.id, knowledge.surface_id);
+    assert_eq!(surface.format_version, knowledge.format_version);
+    assert_eq!(surface.content_digest, knowledge.content_digest);
+    assert_eq!(
+        capability.snapshot_digest,
+        canonical_digest(
+            "a3s.use.capability-snapshot.v1",
+            &(
+                capability.package_id.as_str(),
+                capability.package_version.as_str(),
+                capability.lifecycle_generation,
+                &capability.generation_digest,
+                surface.id.as_str(),
+                surface.format_version.as_str(),
+                surface.content_digest.as_str(),
+            ),
+        )
+    );
+    assert_eq!(
+        capability.snapshot_digest,
+        contract.code.capability_snapshot_digest
+    );
+    let runtime_binding = CognitivePackageBindingV1::new(
+        capability.package_id.clone(),
+        capability.package_version.clone(),
+        capability.lifecycle_generation,
+        capability.generation_digest.clone(),
+        capability.snapshot_digest.clone(),
+        runtime_knowledge,
+        CognitiveContextLimits::default(),
+    )
+    .unwrap();
+
+    let citation: CognitiveKnowledgeCitationV1 =
+        read_json(root, "fixtures/knowledge-citation.json");
+    citation.validate_for(&runtime_binding).unwrap();
+    assert_eq!(citation.schema, knowledge.citation_schema);
+    assert_eq!(citation.package_id, contract.code.package_id);
+    assert_eq!(citation.package_version, contract.code.package_version);
+    assert_eq!(
+        citation.lifecycle_generation,
+        contract.code.lifecycle_generation
+    );
+    assert_eq!(citation.generation_digest, contract.code.generation_digest);
+    assert_eq!(citation.surface_id, knowledge.surface_id);
+    assert_eq!(citation.content_digest, knowledge.content_digest);
+    assert!(!citation.document_path.starts_with('/'));
+    assert!(!citation.document_path.contains(".."));
+    assert!(!citation.heading.trim().is_empty());
+    assert!(!citation.evidence_ids.is_empty());
+    assert_eq!(
+        citation.citation_digest,
+        canonical_digest(
+            "a3s.use.okf-knowledge-citation.v1",
+            &(
+                citation.package_id.as_str(),
+                citation.package_version.as_str(),
+                citation.lifecycle_generation,
+                &citation.generation_digest,
+                citation.surface_id.as_str(),
+                citation.content_digest.as_str(),
+                citation.document_path.as_str(),
+                citation.heading.as_str(),
+                &citation.evidence_ids,
+            ),
+        )
+    );
+
+    let result: TaskResultFixture = read_json(root, "fixtures/code-task-result.json");
+    assert_eq!(result.schema, "a3s.code.agent-task-result.v1");
+    assert_eq!(result.citation_digests, [citation.citation_digest]);
+    assert_eq!(
+        result.result_digest,
+        canonical_digest(
+            "a3s.code.agent-task-result.v1",
+            &(
+                result.schema.as_str(),
+                result.text.as_str(),
+                &result.citation_digests,
+            ),
+        )
+    );
+    assert_eq!(result.result_digest, contract.code.result_digest);
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(root: &Path, path: &str) -> T {
+    serde_json::from_slice(&read_fixture(root, path)).unwrap()
+}

--- a/core/tests/r0_cross_project_support.rs
+++ b/core/tests/r0_cross_project_support.rs
@@ -1,0 +1,455 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const MANIFEST_SHA256: &str =
+    "sha256:ac858d66c68b16442b16e8fd8a11caada06207e810ff64d98358b1a3887fb2c9";
+const PACKAGE_DIGEST_DOMAIN: &str = "agentic.ontology.r0-contract-fixture-package.v1";
+const TASK_PROOF_DIGEST_DOMAIN: &str = "agentic.ontology.r0-code-task-proof.v1";
+const CLOUD_AUDIT_DIGEST_DOMAIN: &str = "agentic.ontology.r0-cloud-audit-link.v1";
+const CONTRACT_DIGEST_DOMAIN: &str = "agentic.ontology.r0-cross-project-contract.v1";
+const MAX_CONTRACT_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractError {
+    Invalid,
+    BindingMismatch,
+    DigestMismatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Contract {
+    pub schema: String,
+    pub candidate: CandidateBinding,
+    pub generation: GenerationBinding,
+    pub knowledge: KnowledgeBinding,
+    pub code: CodeBinding,
+    pub cloud: CloudBinding,
+    pub contract_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CandidateBinding {
+    pub handoff_schema: String,
+    pub handoff_digest: String,
+    pub package_id: String,
+    pub package_version: String,
+    pub knowledge_revision_digest: String,
+    pub package_digest: String,
+    pub manifest_digest: String,
+    pub requested_channel: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GenerationBinding {
+    pub receipt_schema: String,
+    pub receipt_digest: String,
+    pub issuer: String,
+    pub host_target: String,
+    pub handoff_digest: String,
+    pub package_id: String,
+    pub package_version: String,
+    pub lifecycle_generation: u64,
+    pub package_lock_digest: String,
+    pub registry_generation: u64,
+    pub registry_snapshot_digest: String,
+    pub generation_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct KnowledgeBinding {
+    pub schema: String,
+    pub surface_id: String,
+    pub format_version: String,
+    pub content_digest: String,
+    pub search_schema: String,
+    pub read_schema: String,
+    pub citation_schema: String,
+    pub lifecycle_generation: u64,
+    pub generation_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CodeBinding {
+    pub schema: String,
+    pub task_proof_schema: String,
+    pub agent_protocol: String,
+    pub agent_release_identity: String,
+    pub session_id: String,
+    pub run_id: String,
+    pub package_id: String,
+    pub package_version: String,
+    pub lifecycle_generation: u64,
+    pub generation_digest: String,
+    pub capability_snapshot_digest: String,
+    pub command_receipt_digest: String,
+    pub event_stream_digest: String,
+    pub result_digest: String,
+    pub task_proof_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CloudBinding {
+    pub schema: String,
+    pub organization_id: String,
+    pub workspace_id: String,
+    pub package_release_id: String,
+    pub agent_execution_id: String,
+    pub handoff_digest: String,
+    pub generation_receipt_digest: String,
+    pub task_proof_digest: String,
+    pub audit_digest: String,
+}
+
+impl Contract {
+    pub fn parse(bytes: &[u8]) -> Result<Self, ContractError> {
+        if bytes.is_empty() || bytes.len() > MAX_CONTRACT_BYTES {
+            return Err(ContractError::Invalid);
+        }
+        let contract = serde_json::from_slice::<Self>(bytes).map_err(|_| ContractError::Invalid)?;
+        contract.validate()?;
+        Ok(contract)
+    }
+
+    pub fn validate(&self) -> Result<(), ContractError> {
+        if self.schema != "agentic.ontology.r0-cross-project-contract.v1"
+            || self.candidate.handoff_schema != "agentic.ontology.a3s-use-handoff.v1"
+            || self.generation.receipt_schema != "agentic.ontology.a3s-use-generation-receipt.v1"
+            || self.generation.issuer != "a3s-use"
+            || self.knowledge.schema != "agentic.ontology.r0-knowledge-lease-binding.v1"
+            || self.knowledge.search_schema != "a3s.use.okf-knowledge-search-request.v1"
+            || self.knowledge.read_schema != "a3s.use.okf-knowledge-read-request.v1"
+            || self.knowledge.citation_schema != "a3s.use.okf-knowledge-citation.v1"
+            || self.knowledge.format_version != "0.2"
+            || self.code.schema != "agentic.ontology.r0-code-session-binding.v1"
+            || self.code.task_proof_schema != "agentic.ontology.r0-code-task-proof.v1"
+            || self.code.agent_protocol != "a3s.code.agent.v1"
+            || self.cloud.schema != "agentic.ontology.r0-cloud-audit-link.v1"
+            || !matches!(
+                self.candidate.requested_channel.as_str(),
+                "stable" | "beta" | "nightly"
+            )
+            || self.generation.lifecycle_generation == 0
+            || self.generation.registry_generation == 0
+            || self.knowledge.lifecycle_generation == 0
+            || !valid_package_id(&self.candidate.package_id)
+            || self.candidate.package_version.trim().is_empty()
+        {
+            return Err(ContractError::Invalid);
+        }
+        for id in [
+            &self.generation.host_target,
+            &self.knowledge.surface_id,
+            &self.code.session_id,
+            &self.code.run_id,
+            &self.cloud.organization_id,
+            &self.cloud.workspace_id,
+            &self.cloud.package_release_id,
+            &self.cloud.agent_execution_id,
+        ] {
+            if !valid_id(id) {
+                return Err(ContractError::Invalid);
+            }
+        }
+        for digest in [
+            &self.candidate.handoff_digest,
+            &self.candidate.knowledge_revision_digest,
+            &self.candidate.package_digest,
+            &self.candidate.manifest_digest,
+            &self.generation.receipt_digest,
+            &self.generation.handoff_digest,
+            &self.generation.package_lock_digest,
+            &self.generation.registry_snapshot_digest,
+            &self.generation.generation_digest,
+            &self.knowledge.content_digest,
+            &self.knowledge.generation_digest,
+            &self.code.agent_release_identity,
+            &self.code.generation_digest,
+            &self.code.capability_snapshot_digest,
+            &self.code.command_receipt_digest,
+            &self.code.event_stream_digest,
+            &self.code.result_digest,
+            &self.code.task_proof_digest,
+            &self.cloud.handoff_digest,
+            &self.cloud.generation_receipt_digest,
+            &self.cloud.task_proof_digest,
+            &self.cloud.audit_digest,
+            &self.contract_digest,
+        ] {
+            if !valid_digest(digest) {
+                return Err(ContractError::Invalid);
+            }
+        }
+        if self.generation.handoff_digest != self.candidate.handoff_digest
+            || self.generation.package_id != self.candidate.package_id
+            || self.generation.package_version != self.candidate.package_version
+            || self.knowledge.lifecycle_generation != self.generation.lifecycle_generation
+            || self.knowledge.generation_digest != self.generation.generation_digest
+            || self.code.package_id != self.candidate.package_id
+            || self.code.package_version != self.candidate.package_version
+            || self.code.lifecycle_generation != self.generation.lifecycle_generation
+            || self.code.generation_digest != self.generation.generation_digest
+            || self.cloud.handoff_digest != self.candidate.handoff_digest
+            || self.cloud.generation_receipt_digest != self.generation.receipt_digest
+            || self.cloud.task_proof_digest != self.code.task_proof_digest
+        {
+            return Err(ContractError::BindingMismatch);
+        }
+        if self.code.task_proof_digest != self.task_proof_digest()
+            || self.cloud.audit_digest != self.cloud_audit_digest()
+            || self.contract_digest != self.complete_digest()
+        {
+            return Err(ContractError::DigestMismatch);
+        }
+        Ok(())
+    }
+
+    fn task_proof_digest(&self) -> String {
+        canonical_digest(
+            TASK_PROOF_DIGEST_DOMAIN,
+            &(
+                &self.code.task_proof_schema,
+                &self.code.agent_protocol,
+                &self.code.agent_release_identity,
+                &self.code.session_id,
+                &self.code.run_id,
+                &self.code.package_id,
+                &self.code.package_version,
+                self.code.lifecycle_generation,
+                &self.code.generation_digest,
+                &self.code.capability_snapshot_digest,
+                &self.code.command_receipt_digest,
+                &self.code.event_stream_digest,
+                &self.code.result_digest,
+            ),
+        )
+    }
+
+    fn cloud_audit_digest(&self) -> String {
+        canonical_digest(
+            CLOUD_AUDIT_DIGEST_DOMAIN,
+            &(
+                &self.cloud.organization_id,
+                &self.cloud.workspace_id,
+                &self.cloud.package_release_id,
+                &self.cloud.agent_execution_id,
+                &self.cloud.handoff_digest,
+                &self.cloud.generation_receipt_digest,
+                &self.cloud.task_proof_digest,
+            ),
+        )
+    }
+
+    fn complete_digest(&self) -> String {
+        canonical_digest(
+            CONTRACT_DIGEST_DOMAIN,
+            &(
+                &self.schema,
+                &self.candidate,
+                &self.generation,
+                &self.knowledge,
+                &self.code,
+                &self.cloud,
+            ),
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureManifest {
+    schema: String,
+    package: String,
+    contract_schema: String,
+    components: Vec<FixtureComponent>,
+    package_digest: String,
+    files: Vec<FixtureFile>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureComponent {
+    component: String,
+    version: String,
+    boundary: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FixtureFile {
+    path: String,
+    bytes: u64,
+    sha256: String,
+}
+
+pub fn verify_fixture_package(root: &Path) -> Result<(), String> {
+    let manifest_bytes = std::fs::read(root.join("manifest.json")).map_err(|e| e.to_string())?;
+    if sha256(&manifest_bytes) != MANIFEST_SHA256 {
+        return Err("vendored manifest digest drifted".into());
+    }
+    let manifest: FixtureManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|e| e.to_string())?;
+    if manifest.schema != "agentic.ontology.r0-contract-fixture-manifest.v1"
+        || manifest.package != "r0-cross-project-v1"
+        || manifest.contract_schema != "agentic.ontology.r0-cross-project-contract.v1"
+        || manifest
+            .components
+            .iter()
+            .map(|component| {
+                (
+                    component.component.as_str(),
+                    component.version.as_str(),
+                    component.boundary.as_str(),
+                )
+            })
+            .collect::<Vec<_>>()
+            != [
+                (
+                    "a3s-cloud-contracts",
+                    "0.1.0",
+                    "agentic.ontology.r0-cloud-audit-link.v1",
+                ),
+                ("a3s-code-core", "6.8.0", "a3s.code.agent.v1"),
+                (
+                    "a3s-use",
+                    "0.3.0",
+                    "agentic.ontology.a3s-use-generation-receipt.v1",
+                ),
+                (
+                    "agentic-ontology-a3s",
+                    "0.1.0",
+                    "agentic.ontology.r0-cross-project-contract.v1",
+                ),
+            ]
+        || manifest.files.is_empty()
+        || !manifest
+            .files
+            .windows(2)
+            .all(|pair| pair[0].path < pair[1].path)
+    {
+        return Err("vendored fixture manifest is invalid".into());
+    }
+    let mut declared = Vec::with_capacity(manifest.files.len());
+    for file in &manifest.files {
+        if !safe_relative_path(&file.path) || !valid_digest(&file.sha256) {
+            return Err(format!("unsafe fixture entry {}", file.path));
+        }
+        let bytes = std::fs::read(root.join(&file.path)).map_err(|e| e.to_string())?;
+        if u64::try_from(bytes.len()).unwrap_or(u64::MAX) != file.bytes
+            || sha256(&bytes) != file.sha256
+        {
+            return Err(format!("fixture bytes drifted for {}", file.path));
+        }
+        declared.push(file.path.clone());
+    }
+    let mut actual = package_files(root)?;
+    actual.retain(|path| path != "manifest.json");
+    if actual != declared {
+        return Err("vendored fixture file set drifted".into());
+    }
+    if canonical_digest(PACKAGE_DIGEST_DOMAIN, &manifest.files) != manifest.package_digest {
+        return Err("vendored package digest drifted".into());
+    }
+    Ok(())
+}
+
+pub fn canonical_digest<T: Serialize + ?Sized>(domain: &str, value: &T) -> String {
+    let encoded = serde_json::to_vec(value).expect("fixture value must serialize");
+    let mut hasher = Sha256::new();
+    hasher.update(b"agentic-ontology-canonical-v1\0");
+    hasher.update((domain.len() as u64).to_be_bytes());
+    hasher.update(domain.as_bytes());
+    hasher.update((encoded.len() as u64).to_be_bytes());
+    hasher.update(encoded);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+pub fn read_fixture(root: &Path, path: &str) -> Vec<u8> {
+    std::fs::read(root.join(path)).expect("read R0 fixture")
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    })
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 256
+        && value.is_ascii()
+        && !value.bytes().any(|byte| byte.is_ascii_control())
+}
+
+fn valid_package_id(value: &str) -> bool {
+    value.split_once('/').is_some_and(|(publisher, name)| {
+        !publisher.is_empty()
+            && !name.is_empty()
+            && [publisher, name].into_iter().all(|segment| {
+                segment.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'-' | b'_')
+                })
+            })
+    })
+}
+
+fn safe_relative_path(value: &str) -> bool {
+    let path = Path::new(value);
+    !path.as_os_str().is_empty()
+        && !path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)))
+}
+
+fn package_files(root: &Path) -> Result<Vec<String>, String> {
+    fn visit(root: &Path, path: &Path, files: &mut Vec<String>) -> Result<(), String> {
+        let mut entries = std::fs::read_dir(path)
+            .map_err(|e| e.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| e.to_string())?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let file_type = entry.file_type().map_err(|e| e.to_string())?;
+            if file_type.is_symlink() {
+                return Err("fixture package must not contain symlinks".into());
+            }
+            if file_type.is_dir() {
+                visit(root, &entry.path(), files)?;
+            } else if file_type.is_file() {
+                files.push(
+                    entry
+                        .path()
+                        .strip_prefix(root)
+                        .map_err(|e| e.to_string())?
+                        .to_string_lossy()
+                        .replace('\\', "/"),
+                );
+            } else {
+                return Err("fixture package contains an unsupported entry".into());
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = Vec::new();
+    visit(root, root, &mut files)?;
+    files.sort();
+    Ok(files)
+}

--- a/core/tests/test_persisted_schema_roundtrip.rs
+++ b/core/tests/test_persisted_schema_roundtrip.rs
@@ -563,6 +563,7 @@ fn gen_session_data(rng: &mut Rng) -> SessionData {
         principal: rng.opt_string(),
         agent_template_id: rng.opt_string(),
         correlation_id: rng.opt_string(),
+        cognitive_package_binding: None,
     }
 }
 

--- a/scripts/sdk_api_alignment_check.mjs
+++ b/scripts/sdk_api_alignment_check.mjs
@@ -42,6 +42,10 @@ const INTENTIONAL_SESSION_OMISSIONS = new Map([
     'register_dynamic_tool',
     'Requires a Rust Tool trait object; SDK-safe dynamic tools need typed provider APIs.',
   ],
+  [
+    'cognitive_package_binding',
+    'Rust-host cognitive context is injected through a trait object; SDKs cannot create or resume these sessions until a typed callback adapter exists.',
+  ],
 ]);
 
 const AGENT_ALIASES = new Map([
@@ -77,6 +81,10 @@ const INTENTIONAL_SESSION_OPTION_OMISSIONS = new Map([
   ['sandbox_handle', 'Rust BashSandbox trait object; no SDK-safe sandbox provider yet.'],
   ['mcp_manager', 'Rust McpManager handle; SDKs expose add_mcp/remove_mcp runtime APIs.'],
   ['hook_executor', 'Rust HookExecutor trait object; SDKs expose register_hook instead.'],
+  [
+    'cognitive_context',
+    'Rust CognitiveContextProvider trait object; cross-language hosts need a typed callback adapter before this can be value-typed.',
+  ],
 ]);
 
 const SESSION_OPTION_ALIASES = new Map([

--- a/sdk/go/event_protocol_v1.go
+++ b/sdk/go/event_protocol_v1.go
@@ -28,6 +28,7 @@ const (
 	EventPermissionDenied      = "permission_denied"
 	EventContextResolving      = "context_resolving"
 	EventContextResolved       = "context_resolved"
+	EventCognitiveContextBound = "cognitive_context_bound"
 	EventCommandDeadLettered   = "command_dead_lettered"
 	EventCommandRetry          = "command_retry"
 	EventQueueAlert            = "queue_alert"
@@ -75,6 +76,7 @@ var agentEventTypesV1 = [...]string{
 	EventPermissionDenied,
 	EventContextResolving,
 	EventContextResolved,
+	EventCognitiveContextBound,
 	EventCommandDeadLettered,
 	EventCommandRetry,
 	EventQueueAlert,

--- a/sdk/node/event-protocol-v1.d.ts
+++ b/sdk/node/event-protocol-v1.d.ts
@@ -28,6 +28,7 @@ export type KnownAgentEventTypeV1 =
   | 'permission_denied'
   | 'context_resolving'
   | 'context_resolved'
+  | 'cognitive_context_bound'
   | 'command_dead_lettered'
   | 'command_retry'
   | 'queue_alert'

--- a/sdk/python/python/a3s_code/event_protocol_v1.py
+++ b/sdk/python/python/a3s_code/event_protocol_v1.py
@@ -30,6 +30,7 @@ KnownAgentEventTypeV1 = Literal[
     "permission_denied",
     "context_resolving",
     "context_resolved",
+    "cognitive_context_bound",
     "command_dead_lettered",
     "command_retry",
     "queue_alert",
@@ -81,6 +82,7 @@ AGENT_EVENT_TYPES_V1: Final[Tuple[KnownAgentEventTypeV1, ...]] = (
     "permission_denied",
     "context_resolving",
     "context_resolved",
+    "cognitive_context_bound",
     "command_dead_lettered",
     "command_retry",
     "queue_alert",
@@ -131,6 +133,7 @@ class EventType:
     PERMISSION_DENIED: Final[str] = "permission_denied"
     CONTEXT_RESOLVING: Final[str] = "context_resolving"
     CONTEXT_RESOLVED: Final[str] = "context_resolved"
+    COGNITIVE_CONTEXT_BOUND: Final[str] = "cognitive_context_bound"
     COMMAND_DEAD_LETTERED: Final[str] = "command_dead_lettered"
     COMMAND_RETRY: Final[str] = "command_retry"
     QUEUE_ALERT: Final[str] = "queue_alert"


### PR DESCRIPTION
## Summary

- add a Rust-host CognitiveContextSession boundary for one exact A3S Use package generation and Knowledge surface
- validate typed request, binding, citation, source-content, count, and byte identities before prompt injection
- persist the immutable binding in SessionData and SessionSnapshotV1, emit cognitive_context_bound, and require the same host binding on resume
- fail closed on provider/generation/content/citation drift; reject general RAG or graph providers and suppress personal-memory recall for bound turns
- vendor the Agentic Ontology R0 fixture and synchronize the generated Node, Python, and Go event catalogs
- keep Registry lookup, installation, lifecycle, lease ownership, package files, and the human graph outside A3S Code

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- SKIP_REAL_PROVIDER=1 scripts/release_preflight.sh
- CARGO_HTTP_MULTIPLEXING=false bash scripts/check_semver.sh 5.3.5

The complete release preflight passed Rust default/all-features tests, SDK protocol/API alignment, Node smoke and example type checks, Python compilation, Go bridge integration, and the ACL dry run. Real-provider smoke was explicitly skipped because no provider credentials were injected.

## R0 boundary

This consumes the exact-generation Knowledge lease boundary landed by A3S-Lab/Use#92 (merge bb37e8d74d99034775f0fe2d60a8ee03dddb450b). It is owner-repository implementation evidence; the cross-project package-on/package-off/previous-generation integration gate remains separate.