### PR TITLE
fix: release Code 8.0.4 SRT hardlink hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -990,6 +990,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed the legacy 4,096-path preflight rejection from the local SRT
+  hard-link boundary. The existing entry and depth limits still bound
+  discovery, while file-backed macOS Seatbelt profiles can now retain and
+  probe every multi-link source path in large workspaces.
 - Preferred the semantic HTML `<main>` element before falling back to `<body>`
   in `web_fetch`, removing site navigation and footer chrome from ordinary
   evidence pages while preserving the existing bounded conversion and SSRF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.4] - 2026-08-31
+
+### Fixed
+
+- Removed the legacy 4,096-path preflight rejection from the local SRT
+  hard-link boundary. Workspace entry and depth limits continue to bound
+  discovery, while file-backed macOS Seatbelt profiles can retain every
+  multi-link source path in large workspaces.
+
 ## [8.0.3] - 2026-08-28
 
 ### Changed
@@ -990,10 +999,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Removed the legacy 4,096-path preflight rejection from the local SRT
-  hard-link boundary. The existing entry and depth limits still bound
-  discovery, while file-backed macOS Seatbelt profiles can now retain and
-  probe every multi-link source path in large workspaces.
 - Preferred the semantic HTML `<main>` element before falling back to `<body>`
   in `web_fetch`, removing site navigation and footer chrome from ordinary
   evidence pages while preserving the existing bounded conversion and SSRF

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-go-bridge"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "8.0.3"
+version = "8.0.4"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/sandbox/srt.rs
+++ b/core/src/sandbox/srt.rs
@@ -20,7 +20,6 @@ use tokio::process::Command;
 const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_WORKSPACE_SCAN_ENTRIES: usize = 1_000_000;
 const MAX_WORKSPACE_SCAN_DEPTH: usize = 64;
-const MAX_WORKSPACE_HARDLINK_DENIES: usize = 4_096;
 /// npm package accepted by the verified SRT constructor.
 pub const SRT_NPM_PACKAGE_NAME: &str = "@anthropic-ai/sandbox-runtime";
 /// Exact SRT version provisioned by the current A3S CLI managed-runtime path.
@@ -943,6 +942,9 @@ fn workspace_nested_env_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
 }
 
 pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>> {
+    // Keep every discovered source-tree alias. The workspace entry/depth
+    // limits above bound this scan; a smaller path-count limit incorrectly
+    // rejects file-backed macOS Seatbelt profiles before SRT can probe them.
     let mut pending = vec![(workspace.to_path_buf(), 0usize)];
     let mut scanned = 0usize;
     let mut hardlinks = Vec::new();
@@ -983,11 +985,6 @@ pub(crate) fn workspace_hardlink_paths(workspace: &Path) -> Result<Vec<PathBuf>>
             }
             if metadata.is_file() && hard_link_count(&path, &metadata) > 1 {
                 hardlinks.push(path);
-                if hardlinks.len() > MAX_WORKSPACE_HARDLINK_DENIES {
-                    bail!(
-                        "SRT workspace contains more than {MAX_WORKSPACE_HARDLINK_DENIES} multi-link files"
-                    );
-                }
             }
         }
     }

--- a/core/src/sandbox/srt/tests.rs
+++ b/core/src/sandbox/srt/tests.rs
@@ -207,6 +207,56 @@ async fn adapter_denies_every_preexisting_workspace_hardlink_alias() {
     }
 }
 
+#[cfg(unix)]
+#[test]
+fn adapter_accepts_more_than_the_legacy_hardlink_profile_limit() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let outside = root.path().join("outside-secret");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(&outside, "outside-secret").unwrap();
+
+    for index in 0..=4_096 {
+        std::fs::hard_link(&outside, workspace.join(format!("alias-{index:04}.txt"))).unwrap();
+    }
+
+    let capture = root.path().join("captured-settings.json");
+    let (_binary_dir, binary) = fake_srt(&capture);
+    let sandbox = SrtBashSandbox::new(binary, &workspace).unwrap();
+
+    assert_eq!(sandbox.workspace_hardlink_paths.len(), 4_097);
+    let scratch = tempfile::tempdir().unwrap();
+    let settings = sandbox.settings(scratch.path()).unwrap();
+    for boundary in ["denyRead", "denyWrite"] {
+        let paths = settings["filesystem"][boundary].as_array().unwrap();
+        assert!(paths
+            .iter()
+            .any(|path| path == &json!(workspace.join("alias-0000.txt"))));
+        assert!(paths
+            .iter()
+            .any(|path| path == &json!(workspace.join("alias-4096.txt"))));
+    }
+}
+
+#[test]
+fn workspace_scan_retains_more_than_the_legacy_hardlink_limit() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let outside = root.path().join("outside");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+
+    for index in 0..=4_096 {
+        let source = outside.join(format!("source-{index:04}.txt"));
+        std::fs::write(&source, "outside-secret").unwrap();
+        std::fs::hard_link(&source, workspace.join(format!("alias-{index:04}.txt"))).unwrap();
+    }
+
+    let hardlinks = workspace_hardlink_paths(&workspace).unwrap();
+
+    assert_eq!(hardlinks.len(), 4_097);
+}
+
 #[test]
 fn workspace_scan_treats_a_concurrently_removed_entry_as_absent() {
     let workspace = tempfile::tempdir().unwrap();
@@ -623,7 +673,7 @@ async fn real_srt_probe_handles_a_large_hardlink_profile_without_e2big() {
     std::fs::create_dir_all(&workspace).unwrap();
     let outside = root.path().join("outside-secret");
     std::fs::write(&outside, "outside-secret").unwrap();
-    for index in 0..1_024 {
+    for index in 0..=4_096 {
         std::fs::hard_link(
             &outside,
             workspace.join(format!(

--- a/sdk/go/bridge/Cargo.toml
+++ b/sdk/go/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-go-bridge"
-version = "8.0.3"
+version = "8.0.4"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -17,7 +17,7 @@ name = "a3s-code-go-bridge"
 path = "src/main.rs"
 
 [dependencies]
-a3s-code-core = { version = "8.0.3", path = "../../../core", features = ["s3", "serve"] }
+a3s-code-core = { version = "8.0.4", path = "../../../core", features = ["s3", "serve"] }
 async-trait = "0.1"
 anyhow = "1.0"
 base64 = "0.22"

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "8.0.3"
+version = "8.0.4"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "8.0.3", path = "../../core", features = ["headless-search", "s3", "serve"] }
+a3s-code-core = { version = "8.0.4", path = "../../core", features = ["headless-search", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/A3S-Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "8.0.3"
+version = "8.0.4"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "8.0.3"
+__version__ = "8.0.4"
 
 _DEFAULT_BASE_URL = "https://github.com/A3S-Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the A3S Code Python SDK will be documented in this file.
 
 ## [Unreleased]
 
+## [8.0.4] - 2026-08-31
+
+### Changed
+
+- Updated the bundled Core release to 8.0.4. The public Python API is
+  unchanged.
+
 ## [8.0.3] - 2026-08-28
 
 ### Changed

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-acl 0.3.0",
  "a3s-common",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "8.0.3"
+version = "8.0.4"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "8.0.3", path = "../../core", features = ["headless-search", "s3", "serve"] }
+a3s-code-core = { version = "8.0.4", path = "../../core", features = ["headless-search", "s3", "serve"] }
 pyo3 = { version = "0.23", features = ["multiple-pymethods"] }
 tokio = { version = "1.35", features = ["full"] }
 tokio-util = "0.7"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "8.0.3"
+version = "8.0.4"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- integrate the 8.0.4 hotfix branch into current `main` without publishing unrelated post-8.0.3 features in the hotfix tag
- remove the legacy 4,096-entry SRT hard-link preflight rejection while retaining the 1,000,000-entry and depth-64 workspace scan bounds
- add 4,097-entry scanner, adapter, and real managed-SRT regressions
- align Core and SDK release metadata at 8.0.4

## Release topology
- stable release commit: `8977e7c` (v8.0.3 + SRT hotfix + version alignment)
- integration merge: `0805f23`
- `v8.0.4` will point to the stable release commit after this integration reaches `main`

## Verification
- `cargo test --locked -p a3s-code-core --lib`: 2940 passed, 0 failed, 19 ignored
- `cargo clippy --locked --workspace --lib --bins -- -D warnings`
- `cargo fmt --all -- --check`
- release version verifier: consistent at 8.0.4
- `cargo package --locked --allow-dirty --manifest-path core/Cargo.toml`: packaged and independently recompiled