### PR TITLE
perf: defer workspace manifest discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an explicit one-way activation gate for local workspace manifests.
+  Latency-sensitive hosts can construct a `ManifestWorkspaceBackend` without
+  starting its scanner or platform watcher, retain local fallback search while
+  the manifest is empty, and activate asynchronous discovery after their first
+  interactive frame.
 - Added a first-principles capability ledger covering all 20 advertised areas
   and five runtime surfaces, dedicated native Node.js/Python runtime jobs,
   cross-platform retrieval churn, and required hermetic MinIO, Chrome/CDP, and

--- a/README.md
+++ b/README.md
@@ -409,6 +409,15 @@ workspace backends keep the compatible scanner path unless they provide a
 catalog capability. Plain manifest and Code Intelligence sessions do not start
 this additional catalog work.
 
+Latency-sensitive hosts may construct
+`ManifestWorkspaceBackend::new_deferred` or
+`new_deferred_with_access_policy`. The backend keeps ordinary local fallback
+search available while its manifest is empty; calling
+`backend.manifest().activate()` opens a one-way gate that starts the initial
+scan and platform watcher. This lets a terminal or GUI host render its first
+interactive frame before repository-scale discovery begins without weakening
+workspace access or changing the eager constructors.
+
 The compatibility default is deterministic, non-overlapping, UTF-8-safe
 line/byte chunking (80 lines or 64 KiB, at most 128 chunks per file). Typed
 strategies also support fixed byte windows, recursive caller-ordered separators

--- a/core/src/workspace/manifest.rs
+++ b/core/src/workspace/manifest.rs
@@ -35,7 +35,7 @@ use std::sync::{
 #[cfg(test)]
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 
 mod file_kind;
 mod scanner;
@@ -128,6 +128,7 @@ pub struct LocalWorkspaceManifest {
     recent: Arc<RwLock<RecentFiles>>,
     snapshots: broadcast::Sender<LocalWorkspaceManifestSnapshot>,
     changes: broadcast::Sender<WorkspaceFileChange>,
+    activation: watch::Sender<bool>,
     scan_cancelled: Arc<AtomicBool>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -135,6 +136,21 @@ pub struct LocalWorkspaceManifest {
 impl LocalWorkspaceManifest {
     /// Start the manifest scanner/watcher for `root`.
     pub fn start(root: impl Into<PathBuf>) -> Arc<Self> {
+        Self::start_with_activation(root, true)
+    }
+
+    /// Create an empty manifest whose scanner and watcher start only after
+    /// [`Self::activate`] is called.
+    ///
+    /// Search-capable hosts can use this during a latency-sensitive bootstrap:
+    /// manifest-backed operations retain their local filesystem fallback while
+    /// the initial snapshot is empty, so deferring discovery does not make the
+    /// workspace inaccessible.
+    pub fn start_deferred(root: impl Into<PathBuf>) -> Arc<Self> {
+        Self::start_with_activation(root, false)
+    }
+
+    fn start_with_activation(root: impl Into<PathBuf>, active: bool) -> Arc<Self> {
         let root = root.into();
         let root = root.canonicalize().unwrap_or_else(|_| root.clone());
         let initial = LocalWorkspaceManifestSnapshot::empty(root.clone());
@@ -146,12 +162,19 @@ impl LocalWorkspaceManifest {
         let recent = Arc::new(RwLock::new(RecentFiles::default()));
         let (snapshots, _) = broadcast::channel(SNAPSHOT_CHANNEL_CAPACITY);
         let (changes, _) = broadcast::channel(FILE_CHANGE_CHANNEL_CAPACITY);
+        let (activation, mut activation_rx) = watch::channel(active);
         let scan_cancelled = Arc::new(AtomicBool::new(false));
         let task_state = Arc::clone(&state);
         let task_snapshots = snapshots.clone();
         let task_changes = changes.clone();
         let task_scan_cancelled = Arc::clone(&scan_cancelled);
         let task = tokio::spawn(async move {
+            if !*activation_rx.borrow() && activation_rx.wait_for(|active| *active).await.is_err() {
+                return;
+            }
+            if task_scan_cancelled.load(Ordering::Acquire) {
+                return;
+            }
             run_manifest_task(
                 root,
                 task_state,
@@ -166,9 +189,31 @@ impl LocalWorkspaceManifest {
             recent,
             snapshots,
             changes,
+            activation,
             scan_cancelled,
             task,
         })
+    }
+
+    /// Open a deferred manifest's one-way startup gate.
+    ///
+    /// Returns `true` only for the call that transitions the manifest from
+    /// deferred to active. Calling this on an eagerly started or already active
+    /// manifest is harmless and returns `false`.
+    pub fn activate(&self) -> bool {
+        self.activation.send_if_modified(|active| {
+            if *active {
+                false
+            } else {
+                *active = true;
+                true
+            }
+        })
+    }
+
+    /// Whether discovery has been activated for this manifest.
+    pub fn is_active(&self) -> bool {
+        *self.activation.borrow()
     }
 
     pub fn snapshot(&self) -> LocalWorkspaceManifestSnapshot {
@@ -425,6 +470,29 @@ impl ManifestWorkspaceBackend {
         root: impl Into<PathBuf>,
         access_policy: LocalWorkspaceAccessPolicy,
     ) -> Arc<Self> {
+        Self::new_with_access_policy_and_activation(root, access_policy, true)
+    }
+
+    /// Create a manifest-backed local workspace whose initial discovery is
+    /// explicitly activated through [`LocalWorkspaceManifest::activate`].
+    pub fn new_deferred(root: impl Into<PathBuf>) -> Arc<Self> {
+        Self::new_deferred_with_access_policy(root, LocalWorkspaceAccessPolicy::Unrestricted)
+    }
+
+    /// Create a policy-constrained manifest backend without starting its
+    /// scanner or platform watcher until the manifest is activated.
+    pub fn new_deferred_with_access_policy(
+        root: impl Into<PathBuf>,
+        access_policy: LocalWorkspaceAccessPolicy,
+    ) -> Arc<Self> {
+        Self::new_with_access_policy_and_activation(root, access_policy, false)
+    }
+
+    fn new_with_access_policy_and_activation(
+        root: impl Into<PathBuf>,
+        access_policy: LocalWorkspaceAccessPolicy,
+        active: bool,
+    ) -> Arc<Self> {
         let root = root.into();
         let local = Arc::new(LocalWorkspaceBackend::new_with_access_policy(
             root,
@@ -433,7 +501,11 @@ impl ManifestWorkspaceBackend {
         let catalog_local = Arc::new(LocalWorkspaceBackend::new_with_source_egress_policy(
             local.root.clone(),
         ));
-        let manifest = LocalWorkspaceManifest::start(local.root.clone());
+        let manifest = if active {
+            LocalWorkspaceManifest::start(local.root.clone())
+        } else {
+            LocalWorkspaceManifest::start_deferred(local.root.clone())
+        };
         Arc::new(Self {
             local,
             catalog_local,

--- a/core/src/workspace/manifest/tests.rs
+++ b/core/src/workspace/manifest/tests.rs
@@ -192,6 +192,57 @@ async fn manifest_search_matches_glob_and_grep() {
 }
 
 #[tokio::test]
+async fn deferred_manifest_keeps_fallback_search_ready_until_one_way_activation() {
+    let _permit = crate::test_support::resource_intensive_test_permit().await;
+    let temp = tempfile::tempdir().unwrap();
+    write(&temp.path().join("src/main.rs"), b"fn main() {}\n");
+
+    let backend = ManifestWorkspaceBackend::new_deferred(temp.path());
+    let manifest = backend.manifest();
+    let mut snapshots = manifest.subscribe();
+
+    assert!(!manifest.is_active());
+    assert_eq!(manifest.snapshot().version, 0);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(manifest.snapshot().version, 0);
+    assert!(snapshots.try_recv().is_err());
+
+    // Manifest-backed search deliberately falls back to the local backend
+    // while discovery is deferred, so latency-sensitive hosts remain usable.
+    let glob = backend
+        .glob(WorkspaceGlobRequest {
+            base: WorkspacePath::root(),
+            pattern: "**/*.rs".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(glob.matches[0].as_str(), "src/main.rs");
+    assert_eq!(manifest.snapshot().version, 0);
+
+    assert!(manifest.activate());
+    assert!(manifest.is_active());
+    assert!(!manifest.activate());
+    let ready = tokio::time::timeout(
+        crate::test_support::external_resource_start_timeout(Duration::from_secs(5)),
+        snapshots.recv(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(ready.version > 0);
+    assert!(ready.files.iter().any(|file| file.path == "src/main.rs"));
+}
+
+#[tokio::test]
+async fn eager_manifest_is_active_at_construction() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = LocalWorkspaceManifest::start(temp.path());
+
+    assert!(manifest.is_active());
+    assert!(!manifest.activate());
+}
+
+#[tokio::test]
 async fn manifest_credential_boundary_filters_sensitive_grep_candidates() {
     let _permit = crate::test_support::resource_intensive_test_permit().await;
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- add an explicit one-way activation gate for `LocalWorkspaceManifest`
- add deferred `ManifestWorkspaceBackend` constructors while preserving eager defaults
- keep local fallback glob/grep available before manifest activation
- document the latency-sensitive host contract

## Motivation

A released `a3s code` startup probe grew from 158 ms in an empty workspace to 318 ms with 25,114 files. Startup tracing attributed 185 ms to `workspace_services`: manifest discovery starts before the first TUI frame and competes with terminal bootstrap. The CLI will use this API to activate discovery only after the first frame is flushed.

## Validation

- new async regression covers dormant state, fallback search, one-way activation, and eventual snapshot publication
- eager constructors retain their existing active behavior
- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- build and tests run in GitHub Actions; no local compilation performed