### PR TITLE
docs: declare native Code harness contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,15 +63,16 @@ copy or container-sized indexing allocation for hostile Tool output. Regression
 coverage includes UTF-8 head/tail retention, prefix-preserving folds, and
 250,000-item JSON arrays; the v1 algorithm and evidence binding remain stable.
 
-### 3.1 Harness architecture improvements
+### 3.1 Native Harness architecture
 
-A review of DeepSeek Harness reinforces four useful boundaries without making
-Code Core a general dependency-injection or plugin framework. The model should
-see the exact capability surface and readiness state it can act on; each run
-should bind the actual model input rather than only its intended configuration;
-temporary capabilities should have explicit lifetimes; and richer code-mode
-tool presentation should remain a host/profile concern over the same governed
-execution world.
+Code defines its own Harness contract and does not target DeepSeek Harness,
+Cordis, or another foreign runtime. First-principles review led to four native
+boundaries without making Code Core a general dependency-injection or plugin
+framework: the model sees the exact capability surface and readiness state it
+can act on; each Run binds the actual model input rather than only its intended
+configuration; temporary capabilities have explicit lifetimes; and richer
+code-mode Tool presentation remains a host/profile concern over the same
+governed execution world.
 
 | Gate | State | Code-owned outcome | Exit criteria |
 | --- | --- | --- | --- |

--- a/manual/SCOPED_CAPABILITY_ARCHITECTURE.md
+++ b/manual/SCOPED_CAPABILITY_ARCHITECTURE.md
@@ -4,8 +4,9 @@ Status: accepted foundation; A3S Use bridge, immutable set, scoped lifecycle, at
 
 ## Decision
 
-A3S Code will adopt scoped capability lifecycle semantics inspired by
-[Cordis](https://github.com/cordiverse/cordis) without becoming a general
+A3S Code defines a native scoped capability lifecycle. It is informed by
+first-principles review of existing Harness systems, but it is not a Cordis or
+DeepSeek Harness compatibility layer and does not become a general
 dependency-injection or package-management framework.
 
 A3S Use remains the only owner of cognitive-package discovery, verification,
@@ -15,7 +16,7 @@ Use capability snapshot and projects it into product-owned Session, Run, Turn,
 and Subtask scopes. A3S Runtime, Gateway, Flow, and Knowledge continue to own
 their native execution and data lifecycles.
 
-The design adopts Cordis's useful lifecycle properties:
+The native design provides four explicit lifecycle properties:
 
 - context-local capability visibility;
 - dependency-aware activation;


### PR DESCRIPTION
## Summary
- make A3S Code's Harness explicitly native and independent of DeepSeek Harness/Cordis compatibility
- retain typed scoped capabilities, exact Use snapshots, provider seams, and evidence/time ownership
- update the scoped capability architecture to describe native lifecycle semantics

## Validation
- documentation-only change
- created from Code main in an isolated worktree; no zvec-grep working tree changes included
