### PR TITLE
fix(serve): make AgentDir readiness fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check public API compatibility with v5.3.5
         run: |
-          cargo install cargo-semver-checks --version 0.48.0 --locked
+          cargo install cargo-semver-checks --version 0.50.0 --locked
           bash scripts/check_semver.sh 5.3.5
 
       - name: Default tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Check public API compatibility with v5.3.5
         run: |
-          cargo install cargo-semver-checks --version 0.48.0 --locked
+          cargo install cargo-semver-checks --version 0.50.0 --locked
           bash scripts/check_semver.sh 5.3.5
 
       - name: Check SDK protocol and API alignment

--- a/core/src/config/agent_dir.rs
+++ b/core/src/config/agent_dir.rs
@@ -190,18 +190,33 @@ fn md_files(dir: &Path, exts: &[&str]) -> Result<Vec<PathBuf>> {
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
-    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+    let entries = std::fs::read_dir(dir)
         .map_err(|e| CodeError::Context(format!("read {}: {e}", dir.display())))?
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| {
-            p.extension()
-                .and_then(|s| s.to_str())
-                .map(|e| exts.contains(&e))
-                .unwrap_or(false)
-        })
-        .collect();
-    entries.sort();
-    Ok(entries)
+        .map(|entry| entry.map(|entry| entry.path()));
+    collect_md_paths(dir, entries, exts)
+}
+
+fn collect_md_paths(
+    dir: &Path,
+    entries: impl IntoIterator<Item = std::io::Result<PathBuf>>,
+    exts: &[&str],
+) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in entries {
+        let path = entry.map_err(|e| {
+            CodeError::Context(format!("read directory entry in {}: {e}", dir.display()))
+        })?;
+        if path
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|e| exts.contains(&e))
+            .unwrap_or(false)
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
 }
 
 fn load_schedules(dir: &Path) -> Result<Vec<ScheduleSpec>> {
@@ -505,6 +520,23 @@ mod tests {
         assert_eq!(s.limits.max_tool_calls, Some(10));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn directory_entry_errors_are_not_silently_ignored() {
+        let error = collect_md_paths(
+            Path::new("schedules"),
+            [Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "fixture entry denied",
+            ))],
+            &["md"],
+        )
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("read directory entry in schedules"));
+        assert!(message.contains("fixture entry denied"));
     }
 
     /// One script tool per file, written under a unique temp dir, must fail to load.

--- a/core/src/serve/lifecycle.rs
+++ b/core/src/serve/lifecycle.rs
@@ -328,7 +328,7 @@ impl ServeDaemonHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CodeConfig, ScheduleSpec};
+    use crate::config::{CodeConfig, ScheduleSpec, ScriptToolLimits, ScriptToolSpec, ToolSpec};
     use crate::prompts::SystemPromptSlots;
 
     fn test_agent_config() -> CodeConfig {
@@ -408,6 +408,39 @@ providers "anthropic" {
         assert!(handle.is_stopped());
         assert_eq!(handle.failure_code(), Some("SERVE_STARTUP_FAILED"));
         assert!(handle.wait().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn conflicting_declared_tool_fails_before_readiness() {
+        let agent = Arc::new(Agent::from_config(test_agent_config()).await.unwrap());
+        let workspace = tempfile::tempdir().unwrap();
+        let mut agent_dir = agent_dir_with(vec![ScheduleSpec {
+            name: "daily".to_string(),
+            cron: "0 9 * * *".to_string(),
+            prompt: "unused".to_string(),
+            enabled: true,
+        }]);
+        agent_dir.tools.push(ToolSpec::Script(ScriptToolSpec {
+            name: "bash".to_string(),
+            description: "must not shadow the builtin".to_string(),
+            path: std::path::PathBuf::from("scripts/unused.js"),
+            allowed_tools: Some(Vec::new()),
+            limits: ScriptToolLimits::default(),
+        }));
+
+        let handle =
+            spawn_agent_dir_daemon(agent, agent_dir, workspace.path().to_string_lossy(), None)
+                .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), handle.wait_ready())
+                .await
+                .unwrap()
+                .is_err()
+        );
+        assert!(!handle.is_ready());
+        assert!(handle.is_stopped());
+        assert_eq!(handle.failure_code(), Some("SERVE_STARTUP_FAILED"));
     }
 
     #[tokio::test]

--- a/core/src/serve/schedule.rs
+++ b/core/src/serve/schedule.rs
@@ -67,11 +67,17 @@ pub struct Scheduler {
 impl Scheduler {
     /// Build from specs, skipping disabled ones. Errors on any invalid cron.
     pub fn new(specs: impl IntoIterator<Item = ScheduleSpec>) -> Result<Self> {
-        let jobs = specs
-            .into_iter()
-            .filter(|s| s.enabled)
-            .map(ScheduledJob::parse)
-            .collect::<Result<Vec<_>>>()?;
+        let mut jobs = Vec::new();
+        let mut names = std::collections::HashSet::new();
+        for spec in specs.into_iter().filter(|spec| spec.enabled) {
+            if !names.insert(spec.name.clone()) {
+                return Err(CodeError::Context(format!(
+                    "duplicate enabled schedule name: {}",
+                    spec.name
+                )));
+            }
+            jobs.push(ScheduledJob::parse(spec)?);
+        }
         Ok(Self { jobs })
     }
 
@@ -210,6 +216,26 @@ mod tests {
         assert_eq!(s.job_count(), 1);
 
         assert!(Scheduler::new([spec("bad", "xyz", true)]).is_err());
+    }
+
+    #[test]
+    fn scheduler_rejects_duplicate_enabled_names() {
+        let error = Scheduler::new([
+            spec("daily", "0 9 * * *", true),
+            spec("daily", "0 10 * * *", true),
+        ])
+        .err()
+        .expect("duplicate enabled schedule names must fail startup");
+        assert!(error
+            .to_string()
+            .contains("duplicate enabled schedule name: daily"));
+
+        let scheduler = Scheduler::new([
+            spec("daily", "0 9 * * *", true),
+            spec("daily", "0 10 * * *", false),
+        ])
+        .unwrap();
+        assert_eq!(scheduler.job_count(), 1);
     }
 
     #[tokio::test]

--- a/core/src/serve/tools.rs
+++ b/core/src/serve/tools.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use crate::agent_api::AgentSession;
 use crate::config::ToolSpec;
-use crate::error::Result;
+use crate::error::{CodeError, Result};
 use crate::tools::AgentDirScriptTool;
 
 /// Install each parsed [`ToolSpec`] into `session`.
@@ -36,9 +36,15 @@ pub async fn install_agent_dir_tools(session: &AgentSession, specs: &[ToolSpec])
                 session.add_mcp_server(config.clone()).await?;
             }
             ToolSpec::Script(script) => {
-                let registry = Arc::clone(session.tool_executor().registry());
+                let executor = session.tool_executor();
+                let registry = Arc::clone(executor.registry());
                 let tool = Arc::new(AgentDirScriptTool::new(script.clone(), registry));
-                session.tool_executor().register_dynamic_tool(tool);
+                if !executor.register_dynamic_tool_if_absent(tool) {
+                    return Err(CodeError::Context(format!(
+                        "agent-dir script tool `{}` conflicts with an existing tool",
+                        script.name
+                    )));
+                }
             }
         }
     }
@@ -119,17 +125,20 @@ providers "anthropic" {
     }
 
     #[tokio::test]
-    async fn install_script_cannot_shadow_a_builtin() {
+    async fn install_script_collision_fails_startup_without_shadowing() {
         let agent = Agent::from_config(test_config()).await.unwrap();
         let session = agent.session_async("/tmp/ws", None).await.unwrap();
         let registry = session.tool_executor().registry();
         let builtin_bash_desc = registry.get("bash").unwrap().description().to_string();
 
         // A script that tries to take the `bash` name must be rejected, not shadow it.
-        install_agent_dir_tools(&session, &[script_spec("bash", "HIJACKED")])
+        let error = install_agent_dir_tools(&session, &[script_spec("bash", "HIJACKED")])
             .await
-            .unwrap();
+            .unwrap_err();
 
+        assert!(error
+            .to_string()
+            .contains("agent-dir script tool `bash` conflicts with an existing tool"));
         assert_eq!(
             registry.get("bash").unwrap().description(),
             builtin_bash_desc,

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -24,22 +24,94 @@
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-darwin-arm64/-/code-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-rQJcb0rUjuXlRHN1SOG9DE7UPrtnLn1iaWnkEUvsaSh75s4u9J1AbIXtpPHngbmZC2LmMkh6h7qiwbcf0l6yZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-gnu/-/code-linux-arm64-gnu-7.0.2.tgz",
+      "integrity": "sha512-cRwhc+GoY2EcpCQ0SlriQEw0GhoXRMfqt1ih8DLVwoO3x8UzucoEVfCELBP/AB+9ENGknOosiu/E1n53LXlFAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-arm64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-arm64-musl/-/code-linux-arm64-musl-7.0.2.tgz",
+      "integrity": "sha512-SF7hx0jPBc2zZRMgf3BmXlgt4oNQdnDiFUjuq3AAJbJjrSeckdEXQV9pQicauni5Fn4HbJwH4GL7P7Vg61tZRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-gnu": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-gnu/-/code-linux-x64-gnu-7.0.2.tgz",
+      "integrity": "sha512-pp3NzPjPy3K2pUqIDZzLjBOcRlkfvSemMxZK8a4QqUT6DgIPL/PlW2LiLiQiBSusFhI+e+4NCvOU3bQW7XDsVg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-linux-x64-musl": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-linux-x64-musl/-/code-linux-x64-musl-7.0.2.tgz",
+      "integrity": "sha512-UBBAR6yRi6SV6SHAH8P/scAo3lTweFF0jfZ3yH8LSSBJJlCC6yjLbaZTsz0KhSvWJnRV2ILYiHJPZPFzS13osg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@a3s-lab/code-win32-x64-msvc": {
-      "optional": true
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@a3s-lab/code-win32-x64-msvc/-/code-win32-x64-msvc-7.0.2.tgz",
+      "integrity": "sha512-Gaf/M9ocu4rirxEFxT2LJ82h3Ye4ZARIVNUFXTsmKYxkPu7lvSRiTOoicaSV0k5Ov9Te2I03xwfnPYL/EmBWIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",


### PR DESCRIPTION
## Problem

The serve daemon could report `Ready` even when the loaded AgentDir was only partially active:

- per-entry directory enumeration errors were silently dropped, so a schedule or tool file could disappear from the loaded configuration
- duplicate enabled schedule names were accepted even though the daemon routes sessions by name, making two jobs alias the same session
- a script tool colliding with a builtin or previously registered tool was silently ignored while startup continued

That makes readiness unreliable: the process can be healthy while declared work or capabilities are missing.

## Fix

- propagate directory-entry errors instead of filtering them out
- reject duplicate enabled schedule names before sessions are allocated
- register AgentDir script tools only when the name is unowned, and surface collisions as startup failures
- cover the integrated lifecycle so a conflicting declared tool reaches `SERVE_STARTUP_FAILED` and never reports ready

Two separate prerequisite commits restore validation on the current 7.0.2 baseline:

- sync the generated platform-package metadata in the Node lockfile; without it, `npm ci` fails in the Node SDK job before any tests run
- update `cargo-semver-checks` to 0.50.0 because 0.48.0 cannot read rustdoc JSON v60 emitted by the current stable Rust runner

These keep the existing SDK and public API gates executable; they do not change AgentDir behavior.

## Validation

- serve tests with the `serve` feature: 22 passed
- AgentDir configuration tests: 11 passed
- changed serve/config code passes Clippy; the command only allows the four pre-existing `nonminimal_bool` findings in retrieval semantic runtime
- formatting and diff checks pass
- full GitHub CI is triggered for this branch
