### PR TITLE
test(core): reject invalid pre-tool argument rewrites

### DIFF
--- a/core/src/agent_api/direct_tools.rs
+++ b/core/src/agent_api/direct_tools.rs
@@ -275,7 +275,9 @@ mod tests {
     struct DenyToolBudget;
     struct RedactingSecurity;
     #[derive(Debug)]
-    struct RewritingPreToolHook;
+    struct RewritingPreToolHook {
+        value: serde_json::Value,
+    }
 
     #[derive(Debug, Default)]
     struct BlockingPreToolHook {
@@ -321,7 +323,7 @@ mod tests {
         async fn fire(&self, event: &HookEvent) -> HookResult {
             if matches!(event, HookEvent::PreToolUse(_)) {
                 HookResult::continue_with(serde_json::json!({
-                    "updatedInput": {"value": "rewritten"}
+                    "updatedInput": {"value": self.value.clone()}
                 }))
             } else {
                 HookResult::Continue(None)
@@ -1025,7 +1027,9 @@ mod tests {
             tool_executor,
             ToolContext::new(dir.path().to_path_buf()).with_session_id("session-hook-rewrite"),
             AgentConfig {
-                hook_engine: Some(Arc::new(RewritingPreToolHook)),
+                hook_engine: Some(Arc::new(RewritingPreToolHook {
+                    value: serde_json::json!("rewritten"),
+                })),
                 ..AgentConfig::default()
             },
         );
@@ -1040,6 +1044,39 @@ mod tests {
             captured.lock().unwrap().as_ref(),
             Some(&serde_json::json!({"value": "rewritten"}))
         );
+    }
+
+    #[tokio::test]
+    async fn pre_tool_hook_rejects_invalid_rewritten_arguments_before_execution() {
+        let dir = tempfile::tempdir().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let tool_executor = Arc::new(ToolExecutor::new(dir.path().to_string_lossy().to_string()));
+        tool_executor.register_dynamic_tool(Arc::new(ArgumentCaptureTool {
+            captured: Arc::clone(&captured),
+        }));
+        let runtime = direct_runtime_with_config(
+            tool_executor,
+            ToolContext::new(dir.path().to_path_buf())
+                .with_session_id("session-hook-invalid-rewrite"),
+            AgentConfig {
+                hook_engine: Some(Arc::new(RewritingPreToolHook {
+                    value: serde_json::json!(1),
+                })),
+                ..AgentConfig::default()
+            },
+        );
+
+        let result = runtime
+            .call("argument_capture", serde_json::json!({"value": "original"}))
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(matches!(
+            result.error_kind,
+            Some(ToolErrorKind::InvalidArgument { .. })
+        ));
+        assert_eq!(*captured.lock().unwrap(), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- reuse the existing pre-tool rewrite fixture for both valid and invalid inputs
- verify schema-invalid rewritten arguments return a typed InvalidArgument error
- verify the tool body is never executed after an invalid rewrite

## Why

The runtime already supports pre-tool argument rewriting and schema revalidation. This closes the missing fail-closed regression case without duplicating the implementation or changing legacy documentation.

## Stack

Depends on #63, which repairs the post-release Node 7.0.2 lock metadata required by npm ci. Once #63 lands, this PR can be retargeted to main without changing its one-file diff.

## Verification

- cargo fmt --all -- --check
- cargo test -p a3s-code-core pre_tool_hook_
- cargo clippy -p a3s-code-core --tests --no-deps -- -D warnings -A clippy::nonminimal_bool

Strict Clippy without the targeted allowance is currently blocked by four pre-existing nonminimal_bool findings in core/src/workspace/retrieval/semantic_runtime.rs; this PR does not touch that file.