### PR TITLE
fix: harden tool rewrites and restore SDK/CI compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check public API compatibility with v5.3.5
         run: |
-          cargo install cargo-semver-checks --version 0.48.0 --locked
+          cargo install cargo-semver-checks --version 0.50.0 --locked
           bash scripts/check_semver.sh 5.3.5
 
       - name: Default tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Check public API compatibility with v5.3.5
         run: |
-          cargo install cargo-semver-checks --version 0.48.0 --locked
+          cargo install cargo-semver-checks --version 0.50.0 --locked
           bash scripts/check_semver.sh 5.3.5
 
       - name: Check SDK protocol and API alignment

--- a/core/src/agent_api/direct_tools.rs
+++ b/core/src/agent_api/direct_tools.rs
@@ -275,7 +275,9 @@ mod tests {
     struct DenyToolBudget;
     struct RedactingSecurity;
     #[derive(Debug)]
-    struct RewritingPreToolHook;
+    struct RewritingPreToolHook {
+        value: serde_json::Value,
+    }
 
     #[derive(Debug, Default)]
     struct BlockingPreToolHook {
@@ -321,7 +323,7 @@ mod tests {
         async fn fire(&self, event: &HookEvent) -> HookResult {
             if matches!(event, HookEvent::PreToolUse(_)) {
                 HookResult::continue_with(serde_json::json!({
-                    "updatedInput": {"value": "rewritten"}
+                    "updatedInput": {"value": self.value.clone()}
                 }))
             } else {
                 HookResult::Continue(None)
@@ -1025,7 +1027,9 @@ mod tests {
             tool_executor,
             ToolContext::new(dir.path().to_path_buf()).with_session_id("session-hook-rewrite"),
             AgentConfig {
-                hook_engine: Some(Arc::new(RewritingPreToolHook)),
+                hook_engine: Some(Arc::new(RewritingPreToolHook {
+                    value: serde_json::json!("rewritten"),
+                })),
                 ..AgentConfig::default()
             },
         );
@@ -1040,6 +1044,39 @@ mod tests {
             captured.lock().unwrap().as_ref(),
             Some(&serde_json::json!({"value": "rewritten"}))
         );
+    }
+
+    #[tokio::test]
+    async fn pre_tool_hook_rejects_invalid_rewritten_arguments_before_execution() {
+        let dir = tempfile::tempdir().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let tool_executor = Arc::new(ToolExecutor::new(dir.path().to_string_lossy().to_string()));
+        tool_executor.register_dynamic_tool(Arc::new(ArgumentCaptureTool {
+            captured: Arc::clone(&captured),
+        }));
+        let runtime = direct_runtime_with_config(
+            tool_executor,
+            ToolContext::new(dir.path().to_path_buf())
+                .with_session_id("session-hook-invalid-rewrite"),
+            AgentConfig {
+                hook_engine: Some(Arc::new(RewritingPreToolHook {
+                    value: serde_json::json!(1),
+                })),
+                ..AgentConfig::default()
+            },
+        );
+
+        let result = runtime
+            .call("argument_capture", serde_json::json!({"value": "original"}))
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(matches!(
+            result.error_kind,
+            Some(ToolErrorKind::InvalidArgument { .. })
+        ));
+        assert_eq!(*captured.lock().unwrap(), None);
     }
 
     #[tokio::test]

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -24,22 +24,94 @@
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-darwin-arm64/-/code-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-rQJcb0rUjuXlRHN1SOG9DE7UPrtnLn1iaWnkEUvsaSh75s4u9J1AbIXtpPHngbmZC2LmMkh6h7qiwbcf0l6yZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-gnu/-/code-linux-arm64-gnu-7.0.2.tgz",
+      "integrity": "sha512-cRwhc+GoY2EcpCQ0SlriQEw0GhoXRMfqt1ih8DLVwoO3x8UzucoEVfCELBP/AB+9ENGknOosiu/E1n53LXlFAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-musl/-/code-linux-arm64-musl-7.0.2.tgz",
+      "integrity": "sha512-SF7hx0jPBc2zZRMgf3BmXlgt4oNQdnDiFUjuq3AAJbJjrSeckdEXQV9pQicauni5Fn4HbJwH4GL7P7Vg61tZRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-gnu/-/code-linux-x64-gnu-7.0.2.tgz",
+      "integrity": "sha512-pp3NzPjPy3K2pUqIDZzLjBOcRlkfvSemMxZK8a4QqUT6DgIPL/PlW2LiLiQiBSusFhI+e+4NCvOU3bQW7XDsVg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-musl/-/code-linux-x64-musl-7.0.2.tgz",
+      "integrity": "sha512-UBBAR6yRi6SV6SHAH8P/scAo3lTweFF0jfZ3yH8LSSBJJlCC6yjLbaZTsz0KhSvWJnRV2ILYiHJPZPFzS13osg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-win32-x64-msvc": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-win32-x64-msvc/-/code-win32-x64-msvc-7.0.2.tgz",
+      "integrity": "sha512-Gaf/M9ocu4rirxEFxT2LJ82h3Ye4ZARIVNUFXTsmKYxkPu7lvSRiTOoicaSV0k5Ov9Te2I03xwfnPYL/EmBWIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",


### PR DESCRIPTION
## Summary

This PR consolidates three related maintenance fixes for the 7.0.2 line:

- restore the generated Node platform-package metadata in `sdk/node/package-lock.json`
- add a regression proving invalid pre-tool hook rewrites are revalidated and rejected before tool execution
- update `cargo-semver-checks` from 0.48.0 to 0.50.0 in CI and release workflows so the public API gate supports current stable Rust / rustdoc JSON v60

Together these changes keep the core runtime fail-closed and keep SDK/release validation reproducible on the current toolchain.

## Validation

- `cargo test -p a3s-code-core pre_tool_hook_` — 2 passed
- public API compatibility passed with `cargo-semver-checks 0.50.0` on GitHub's Rust 1.98 runner
- full consolidated CI is triggered by this branch update
