### PR TITLE
fix(node): sync 7.0.2 platform package lock metadata

### DIFF
--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -24,22 +24,94 @@
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-darwin-arm64/-/code-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-rQJcb0rUjuXlRHN1SOG9DE7UPrtnLn1iaWnkEUvsaSh75s4u9J1AbIXtpPHngbmZC2LmMkh6h7qiwbcf0l6yZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-gnu/-/code-linux-arm64-gnu-7.0.2.tgz",
+      "integrity": "sha512-cRwhc+GoY2EcpCQ0SlriQEw0GhoXRMfqt1ih8DLVwoO3x8UzucoEVfCELBP/AB+9ENGknOosiu/E1n53LXlFAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-musl/-/code-linux-arm64-musl-7.0.2.tgz",
+      "integrity": "sha512-SF7hx0jPBc2zZRMgf3BmXlgt4oNQdnDiFUjuq3AAJbJjrSeckdEXQV9pQicauni5Fn4HbJwH4GL7P7Vg61tZRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-gnu/-/code-linux-x64-gnu-7.0.2.tgz",
+      "integrity": "sha512-pp3NzPjPy3K2pUqIDZzLjBOcRlkfvSemMxZK8a4QqUT6DgIPL/PlW2LiLiQiBSusFhI+e+4NCvOU3bQW7XDsVg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-musl/-/code-linux-x64-musl-7.0.2.tgz",
+      "integrity": "sha512-UBBAR6yRi6SV6SHAH8P/scAo3lTweFF0jfZ3yH8LSSBJJlCC6yjLbaZTsz0KhSvWJnRV2ILYiHJPZPFzS13osg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-win32-x64-msvc": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-win32-x64-msvc/-/code-win32-x64-msvc-7.0.2.tgz",
+      "integrity": "sha512-Gaf/M9ocu4rirxEFxT2LJ82h3Ye4ZARIVNUFXTsmKYxkPu7lvSRiTOoicaSV0k5Ov9Te2I03xwfnPYL/EmBWIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",


### PR DESCRIPTION
## Summary

- regenerate the Node SDK lockfile after the 7.0.2 platform packages became available
- restore exact version, registry integrity, CPU, OS, and libc metadata for all six optional native packages
- make npm ci deterministic again after the release publication step

## Verification

- npm install --package-lock-only --ignore-scripts --no-audit --no-fund
- npm ci --ignore-scripts --no-audit --no-fund

This is separated from the pre-tool hook regression test PR so each change remains single-purpose.