### PR TITLE
fix(core): close aborted parallel task lifecycle events

### DIFF
--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -28,9 +28,10 @@ use async_trait::async_trait;
 use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
+use std::collections::HashSet;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::sync::broadcast;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -94,6 +95,63 @@ struct ScopedTaskExecution<'a> {
     emit_start: bool,
     parent_cancellation: Option<&'a CancellationToken>,
     admitted_capability_subtask: Option<crate::capability::AgentCapabilitySubtask>,
+    parallel_lifecycle: Option<Arc<ParallelTaskLifecycle>>,
+}
+
+/// Coordinates terminal lifecycle events for one bounded parallel fan-out.
+///
+/// A child normally emits its own `SubagentEnd`, but an outer `JoinSet` may
+/// have to abort a child that is stuck in a non-cooperative provider or
+/// subprocess. The fan-out then emits a synthetic terminal event. Keeping
+/// this state separate from the public task tracker lets the natural and
+/// synthetic paths race safely while still guaranteeing exactly one end event
+/// for every emitted start event.
+#[derive(Default)]
+pub(super) struct ParallelTaskLifecycle {
+    state: Mutex<ParallelTaskLifecycleState>,
+}
+
+#[derive(Default)]
+struct ParallelTaskLifecycleState {
+    started: HashSet<String>,
+    ended: HashSet<String>,
+}
+
+impl ParallelTaskLifecycle {
+    fn lock_state(&self) -> MutexGuard<'_, ParallelTaskLifecycleState> {
+        match self.state.lock() {
+            Ok(guard) => guard,
+            // A poisoned lifecycle state still contains the authoritative
+            // event history. Recover it instead of turning cancellation
+            // cleanup into a process panic.
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    /// Record that the start event has been written to the tracker/stream.
+    /// This method deliberately has no await point: once a start is observable
+    /// the enclosing task cannot be aborted between the write and this mark.
+    fn mark_started(&self, task_id: &str) {
+        self.lock_state().started.insert(task_id.to_string());
+    }
+
+    fn is_started(&self, task_id: &str) -> bool {
+        self.lock_state().started.contains(task_id)
+    }
+
+    /// Mark a started task as terminal after its terminal event has been
+    /// written. The parallel fan-out drains every child join before synthetic
+    /// cleanup, so natural and synthetic terminal emitters cannot overlap.
+    fn mark_ended(&self, task_id: &str) {
+        let mut state = self.lock_state();
+        if state.started.contains(task_id) {
+            state.ended.insert(task_id.to_string());
+        }
+    }
+
+    fn is_ended(&self, task_id: &str) -> bool {
+        self.lock_state().ended.contains(task_id)
+    }
 }
 
 mod result_projection;
@@ -371,6 +429,7 @@ impl TaskExecutor {
                 emit_start: true,
                 parent_cancellation,
                 admitted_capability_subtask: None,
+                parallel_lifecycle: None,
             },
         )
         .await
@@ -397,6 +456,7 @@ impl TaskExecutor {
                 emit_start,
                 parent_cancellation: self.parent_cancellation.as_ref(),
                 admitted_capability_subtask: None,
+                parallel_lifecycle: None,
             },
         )
         .await
@@ -414,6 +474,7 @@ impl TaskExecutor {
             emit_start,
             parent_cancellation,
             admitted_capability_subtask,
+            parallel_lifecycle,
         } = execution;
         let was_promoted = admitted_capability_subtask.is_some();
         if !was_promoted && parent_cancellation.is_some_and(CancellationToken::is_cancelled) {
@@ -448,6 +509,7 @@ impl TaskExecutor {
                 emit_start,
                 cancel_token,
                 capability_runtime,
+                parallel_lifecycle,
             )
             .await;
         let close = close_capability_subtask(capability_subtask.as_ref()).await;
@@ -475,6 +537,7 @@ impl TaskExecutor {
         emit_start: bool,
         cancel_token: CancellationToken,
         capability_runtime: Option<crate::capability::AgentCapabilityRuntime>,
+        parallel_lifecycle: Option<Arc<ParallelTaskLifecycle>>,
     ) -> Result<TaskResult> {
         // Background callers receive the task id before this future starts.
         // Register immediately so targeted cancellation also interrupts time
@@ -545,6 +608,12 @@ impl TaskExecutor {
             }
             if let Some(ref tx) = event_tx {
                 let _ = tx.send(event);
+            }
+            if let Some(lifecycle) = &parallel_lifecycle {
+                // Keep this after the last await and after the broadcast so an
+                // abort can never suppress a start that the lifecycle thinks
+                // was emitted.
+                lifecycle.mark_started(&task_id);
             }
         }
 
@@ -888,6 +957,12 @@ impl TaskExecutor {
         if let Some(ref tx) = event_tx {
             let _ = tx.send(end_event);
         }
+        if let Some(lifecycle) = &parallel_lifecycle {
+            // Keep this as the final synchronous operation. If the child was
+            // aborted at an earlier await, synthetic cleanup can still fill in
+            // the missing terminal event.
+            lifecycle.mark_ended(&task_id);
+        }
 
         Ok(TaskResult {
             output,
@@ -1010,6 +1085,7 @@ impl TaskExecutor {
                         emit_start: false,
                         parent_cancellation: parent_cancellation.as_ref(),
                         admitted_capability_subtask,
+                        parallel_lifecycle: None,
                     },
                 )
                 .await

--- a/core/src/tools/task/parallel_execution.rs
+++ b/core/src/tools/task/parallel_execution.rs
@@ -57,6 +57,7 @@ impl TaskExecutor {
             Some(cancellation) => Arc::new(ScopedTaskExecutor {
                 executor: Arc::clone(self),
                 parent_cancellation: cancellation.clone(),
+                parallel_lifecycle: None,
             }),
             None => Arc::<Self>::clone(self),
         };
@@ -124,9 +125,11 @@ impl TaskExecutor {
             .clamp(1, task_count.max(1));
 
         let max_concurrency = self.max_parallel_tasks.max(1);
+        let parallel_lifecycle = Arc::new(ParallelTaskLifecycle::default());
         let scoped_executor: Arc<dyn AgentExecutor> = Arc::new(ScopedTaskExecutor {
             executor: Arc::clone(self),
             parent_cancellation: parallel_cancellation.clone(),
+            parallel_lifecycle: Some(Arc::clone(&parallel_lifecycle)),
         });
         let mut pending = specs.into_iter().enumerate();
         let mut join_set = JoinSet::new();
@@ -247,11 +250,6 @@ impl TaskExecutor {
             }
         }
 
-        if timed_out || returned_early || active_count > 0 {
-            parallel_cancellation.cancel();
-            settle_cancelled_parallel_tasks(&mut join_set).await;
-        }
-
         let unfinished_message = if timed_out {
             format!(
                 "Task timed out before parallel_task finished collecting child results after {} ms.",
@@ -264,6 +262,20 @@ impl TaskExecutor {
         } else {
             "Task did not return a result before parallel_task ended.".to_string()
         };
+        if timed_out || returned_early || active_count > 0 {
+            let cancelled_indexes = active_indexes.values().copied().collect::<Vec<_>>();
+            parallel_cancellation.cancel();
+            settle_cancelled_parallel_tasks(&mut join_set, &mut active_indexes).await;
+            self.emit_abandoned_parallel_task_ends(
+                &cancelled_indexes,
+                &labels,
+                event_tx.as_ref(),
+                &unfinished_message,
+                Some(&parallel_lifecycle),
+            )
+            .await;
+        }
+
         let results = results
             .into_iter()
             .enumerate()
@@ -290,16 +302,76 @@ impl TaskExecutor {
             min_success_count,
         }
     }
+
+    /// Emit a terminal lifecycle event for a child that could not settle
+    /// within the bounded cancellation grace period. A parent fan-out still
+    /// returns a deterministic failed result for such a child, so its
+    /// `subagent_start` must not remain open in the event stream or tracker.
+    async fn emit_abandoned_parallel_task_ends(
+        &self,
+        indexes: &[usize],
+        labels: &[(String, String)],
+        event_tx: Option<&broadcast::Sender<AgentEvent>>,
+        output: &str,
+        lifecycle: Option<&ParallelTaskLifecycle>,
+    ) {
+        for &index in indexes {
+            let Some((task_id, agent)) = labels.get(index) else {
+                continue;
+            };
+            if let Some(lifecycle) = lifecycle {
+                if !lifecycle.is_started(task_id) || lifecycle.is_ended(task_id) {
+                    continue;
+                }
+            }
+            let event = AgentEvent::SubagentEnd {
+                task_id: task_id.clone(),
+                session_id: format!("task-run-{task_id}"),
+                agent: agent.clone(),
+                output: output.to_string(),
+                success: false,
+                finished_ms: epoch_ms(),
+            };
+            let event = self
+                .parent_context
+                .as_ref()
+                .and_then(|context| context.security_provider.as_deref())
+                .map(|provider| crate::security::sanitize_agent_event(provider, &event))
+                .unwrap_or(event);
+
+            if let Some(tracker) = &self.subagent_tracker {
+                // Preserve the explicit cancellation state in the materialized
+                // tracker when a child did not reach its own end-event path.
+                // `record_event` then fills in the terminal output/timestamp;
+                // a late child end cannot downgrade Cancelled.
+                let _ = tracker.cancel(task_id).await;
+                tracker.record_event(&event).await;
+                tracker.clear_canceller(task_id).await;
+            }
+            if let Some(tx) = event_tx {
+                let _ = tx.send(event);
+            }
+            if let Some(lifecycle) = lifecycle {
+                lifecycle.mark_ended(task_id);
+            }
+        }
+    }
 }
 
 async fn settle_cancelled_parallel_tasks(
     join_set: &mut JoinSet<(usize, std::result::Result<StepOutcome, String>)>,
+    active_indexes: &mut HashMap<tokio::task::Id, usize>,
 ) {
     const SETTLEMENT_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
     let deadline = tokio::time::Instant::now() + SETTLEMENT_GRACE;
     while !join_set.is_empty() {
-        match tokio::time::timeout_at(deadline, join_set.join_next()).await {
-            Ok(Some(_)) => {}
+        match tokio::time::timeout_at(deadline, join_set.join_next_with_id()).await {
+            Ok(Some(Ok((task_id, _)))) => {
+                active_indexes.remove(&task_id);
+            }
+            Ok(Some(Err(error))) => {
+                active_indexes.remove(&error.id());
+            }
             Ok(None) => return,
             Err(_) => break,
         }
@@ -309,7 +381,17 @@ async fn settle_cancelled_parallel_tasks(
         return;
     }
     join_set.abort_all();
-    while join_set.join_next().await.is_some() {}
+    while let Some(joined) = join_set.join_next_with_id().await {
+        match joined {
+            Ok((task_id, _)) => {
+                active_indexes.remove(&task_id);
+            }
+            Err(error) => {
+                active_indexes.remove(&error.id());
+            }
+        }
+    }
+    active_indexes.clear();
 }
 
 fn spawn_parallel_task_step(
@@ -397,6 +479,7 @@ impl AgentExecutor for TaskExecutor {
             spec,
             event_tx,
             self.parent_cancellation.as_ref(),
+            None,
         )
         .await
     }
@@ -412,6 +495,7 @@ impl TaskExecutor {
         spec: AgentStepSpec,
         event_tx: Option<broadcast::Sender<AgentEvent>>,
         parent_cancellation: Option<&CancellationToken>,
+        parallel_lifecycle: Option<Arc<ParallelTaskLifecycle>>,
     ) -> StepOutcome {
         let agent = spec.agent.clone();
         let task_id = spec.task_id.clone();
@@ -437,6 +521,7 @@ impl TaskExecutor {
                     emit_start: true,
                     parent_cancellation,
                     admitted_capability_subtask: None,
+                    parallel_lifecycle,
                 },
             )
             .await
@@ -534,6 +619,7 @@ impl TaskExecutor {
 struct ScopedTaskExecutor {
     executor: Arc<TaskExecutor>,
     parent_cancellation: CancellationToken,
+    parallel_lifecycle: Option<Arc<ParallelTaskLifecycle>>,
 }
 
 #[async_trait]
@@ -544,7 +630,12 @@ impl AgentExecutor for ScopedTaskExecutor {
         event_tx: Option<broadcast::Sender<AgentEvent>>,
     ) -> StepOutcome {
         self.executor
-            .execute_step_with_parent_cancellation(spec, event_tx, Some(&self.parent_cancellation))
+            .execute_step_with_parent_cancellation(
+                spec,
+                event_tx,
+                Some(&self.parent_cancellation),
+                self.parallel_lifecycle.clone(),
+            )
             .await
     }
 
@@ -556,6 +647,30 @@ impl AgentExecutor for ScopedTaskExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct NoopLlmClient;
+
+    #[async_trait::async_trait]
+    impl LlmClient for NoopLlmClient {
+        async fn complete(
+            &self,
+            _messages: &[crate::llm::Message],
+            _system: Option<&str>,
+            _tools: &[crate::llm::ToolDefinition],
+        ) -> anyhow::Result<crate::llm::LlmResponse> {
+            anyhow::bail!("NoopLlmClient must not be called")
+        }
+
+        async fn complete_streaming(
+            &self,
+            _messages: &[crate::llm::Message],
+            _system: Option<&str>,
+            _tools: &[crate::llm::ToolDefinition],
+            _cancel_token: CancellationToken,
+        ) -> anyhow::Result<tokio::sync::mpsc::Receiver<crate::llm::StreamEvent>> {
+            anyhow::bail!("NoopLlmClient must not be called")
+        }
+    }
 
     #[tokio::test]
     async fn aborted_join_keeps_the_spawned_branch_index() {
@@ -576,6 +691,78 @@ mod tests {
             take_parallel_task_index(&mut active_indexes, error.id()),
             Some(7)
         );
+        assert!(active_indexes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn abandoned_parallel_settlement_emits_terminal_end_and_updates_tracker() {
+        use crate::subagent_task_tracker::{InMemorySubagentTaskTracker, SubagentStatus};
+
+        let tracker = Arc::new(InMemorySubagentTaskTracker::new());
+        let task_id = "task-abandoned".to_string();
+        let lifecycle = Arc::new(ParallelTaskLifecycle::default());
+        lifecycle.mark_started(&task_id);
+        tracker
+            .record_event(&AgentEvent::SubagentStart {
+                task_id: task_id.clone(),
+                session_id: format!("task-run-{task_id}"),
+                parent_session_id: "parent".to_string(),
+                agent: "worker".to_string(),
+                description: "abandoned branch".to_string(),
+                started_ms: 1,
+            })
+            .await;
+        tracker
+            .register_canceller(&task_id, CancellationToken::new())
+            .await;
+
+        let executor = TaskExecutor::new(
+            Arc::new(AgentRegistry::new()),
+            Arc::new(NoopLlmClient),
+            ".".to_string(),
+        )
+        .with_subagent_tracker(Arc::clone(&tracker));
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+        executor
+            .emit_abandoned_parallel_task_ends(
+                &[0],
+                &[(task_id.clone(), "worker".to_string())],
+                Some(&event_tx),
+                "Task cancelled after parallel_task collected one successful child result(s).",
+                Some(&lifecycle),
+            )
+            .await;
+
+        let event = event_rx.try_recv().expect("synthetic end event");
+        match event {
+            AgentEvent::SubagentEnd {
+                task_id: event_task_id,
+                success,
+                output,
+                ..
+            } => {
+                assert_eq!(event_task_id, task_id);
+                assert!(!success);
+                assert!(output.contains("cancelled"));
+            }
+            other => panic!("expected SubagentEnd, got {other:?}"),
+        }
+        assert_eq!(
+            tracker.get(&task_id).await.unwrap().status,
+            SubagentStatus::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_parallel_settlement_drains_join_set() {
+        let mut join_set = JoinSet::new();
+        let handle = join_set.spawn(async {
+            std::future::pending::<(usize, std::result::Result<StepOutcome, String>)>().await
+        });
+        let mut active_indexes = HashMap::from([(handle.id(), 3)]);
+
+        settle_cancelled_parallel_tasks(&mut join_set, &mut active_indexes).await;
+        assert!(join_set.is_empty());
         assert!(active_indexes.is_empty());
     }
 }

--- a/core/src/tools/task/tests.rs
+++ b/core/src/tools/task/tests.rs
@@ -4537,6 +4537,147 @@ async fn parallel_task_tool_can_return_after_min_success_count() {
     assert_eq!(metadata["results"][1]["success"], true);
 }
 
+struct FastAndBlockingParallelLlmClient {
+    blocked_started: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl LlmClient for FastAndBlockingParallelLlmClient {
+    async fn complete(
+        &self,
+        messages: &[Message],
+        system: Option<&str>,
+        _tools: &[ToolDefinition],
+    ) -> Result<LlmResponse> {
+        if is_pre_analysis_system(system) {
+            return Ok(pre_analysis_response(messages));
+        }
+        if last_text(messages).contains("blocked branch") {
+            self.blocked_started.notify_one();
+            return std::future::pending::<Result<LlmResponse>>().await;
+        }
+        Ok(text_response("fast branch complete"))
+    }
+
+    async fn complete_streaming(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+        _cancel_token: tokio_util::sync::CancellationToken,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        anyhow::bail!("streaming is not used by parallel lifecycle tests")
+    }
+}
+
+#[tokio::test]
+async fn parallel_task_tool_emits_terminal_event_for_aborted_child() {
+    use crate::subagent_task_tracker::{InMemorySubagentTaskTracker, SubagentStatus};
+
+    let workspace = tempfile::tempdir().unwrap();
+    let blocked_started = Arc::new(Notify::new());
+    let tracker = Arc::new(InMemorySubagentTaskTracker::new());
+    let executor = Arc::new(
+        TaskExecutor::new(
+            test_registry_with_text_worker(),
+            Arc::new(FastAndBlockingParallelLlmClient {
+                blocked_started: Arc::clone(&blocked_started),
+            }),
+            workspace.path().to_string_lossy().to_string(),
+        )
+        .with_subagent_tracker(Arc::clone(&tracker)),
+    );
+    let tool = ParallelTaskTool::new(executor);
+    let (event_tx, mut event_rx) = broadcast::channel(128);
+    let context = ToolContext::new(workspace.path().to_path_buf())
+        .with_session_id("parallel-parent")
+        .with_agent_event_tx(event_tx);
+
+    let output = tool
+        .execute(
+            &serde_json::json!({
+                "allow_partial_failure": true,
+                "min_success_count": 1,
+                "tasks": [
+                    {
+                        "agent": "worker",
+                        "description": "fast branch",
+                        "prompt": "complete the fast branch",
+                        "max_steps": 0
+                    },
+                    {
+                        "agent": "worker",
+                        "description": "blocked branch",
+                        "prompt": "wait forever in the blocked branch",
+                        "max_steps": 1
+                    }
+                ]
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        output.success,
+        "early return should be tolerated: {output:#?}"
+    );
+    let metadata = output.metadata.expect("parallel metadata");
+    assert_eq!(metadata["returned_early"], true);
+    assert_eq!(metadata["success_count"], 1);
+    assert_eq!(metadata["failed_count"], 1);
+
+    // The blocked branch must have entered its provider call; otherwise a
+    // missing terminal event could be explained by a pre-start admission
+    // race rather than by cancellation cleanup.
+    tokio::time::timeout(Duration::from_secs(1), blocked_started.notified())
+        .await
+        .expect("blocked child provider call should start");
+
+    let mut starts = HashMap::new();
+    let mut ends = HashMap::new();
+    while let Ok(event) = event_rx.try_recv() {
+        match event {
+            AgentEvent::SubagentStart {
+                task_id,
+                description,
+                ..
+            } => {
+                starts.insert(task_id, description);
+            }
+            AgentEvent::SubagentEnd {
+                task_id,
+                output,
+                success,
+                ..
+            } => {
+                ends.insert(task_id, (output, success));
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(starts.len(), 2, "every child should emit start: {starts:?}");
+    assert_eq!(
+        ends.len(),
+        2,
+        "every started child should emit end: {ends:?}"
+    );
+    for task_id in starts.keys() {
+        assert!(ends.contains_key(task_id), "missing end for {task_id}");
+    }
+    let blocked_id = starts
+        .iter()
+        .find_map(|(task_id, description)| (description == "blocked branch").then_some(task_id))
+        .expect("blocked child start event");
+    let (blocked_output, blocked_success) = ends.get(blocked_id).unwrap();
+    assert!(!blocked_success);
+    assert!(blocked_output.contains("cancelled"));
+    assert!(matches!(
+        tracker.get(blocked_id).await.unwrap().status,
+        SubagentStatus::Failed | SubagentStatus::Cancelled
+    ));
+}
+
 #[tokio::test]
 async fn parallel_task_tool_returns_structured_child_output_when_schema_requested() {
     let workspace = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- track lifecycle state for bounded parallel fan-outs
- emit a sanitized synthetic `SubagentEnd` when cancellation aborts a child after its start event
- keep tracker state terminal and drain join handles/index mappings
- add regression coverage for early-return, tracker, and join-set cleanup paths

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p a3s-code-core --lib parallel_task_tool`
- `cargo test -p a3s-code-core --lib parallel_execution`
- `cargo test -p a3s-code-core --lib tools::task` (121 passed)
- `ulimit -n 4096 && cargo test -p a3s-code-core --lib -- --test-threads=4` (2965 passed, 20 ignored)
- `ulimit -n 4096 && cargo clippy -p a3s-code-core --lib --tests -- -D warnings`

The default shell soft limit is 256 file descriptors; the full-suite run is
reported with the explicit test-process limit above to avoid unrelated runtime
creation failures.
