### PR TITLE
fix(python): reject ambiguous native artifacts

### DIFF
--- a/.github/workflows/sdk-runtime.yml
+++ b/.github/workflows/sdk-runtime.yml
@@ -84,6 +84,7 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install 'maturin>=1,<2' pytest
+          python sdk/python/scripts/clean_native_artifacts.py
           maturin develop --locked --manifest-path sdk/python/Cargo.toml
           python -m pytest -q sdk/python/tests sdk/python/test_confirmation_inheritance.py
           python sdk/python/tests/test_budget_guard.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of serializing schema-invalid `null` values.
 - Broke Tool registry, orchestrator, and Skill executor reference cycles so
   Session teardown releases durable-memory repository handles and file locks.
+- Made Python SDK imports fail closed when multiple generated `_native`
+  extensions could select a stale interpreter-specific binary, and added a
+  deterministic cleanup command before editable SDK builds.
+
 ## [8.0.4] - 2026-08-31
 
 ### Fixed

--- a/scripts/sdk_real_config_env_integration.sh
+++ b/scripts/sdk_real_config_env_integration.sh
@@ -162,7 +162,9 @@ try:
 except Exception as exc:
     raise SystemExit(
         "Python SDK import failed. Build/install it first, e.g. "
-        "`cd sdk/python && maturin develop`, then rerun this script.\n"
+        "run `python sdk/python/scripts/clean_native_artifacts.py` and "
+        "`maturin develop --locked --manifest-path sdk/python/Cargo.toml`, "
+        "then rerun this script.\n"
         f"Import error: {exc}"
     )
 
@@ -176,7 +178,9 @@ if missing:
     raise SystemExit(
         "Python SDK import resolved to a build that is missing current API "
         f"{', '.join(missing)}. Build/install the workspace SDK first, e.g. "
-        "`cd sdk/python && maturin develop`, then rerun this script.\n"
+        "run `python sdk/python/scripts/clean_native_artifacts.py` and "
+        "`maturin develop --locked --manifest-path sdk/python/Cargo.toml`, "
+        "then rerun this script.\n"
         f"Imported from: {location}"
     )
 PY

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -55,6 +55,20 @@ The Intel macOS 12 wheel does not include the optional local ONNX embedding
 adapter. Use model-free retrieval or an explicitly authorized remote
 embedding provider on that platform.
 
+### Development build
+
+Clean generated native extensions before an editable development build. This
+prevents an older interpreter-specific extension from taking precedence over a
+new stable-ABI extension in the same package directory:
+
+```bash
+python sdk/python/scripts/clean_native_artifacts.py
+maturin develop --locked --manifest-path sdk/python/Cargo.toml
+```
+
+The package fails closed with an actionable import error if multiple `_native`
+extensions are present, instead of silently loading a stale binary.
+
 ## Quick Start
 
 ```python

--- a/sdk/python/python/a3s_code/__init__.py
+++ b/sdk/python/python/a3s_code/__init__.py
@@ -1,5 +1,10 @@
 """A3S Code Python SDK."""
 
+from ._native_artifacts import ensure_unambiguous_native_extension as _ensure_native
+
+_ensure_native()
+del _ensure_native
+
 from ._native import *
 from .event_protocol_v1 import (
     AGENT_EVENT_TYPES_V1,

--- a/sdk/python/python/a3s_code/_native_artifacts.py
+++ b/sdk/python/python/a3s_code/_native_artifacts.py
@@ -1,0 +1,59 @@
+"""Deterministic discovery and cleanup for generated native extensions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _is_native_extension_artifact(path: Path) -> bool:
+    name = path.name
+    return (
+        path.is_file()
+        and name.startswith("_native.")
+        and path.suffix.lower() in {".pyd", ".so", ".dylib"}
+    )
+
+
+def find_native_extension_artifacts(
+    package_dir: Path | None = None,
+) -> tuple[Path, ...]:
+    """Return generated ``_native`` extension files in deterministic order."""
+
+    root = package_dir or Path(__file__).resolve().parent
+    return tuple(
+        sorted(path for path in root.iterdir() if _is_native_extension_artifact(path))
+    )
+
+
+def ensure_unambiguous_native_extension(package_dir: Path | None = None) -> None:
+    """Fail closed when Python could silently select a stale native binary."""
+
+    artifacts = find_native_extension_artifacts(package_dir)
+    if len(artifacts) <= 1:
+        return
+
+    names = ", ".join(path.name for path in artifacts)
+    raise ImportError(
+        "Multiple A3S Code native extensions are present and import order is "
+        f"ambiguous: {names}. Remove generated native artifacts and rebuild. "
+        "From a source checkout, run "
+        "`python sdk/python/scripts/clean_native_artifacts.py`."
+    )
+
+
+def clean_native_extension_artifacts(
+    package_dir: Path | None = None,
+) -> tuple[Path, ...]:
+    """Remove rebuildable ``_native`` extension files and return their paths."""
+
+    artifacts = find_native_extension_artifacts(package_dir)
+    for artifact in artifacts:
+        artifact.unlink()
+    return artifacts
+
+
+__all__ = [
+    "clean_native_extension_artifacts",
+    "ensure_unambiguous_native_extension",
+    "find_native_extension_artifacts",
+]

--- a/sdk/python/scripts/clean_native_artifacts.py
+++ b/sdk/python/scripts/clean_native_artifacts.py
@@ -1,0 +1,37 @@
+"""Remove generated A3S Code native extensions before a development build."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+SDK_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_MODULE = SDK_ROOT / "python" / "a3s_code" / "_native_artifacts.py"
+PACKAGE_DIR = SDK_ROOT / "python" / "a3s_code"
+
+
+def _load_artifact_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "_a3s_code_native_artifacts", ARTIFACT_MODULE
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load native artifact helper: {ARTIFACT_MODULE}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> None:
+    module = _load_artifact_module()
+    removed = module.clean_native_extension_artifacts(PACKAGE_DIR)
+    if not removed:
+        print("No generated A3S Code native extensions found.")
+        return
+    for path in removed:
+        print(f"Removed rebuildable native artifact: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/test_native_artifacts.py
+++ b/sdk/python/tests/test_native_artifacts.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from a3s_code._native_artifacts import (
+    clean_native_extension_artifacts,
+    ensure_unambiguous_native_extension,
+    find_native_extension_artifacts,
+)
+
+
+def _touch(directory: Path, name: str) -> Path:
+    path = directory / name
+    path.write_bytes(b"test artifact")
+    return path
+
+
+def test_native_artifact_discovery_is_exact_and_deterministic(tmp_path: Path) -> None:
+    expected = (
+        _touch(tmp_path, "_native.abi3.so"),
+        _touch(tmp_path, "_native.cpython-313-x86_64-linux-gnu.so"),
+        _touch(tmp_path, "_native.pyd"),
+    )
+    _touch(tmp_path, "_native_artifacts.py")
+    _touch(tmp_path, "another_native.pyd")
+
+    assert find_native_extension_artifacts(tmp_path) == expected
+
+
+def test_ambiguous_native_artifacts_fail_closed(tmp_path: Path) -> None:
+    _touch(tmp_path, "_native.cp313-win_amd64.pyd")
+    _touch(tmp_path, "_native.pyd")
+
+    with pytest.raises(ImportError, match="import order is ambiguous"):
+        ensure_unambiguous_native_extension(tmp_path)
+
+
+def test_cleanup_removes_only_rebuildable_native_artifacts(tmp_path: Path) -> None:
+    stale = _touch(tmp_path, "_native.cp313-win_amd64.pyd")
+    current = _touch(tmp_path, "_native.pyd")
+    retained = _touch(tmp_path, "callback_provider.pyd")
+
+    assert clean_native_extension_artifacts(tmp_path) == (stale, current)
+    assert not stale.exists()
+    assert not current.exists()
+    assert retained.exists()
+    ensure_unambiguous_native_extension(tmp_path)


### PR DESCRIPTION
## Summary
- reject ambiguous generated Python native extensions before import
- provide a deterministic cleanup command and run it before editable CI builds
- document the development workflow and retain regression coverage

## Verification
- maturin develop --locked --manifest-path sdk/python/Cargo.toml
- Python SDK tests: 21 passed, 4 skipped
- Python budget, parallel-budget, session-close, and subagent-query runtime scripts
- real duplicate-extension rejection, cleanup, rebuild, and successful re-import
- cargo fmt --all -- --check
- git diff --check

S3 workspace and Sandbox behavior are unchanged.