### PR TITLE
chore: prepare 7.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.2] - 2026-08-20
+
 ### Added
 
 - Added an explicit one-way activation gate for local workspace manifests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-go-bridge"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "7.0.1"
+version = "7.0.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/go/bridge/Cargo.toml
+++ b/sdk/go/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-go-bridge"
-version = "7.0.1"
+version = "7.0.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -17,7 +17,7 @@ name = "a3s-code-go-bridge"
 path = "src/main.rs"
 
 [dependencies]
-a3s-code-core = { version = "7.0.1", path = "../../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "7.0.2", path = "../../../core", features = ["s3", "serve"] }
 async-trait = "0.1"
 anyhow = "1.0"
 base64 = "0.22"

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "7.0.1"
+version = "7.0.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "7.0.1", path = "../../core", features = ["headless-search", "s3", "serve"] }
+a3s-code-core = { version = "7.0.2", path = "../../core", features = ["headless-search", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "7.0.1",
-        "@a3s-lab/code-linux-arm64-gnu": "7.0.1",
-        "@a3s-lab/code-linux-arm64-musl": "7.0.1",
-        "@a3s-lab/code-linux-x64-gnu": "7.0.1",
-        "@a3s-lab/code-linux-x64-musl": "7.0.1",
-        "@a3s-lab/code-win32-x64-msvc": "7.0.1"
+        "@a3s-lab/code-darwin-arm64": "7.0.2",
+        "@a3s-lab/code-linux-arm64-gnu": "7.0.2",
+        "@a3s-lab/code-linux-arm64-musl": "7.0.2",
+        "@a3s-lab/code-linux-x64-gnu": "7.0.2",
+        "@a3s-lab/code-linux-x64-musl": "7.0.2",
+        "@a3s-lab/code-win32-x64-msvc": "7.0.2"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,91 +15,31 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "7.0.1",
-        "@a3s-lab/code-linux-arm64-gnu": "7.0.1",
-        "@a3s-lab/code-linux-arm64-musl": "7.0.1",
-        "@a3s-lab/code-linux-x64-gnu": "7.0.1",
-        "@a3s-lab/code-linux-x64-musl": "7.0.1",
-        "@a3s-lab/code-win32-x64-msvc": "7.0.1"
+        "@a3s-lab/code-darwin-arm64": "7.0.2",
+        "@a3s-lab/code-linux-arm64-gnu": "7.0.2",
+        "@a3s-lab/code-linux-arm64-musl": "7.0.2",
+        "@a3s-lab/code-linux-x64-gnu": "7.0.2",
+        "@a3s-lab/code-linux-x64-musl": "7.0.2",
+        "@a3s-lab/code-win32-x64-msvc": "7.0.2"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-darwin-arm64/-/code-darwin-arm64-7.0.1.tgz",
-      "integrity": "sha512-C3Ab5P+EWfVxPjeETI2FIWC9sIoBivCbXkvSVYZki/sQacivko/mXYSP1GpBRii+GqgyCgCzJKWQLwNA1sPPAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "optional": true
     },
     "node_modules/@a3s-lab/code-linux-arm64-gnu": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-gnu/-/code-linux-arm64-gnu-7.0.1.tgz",
-      "integrity": "sha512-VLsz86n9GKubXGyzR34SluxIrK0IvdoiPPtvFr5CxCZAUMIRCWGHM41iOL9LpqKi7MymJBvQpYpTKSfOer8mmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "optional": true
     },
     "node_modules/@a3s-lab/code-linux-arm64-musl": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-musl/-/code-linux-arm64-musl-7.0.1.tgz",
-      "integrity": "sha512-QeBLrhZKStlXtqmVl2LKa40G1WMxoDOVDSeN/thgtQmtsEjTZNoUFu9FGQjHYmozUCWesWi5pCJEHLhyduAapQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "optional": true
     },
     "node_modules/@a3s-lab/code-linux-x64-gnu": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-gnu/-/code-linux-x64-gnu-7.0.1.tgz",
-      "integrity": "sha512-al+MfS4wLI6Ww+0tgLCUVWBocvGE+Tm6WolAqGt8etCIBsLIQPF7p42aToYrdvRY2j06HyHsJVf/9j6pWfo4yg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "optional": true
     },
     "node_modules/@a3s-lab/code-linux-x64-musl": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-musl/-/code-linux-x64-musl-7.0.1.tgz",
-      "integrity": "sha512-yA+cZ/VcZFnd2RoJnBdUSwojIk+xmStaPpXTifki7fgV+KretcmUy58jyUuSMAxU2vLbKXiTytreu/7+gbtkMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "optional": true
     },
     "node_modules/@a3s-lab/code-win32-x64-msvc": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@a3s-lab/code-win32-x64-msvc/-/code-win32-x64-msvc-7.0.1.tgz",
-      "integrity": "sha512-29kxVXj0AmB5O2fhcspK4Hi2EAqNVVTkDjm6Mb5tjK4Od0nDm9DHyMVexTZQJMFCboWRRBdMaifhOat4xTj8Tg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -46,11 +46,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "7.0.1",
-    "@a3s-lab/code-linux-x64-gnu": "7.0.1",
-    "@a3s-lab/code-linux-x64-musl": "7.0.1",
-    "@a3s-lab/code-linux-arm64-gnu": "7.0.1",
-    "@a3s-lab/code-linux-arm64-musl": "7.0.1",
-    "@a3s-lab/code-win32-x64-msvc": "7.0.1"
+    "@a3s-lab/code-darwin-arm64": "7.0.2",
+    "@a3s-lab/code-linux-x64-gnu": "7.0.2",
+    "@a3s-lab/code-linux-x64-musl": "7.0.2",
+    "@a3s-lab/code-linux-arm64-gnu": "7.0.2",
+    "@a3s-lab/code-linux-arm64-musl": "7.0.2",
+    "@a3s-lab/code-win32-x64-msvc": "7.0.2"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "7.0.1"
+version = "7.0.2"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "7.0.1"
+__version__ = "7.0.2"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [7.0.2] - 2026-08-20
+
+### Changed
+
+- Updated the bundled Core release to 7.0.2. The public Python API is
+  unchanged.
+
 ## [7.0.1] - 2026-08-17
 
 ### Fixed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "7.0.1"
+version = "7.0.2"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "7.0.1", path = "../../core", features = ["headless-search", "s3", "serve"] }
+a3s-code-core = { version = "7.0.2", path = "../../core", features = ["headless-search", "s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 tokio-util = "0.7"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "7.0.1"
+version = "7.0.2"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- release deferred workspace-manifest activation
- synchronize Rust, Node.js, Python, bootstrap, and Go versions at 7.0.2
- keep unpublished native Node packages as optional lockfile stubs until release publication

## Validation
- `scripts/check_release_versions.sh 7.0.2`
- `bash check-version.sh 7.0.2`
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `git diff --check`

All builds and tests run in GitHub Actions; no local compilation was performed.