### PR TITLE
feat(core): add native research evidence contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ telemetry remain opt-in.
 | Agent runtime           | Async `Agent`, workspace-bound `AgentSession`, send, stream, resume, replace, cancel, close, replay, and safe-point `steer`/`interrupt` run control                                                                                                                                          | Baseline                                                                                                                                                                  |
 | Governed tools          | Files, search, shell, Git, web, structured generation, batch, program, Skills, MCP, delegation, deterministic result projection, and evidence                                                                                           | Exposed only when workspace and policy allow                                                                                                                              |
 | Evaluation substrate    | Provider-neutral execution targets/frames, digest-only fact journals, atomic bounded evidence snapshots, isolated auxiliary runs, host boundary supervision, restart-safe dispatch leases, durable result CAS, and strict versioned Rust/Node/Python/Go wire projections | Inject an `EvaluationPolicy`/`AuxiliaryExecutor` and optionally a dispatch/result store; Core supplies mechanisms and generated transport schemas, while reviewer rubrics, findings, authorization, and Cloud audit remain host-owned |
+| Native research contracts | Versioned digest-bound research runs, evidence facts, provenance receipts, review findings, and project events with bounded fields and fail-closed lifecycle transitions | Hosts bind exact source/evidence snapshots and `RunCapabilityBindingV1`; A3S Use supplies package/environment identity and Desktop/Cloud own scientific policy, review decisions, retention, and publication |
 | Code intelligence       | Saved-file symbols, definitions, declarations, references, implementations, diagnostics, revisions, and stale-state metadata                                                                                                            | Host-selected local workspace                                                                                                                                             |
 | Workspace retrieval     | Asynchronous session-owned chunk catalog, official zvec-rust FTS/BM25 by default, Memory-backed exact vectors, hybrid RRF, optional deterministic CPU reranking, readiness/coverage metrics, and digest-verified current-source results | Explicit per-session opt-in for semantic/vector work; baseline lexical and symbol search needs no embedding model or vector database; native zvec builds require an attested platform library |
 | Context and memory      | Ranked context, repeated compaction, three-tier V1 memory, typed stores, recall, extraction, non-destructive supersession, V2 candidate shadowing, audited active-only lexical/semantic/one-hop relation recall, deterministic RRF, verified revision-CAS snapshot refresh receipts, exact namespace-token acceleration, host-persisted safe refresh checkpoints, opt-in session-owned refresh scheduling, exact restart binding, and owned maintenance health | Host-selected; V2 requires an exact repository/namespace binding and evidence-backed activation; semantic recall additionally requires a typed embedding provider, caller-owned vector index, explicit refresh timing, and exact schema-5 generation identity |
@@ -202,6 +203,14 @@ runtime authority/run-control contract, the canonical repository-tool schema,
 and shared safety boundaries. The host runtime remains authoritative for every
 permission, approval, budget, cancellation, and sandbox decision; prompt text
 does not grant a capability that the current session has not exposed.
+
+Scientific workflows use the same boundary. `a3s-code-core::research` binds a
+run to exact project, source, evidence, and Code/Use capability identities;
+records digest-only observations; and issues provenance and review shapes that
+can be rendered by a host. It deliberately leaves package resolution,
+reviewer rubrics, acceptance thresholds, human approval, retention, and
+publication to A3S Use and the host application. See
+[Native Research Contracts](manual/RESEARCH_CONTRACTS.md).
 
 ## Configure the runtime
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,10 @@ defines shared ownership and dependency order. This roadmap must not create a
 second Cloud Agent lifecycle, scheduler, queue, Secret store, usage ledger, or
 checkpoint authority.
 
+Scientific discovery is a product composition over this runtime, not a new
+runtime mode. The cross-repository implementation plan is tracked in the
+[scientific discovery platform roadmap](https://github.com/A3S-Lab/a3s/blob/main/docs/scientific-discovery-platform-roadmap.md).
+
 ## 2. Current foundation
 
 - `Agent`, `AgentSession`, governed Tool invocation, model adapters, bounded
@@ -234,7 +238,27 @@ until all lifecycle and recovery invariants are covered. Durable fact/result
 storage, tenant authorization, retention, placement, and business lineage
 remain host/Cloud adapter responsibilities behind the published traits.
 
-### 3.3 Scoped capability program
+### 3.3 Native scientific research contracts
+
+The first Code-side slice makes scientific execution observable and
+reproducible without importing a foreign Harness or moving scientific policy
+into Core. These contracts are transport and integrity primitives: A3S Use
+binds the selected package/environment generation, while the host or Desktop
+decides how to search, review, approve, retain, and publish results.
+
+| Gate | State | Code-owned outcome | Exit criteria |
+| --- | --- | --- | --- |
+| `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Eleven focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
+| `RESEARCH-EXEC1` | Planned | Host adapter that drives a research run through source capture, evidence append, artifact publication, and evaluator dispatch while retaining one Code Run identity | Integration tests prove restart, cancellation, contiguous evidence, artifact immutability, and exact Code/Use binding across a real workspace |
+| `RESEARCH-REVIEW1` | Planned | Host-owned reviewer composition over the generic evaluation substrate, projecting bounded findings and human decisions without a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral |
+
+The delivered contract slice is documented in
+[Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
+small: it does not claim a complete project aggregate, scientific knowledge
+graph, package registry, or publication service. Those capabilities belong to
+the host, A3S Use, and Desktop phases in the cross-repository roadmap.
+
+### 3.4 Scoped capability program
 
 The [Scoped Capability Architecture](manual/SCOPED_CAPABILITY_ARCHITECTURE.md)
 adopts Cordis-style context, fiber, and reversible-effect lifecycle semantics
@@ -367,7 +391,7 @@ does not acquire, publish, mutate, or retire an A3S Use generation. Delegated
 runs inherit the exact parent Profile, and resume rejects a different explicit
 Profile.
 
-### 3.4 Durable memory program
+### 3.5 Durable memory program
 
 The durable-memory program adds reusable, evidence-backed agent state without
 turning an extraction model or a storage backend into a truth authority. A3S

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -115,6 +115,7 @@ pub mod program;
 pub(crate) mod prompts;
 pub mod queue;
 pub mod release;
+pub mod research;
 pub mod retention;
 pub(crate) mod retry;
 pub mod rl_trajectory;
@@ -294,6 +295,15 @@ pub use orchestration::{
     WorkflowStepRecord, WORKFLOW_CHECKPOINT_SCHEMA_VERSION,
 };
 pub use prompts::{AgentStyle, DetectionConfidence, PlanningMode, SystemPromptSlots};
+pub use research::{
+    ResearchArtifactKindV1, ResearchContractError, ResearchEventV1, ResearchEvidenceFactKindV1,
+    ResearchEvidenceFactV1, ResearchProvenanceReceiptV1, ResearchReproducibilityV1,
+    ResearchReviewCategoryV1, ResearchReviewFindingV1, ResearchReviewLocationV1,
+    ResearchReviewSeverityV1, ResearchReviewStatusV1, ResearchRunStatusV1, ResearchRunV1,
+    RESEARCH_ARTIFACT_KINDS, RESEARCH_EVENT_SCHEMA_V1, RESEARCH_EVIDENCE_FACT_SCHEMA_V1,
+    RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1, RESEARCH_REVIEW_FINDING_SCHEMA_V1,
+    RESEARCH_RUN_SCHEMA_V1,
+};
 pub use rl_trajectory::{RlTrajectoryConfig, RlTrajectoryMode, RlTrajectoryRecorder};
 pub use run::{
     ActiveToolSnapshot, InMemoryRunStore, RunEventRecord, RunHandle, RunRecord, RunReservation,

--- a/core/src/research/error.rs
+++ b/core/src/research/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+/// Validation failures for native scientific research contracts.
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ResearchContractError {
+    #[error("research contract schema is unsupported")]
+    UnsupportedSchema,
+    #[error("research contract field `{0}` is invalid")]
+    InvalidField(&'static str),
+    #[error("research contract field `{0}` is not a canonical SHA-256 digest")]
+    InvalidDigest(&'static str),
+    #[error("research contract digest for `{0}` does not match its contents")]
+    DigestMismatch(&'static str),
+    #[error("research contract transition from `{from}` to `{to}` is invalid")]
+    InvalidTransition {
+        from: &'static str,
+        to: &'static str,
+    },
+    #[error("research contract serialization failed: {0}")]
+    Serialization(String),
+}

--- a/core/src/research/event.rs
+++ b/core/src/research/event.rs
@@ -1,0 +1,155 @@
+use super::{digest, validate_digest_field, validate_id, ResearchContractError};
+use serde::{Deserialize, Serialize};
+
+pub const RESEARCH_EVENT_SCHEMA_V1: &str = "a3s.code.science-event.v1";
+const RESEARCH_EVENT_DIGEST_DOMAIN: &str = "a3s.code.science-event.identity.v1";
+pub const RESEARCH_MAX_EVENT_TYPE_BYTES: usize = 128;
+
+/// Digest-only research event projection for Desktop and other hosts.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchEventV1 {
+    pub schema: String,
+    pub project_id: String,
+    pub project_revision: u64,
+    pub run_id: Option<String>,
+    pub sequence: u64,
+    pub event_type: String,
+    pub payload_digest: String,
+    pub observed_at_ms: u64,
+    pub event_digest: String,
+}
+
+impl ResearchEventV1 {
+    pub fn new(
+        project_id: impl Into<String>,
+        project_revision: u64,
+        run_id: Option<String>,
+        sequence: u64,
+        event_type: impl Into<String>,
+        payload_digest: impl Into<String>,
+        observed_at_ms: u64,
+    ) -> Result<Self, ResearchContractError> {
+        let mut event = Self {
+            schema: RESEARCH_EVENT_SCHEMA_V1.to_owned(),
+            project_id: project_id.into(),
+            project_revision,
+            run_id,
+            sequence,
+            event_type: event_type.into(),
+            payload_digest: payload_digest.into(),
+            observed_at_ms,
+            event_digest: String::new(),
+        };
+        event.validate_without_digest()?;
+        event.event_digest = event.expected_digest()?;
+        Ok(event)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("eventDigest", &self.event_digest)?;
+        if self.event_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("eventDigest"));
+        }
+        Ok(())
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_EVENT_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("projectId", &self.project_id)?;
+        if self.project_revision == 0 {
+            return Err(ResearchContractError::InvalidField("projectRevision"));
+        }
+        if let Some(run_id) = &self.run_id {
+            validate_id("runId", run_id)?;
+        }
+        if self.sequence == 0 {
+            return Err(ResearchContractError::InvalidField("sequence"));
+        }
+        validate_event_type(&self.event_type)?;
+        validate_digest_field("payloadDigest", &self.payload_digest)?;
+        if self.observed_at_ms == 0 {
+            return Err(ResearchContractError::InvalidField("observedAtMs"));
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            project_id: &'a str,
+            project_revision: u64,
+            run_id: Option<&'a str>,
+            sequence: u64,
+            event_type: &'a str,
+            payload_digest: &'a str,
+            observed_at_ms: u64,
+        }
+        digest(
+            RESEARCH_EVENT_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                project_id: &self.project_id,
+                project_revision: self.project_revision,
+                run_id: self.run_id.as_deref(),
+                sequence: self.sequence,
+                event_type: &self.event_type,
+                payload_digest: &self.payload_digest,
+                observed_at_ms: self.observed_at_ms,
+            },
+        )
+    }
+}
+
+fn validate_event_type(value: &str) -> Result<(), ResearchContractError> {
+    if value.is_empty()
+        || value.len() > RESEARCH_MAX_EVENT_TYPE_BYTES
+        || value.starts_with('.')
+        || value.ends_with('.')
+        || value.split('.').any(|segment| {
+            segment.is_empty()
+                || !segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        })
+    {
+        return Err(ResearchContractError::InvalidField("eventType"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    #[test]
+    fn event_rejects_noncanonical_event_types_and_binds_payload() {
+        assert!(matches!(
+            ResearchEventV1::new("project-1", 1, None, 1, "Research.Started", digest('a'), 1),
+            Err(ResearchContractError::InvalidField("eventType"))
+        ));
+        let event = ResearchEventV1::new(
+            "project-1",
+            1,
+            Some("run-1".to_owned()),
+            1,
+            "research.run.admitted",
+            digest('a'),
+            1,
+        )
+        .unwrap();
+        assert!(event.validate().is_ok());
+
+        let mut encoded = serde_json::to_value(&event).unwrap();
+        encoded["unexpected"] = serde_json::Value::Bool(true);
+        assert!(serde_json::from_value::<ResearchEventV1>(encoded).is_err());
+    }
+}

--- a/core/src/research/evidence.rs
+++ b/core/src/research/evidence.rs
@@ -1,0 +1,203 @@
+use super::{digest, validate_digest_field, validate_id, validate_text, ResearchContractError};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const RESEARCH_EVIDENCE_FACT_SCHEMA_V1: &str = "a3s.code.evidence-fact.v1";
+const RESEARCH_EVIDENCE_FACT_DIGEST_DOMAIN: &str = "a3s.code.evidence-fact.identity.v1";
+pub const RESEARCH_MAX_FACT_METADATA: usize = 32;
+pub const RESEARCH_MAX_METADATA_VALUE_BYTES: usize = 1024;
+
+/// Stable categories for digest-only research observations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchEvidenceFactKindV1 {
+    Source,
+    SourceSpan,
+    Claim,
+    Citation,
+    Measurement,
+    Derivation,
+    Artifact,
+    Validation,
+    Review,
+}
+
+/// One append-only, bounded observation in a research evidence ledger.
+///
+/// The value contains references and metadata, never the source text or raw
+/// model/tool payload. A host may resolve the digests through its own artifact
+/// store after checking the associated authority and project revision.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchEvidenceFactV1 {
+    pub schema: String,
+    pub run_id: String,
+    pub sequence: u64,
+    pub kind: ResearchEvidenceFactKindV1,
+    pub subject_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_digest: Option<String>,
+    pub content_digest: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+    pub observed_at_ms: u64,
+    pub fact_digest: String,
+}
+
+impl ResearchEvidenceFactV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        run_id: impl Into<String>,
+        sequence: u64,
+        kind: ResearchEvidenceFactKindV1,
+        subject_id: impl Into<String>,
+        source_digest: Option<String>,
+        content_digest: impl Into<String>,
+        metadata: BTreeMap<String, String>,
+        observed_at_ms: u64,
+    ) -> Result<Self, ResearchContractError> {
+        let mut fact = Self {
+            schema: RESEARCH_EVIDENCE_FACT_SCHEMA_V1.to_owned(),
+            run_id: run_id.into(),
+            sequence,
+            kind,
+            subject_id: subject_id.into(),
+            source_digest,
+            content_digest: content_digest.into(),
+            metadata,
+            observed_at_ms,
+            fact_digest: String::new(),
+        };
+        fact.validate_without_digest()?;
+        fact.fact_digest = fact.expected_digest()?;
+        Ok(fact)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("factDigest", &self.fact_digest)?;
+        if self.fact_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("factDigest"));
+        }
+        Ok(())
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_EVIDENCE_FACT_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("runId", &self.run_id)?;
+        if self.sequence == 0 {
+            return Err(ResearchContractError::InvalidField("sequence"));
+        }
+        validate_id("subjectId", &self.subject_id)?;
+        if let Some(source_digest) = &self.source_digest {
+            validate_digest_field("sourceDigest", source_digest)?;
+        }
+        validate_digest_field("contentDigest", &self.content_digest)?;
+        if self.metadata.len() > RESEARCH_MAX_FACT_METADATA {
+            return Err(ResearchContractError::InvalidField("metadata"));
+        }
+        for (key, value) in &self.metadata {
+            validate_id("metadata.key", key)?;
+            validate_text("metadata.value", value, RESEARCH_MAX_METADATA_VALUE_BYTES)?;
+        }
+        if self.observed_at_ms == 0 {
+            return Err(ResearchContractError::InvalidField("observedAtMs"));
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            run_id: &'a str,
+            sequence: u64,
+            kind: ResearchEvidenceFactKindV1,
+            subject_id: &'a str,
+            source_digest: Option<&'a str>,
+            content_digest: &'a str,
+            metadata: &'a BTreeMap<String, String>,
+            observed_at_ms: u64,
+        }
+        digest(
+            RESEARCH_EVIDENCE_FACT_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                run_id: &self.run_id,
+                sequence: self.sequence,
+                kind: self.kind,
+                subject_id: &self.subject_id,
+                source_digest: self.source_digest.as_deref(),
+                content_digest: &self.content_digest,
+                metadata: &self.metadata,
+                observed_at_ms: self.observed_at_ms,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    #[test]
+    fn fact_is_digest_bound_and_metadata_is_canonical() {
+        let mut metadata = BTreeMap::new();
+        metadata.insert("locator".to_owned(), "page-3".to_owned());
+        let fact = ResearchEvidenceFactV1::new(
+            "run-1",
+            1,
+            ResearchEvidenceFactKindV1::Claim,
+            "claim-1",
+            Some(digest('a')),
+            digest('b'),
+            metadata,
+            1,
+        )
+        .unwrap();
+        assert!(fact.validate().is_ok());
+        let mut tampered = fact.clone();
+        tampered.metadata.insert("extra".to_owned(), "x".to_owned());
+        assert!(matches!(
+            tampered.validate(),
+            Err(ResearchContractError::DigestMismatch("factDigest"))
+        ));
+    }
+
+    #[test]
+    fn fact_rejects_zero_sequence_and_raw_multiline_metadata() {
+        let error = ResearchEvidenceFactV1::new(
+            "run-1",
+            0,
+            ResearchEvidenceFactKindV1::Source,
+            "source-1",
+            None,
+            digest('a'),
+            BTreeMap::new(),
+            1,
+        )
+        .unwrap_err();
+        assert_eq!(error, ResearchContractError::InvalidField("sequence"));
+
+        let mut metadata = BTreeMap::new();
+        metadata.insert("note".to_owned(), "line one\nline two".to_owned());
+        let error = ResearchEvidenceFactV1::new(
+            "run-1",
+            1,
+            ResearchEvidenceFactKindV1::Source,
+            "source-1",
+            None,
+            digest('a'),
+            metadata,
+            1,
+        )
+        .unwrap_err();
+        assert_eq!(error, ResearchContractError::InvalidField("metadata.value"));
+    }
+}

--- a/core/src/research/mod.rs
+++ b/core/src/research/mod.rs
@@ -1,0 +1,77 @@
+//! Native research-run contracts for the A3S Code scientific workflow.
+//!
+//! This module contains bounded, digest-bound transport values. It does not
+//! resolve packages, choose scientific methods, or decide whether a finding
+//! is acceptable. A3S Use owns package and environment authority; hosts own
+//! scientific policy and human decisions.
+
+mod error;
+mod event;
+mod evidence;
+mod provenance;
+mod review;
+mod run;
+
+pub use error::ResearchContractError;
+pub use event::{ResearchEventV1, RESEARCH_EVENT_SCHEMA_V1, RESEARCH_MAX_EVENT_TYPE_BYTES};
+pub use evidence::{
+    ResearchEvidenceFactKindV1, ResearchEvidenceFactV1, RESEARCH_EVIDENCE_FACT_SCHEMA_V1,
+    RESEARCH_MAX_FACT_METADATA, RESEARCH_MAX_METADATA_VALUE_BYTES,
+};
+pub use provenance::{
+    ResearchArtifactKindV1, ResearchProvenanceReceiptV1, RESEARCH_ARTIFACT_KINDS,
+    RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1,
+};
+pub use review::{
+    ResearchReviewCategoryV1, ResearchReviewFindingV1, ResearchReviewLocationV1,
+    ResearchReviewSeverityV1, ResearchReviewStatusV1, RESEARCH_REVIEW_FINDING_SCHEMA_V1,
+};
+pub use run::{
+    ResearchReproducibilityV1, ResearchRunStatusV1, ResearchRunV1, RESEARCH_RUN_SCHEMA_V1,
+};
+
+pub(crate) const RESEARCH_MAX_ID_BYTES: usize = 256;
+pub(crate) const RESEARCH_MAX_TEXT_BYTES: usize = 16 * 1024;
+pub(crate) const RESEARCH_MAX_DIGESTS: usize = 512;
+
+pub(crate) fn validate_id(field: &'static str, value: &str) -> Result<(), ResearchContractError> {
+    if value.is_empty()
+        || value.len() > RESEARCH_MAX_ID_BYTES
+        || value.contains('\0')
+        || value.lines().count() != 1
+    {
+        return Err(ResearchContractError::InvalidField(field));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_text(
+    field: &'static str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), ResearchContractError> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.contains('\0')
+        || value.lines().count() > 1
+    {
+        return Err(ResearchContractError::InvalidField(field));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_digest_field(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ResearchContractError> {
+    crate::evaluation::validate_digest(value)
+        .map_err(|_| ResearchContractError::InvalidDigest(field))
+}
+
+pub(crate) fn digest<T: serde::Serialize>(
+    domain: &'static str,
+    value: &T,
+) -> Result<String, ResearchContractError> {
+    crate::evaluation::digest_json(domain, value)
+        .map_err(|error| ResearchContractError::Serialization(error.to_string()))
+}

--- a/core/src/research/provenance.rs
+++ b/core/src/research/provenance.rs
@@ -1,0 +1,242 @@
+use super::{
+    digest, validate_digest_field, validate_id, ResearchContractError, RESEARCH_MAX_DIGESTS,
+};
+use serde::{Deserialize, Serialize};
+
+pub const RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1: &str = "a3s.code.provenance-receipt.v1";
+const RESEARCH_PROVENANCE_RECEIPT_DIGEST_DOMAIN: &str = "a3s.code.provenance-receipt.identity.v1";
+
+/// Artifact families that can be bound to a research provenance receipt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchArtifactKindV1 {
+    Figure,
+    Table,
+    Dataset,
+    Notebook,
+    Model,
+    Report,
+    Other,
+}
+
+pub const RESEARCH_ARTIFACT_KINDS: &[ResearchArtifactKindV1] = &[
+    ResearchArtifactKindV1::Figure,
+    ResearchArtifactKindV1::Table,
+    ResearchArtifactKindV1::Dataset,
+    ResearchArtifactKindV1::Notebook,
+    ResearchArtifactKindV1::Model,
+    ResearchArtifactKindV1::Report,
+    ResearchArtifactKindV1::Other,
+];
+
+/// Reproducibility identity for one generated artifact.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchProvenanceReceiptV1 {
+    pub schema: String,
+    pub project_id: String,
+    pub project_revision: u64,
+    pub run_id: String,
+    pub artifact_id: String,
+    pub artifact_kind: ResearchArtifactKindV1,
+    pub artifact_digest: String,
+    pub input_digests: Vec<String>,
+    pub workflow_digest: String,
+    pub code_digest: String,
+    pub environment_digest: String,
+    pub provider_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub random_seed: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation_digest: Option<String>,
+    pub receipt_digest: String,
+}
+
+impl ResearchProvenanceReceiptV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        project_id: impl Into<String>,
+        project_revision: u64,
+        run_id: impl Into<String>,
+        artifact_id: impl Into<String>,
+        artifact_kind: ResearchArtifactKindV1,
+        artifact_digest: impl Into<String>,
+        mut input_digests: Vec<String>,
+        workflow_digest: impl Into<String>,
+        code_digest: impl Into<String>,
+        environment_digest: impl Into<String>,
+        provider_id: impl Into<String>,
+        model_digest: Option<String>,
+        random_seed: Option<u64>,
+        validation_digest: Option<String>,
+    ) -> Result<Self, ResearchContractError> {
+        input_digests.sort();
+        input_digests.dedup();
+        let mut receipt = Self {
+            schema: RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1.to_owned(),
+            project_id: project_id.into(),
+            project_revision,
+            run_id: run_id.into(),
+            artifact_id: artifact_id.into(),
+            artifact_kind,
+            artifact_digest: artifact_digest.into(),
+            input_digests,
+            workflow_digest: workflow_digest.into(),
+            code_digest: code_digest.into(),
+            environment_digest: environment_digest.into(),
+            provider_id: provider_id.into(),
+            model_digest,
+            random_seed,
+            validation_digest,
+            receipt_digest: String::new(),
+        };
+        receipt.validate_without_digest()?;
+        receipt.receipt_digest = receipt.expected_digest()?;
+        Ok(receipt)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("receiptDigest", &self.receipt_digest)?;
+        if self.receipt_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("receiptDigest"));
+        }
+        Ok(())
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("projectId", &self.project_id)?;
+        if self.project_revision == 0 {
+            return Err(ResearchContractError::InvalidField("projectRevision"));
+        }
+        validate_id("runId", &self.run_id)?;
+        validate_id("artifactId", &self.artifact_id)?;
+        validate_digest_field("artifactDigest", &self.artifact_digest)?;
+        if self.input_digests.is_empty() || self.input_digests.len() > RESEARCH_MAX_DIGESTS {
+            return Err(ResearchContractError::InvalidField("inputDigests"));
+        }
+        for pair in self.input_digests.windows(2) {
+            if pair[0] >= pair[1] {
+                return Err(ResearchContractError::InvalidField("inputDigests"));
+            }
+        }
+        for digest in &self.input_digests {
+            validate_digest_field("inputDigests", digest)?;
+        }
+        validate_digest_field("workflowDigest", &self.workflow_digest)?;
+        validate_digest_field("codeDigest", &self.code_digest)?;
+        validate_digest_field("environmentDigest", &self.environment_digest)?;
+        validate_id("providerId", &self.provider_id)?;
+        if let Some(model_digest) = &self.model_digest {
+            validate_digest_field("modelDigest", model_digest)?;
+        }
+        if let Some(validation_digest) = &self.validation_digest {
+            validate_digest_field("validationDigest", validation_digest)?;
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            project_id: &'a str,
+            project_revision: u64,
+            run_id: &'a str,
+            artifact_id: &'a str,
+            artifact_kind: ResearchArtifactKindV1,
+            artifact_digest: &'a str,
+            input_digests: &'a [String],
+            workflow_digest: &'a str,
+            code_digest: &'a str,
+            environment_digest: &'a str,
+            provider_id: &'a str,
+            model_digest: Option<&'a str>,
+            random_seed: Option<u64>,
+            validation_digest: Option<&'a str>,
+        }
+        digest(
+            RESEARCH_PROVENANCE_RECEIPT_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                project_id: &self.project_id,
+                project_revision: self.project_revision,
+                run_id: &self.run_id,
+                artifact_id: &self.artifact_id,
+                artifact_kind: self.artifact_kind,
+                artifact_digest: &self.artifact_digest,
+                input_digests: &self.input_digests,
+                workflow_digest: &self.workflow_digest,
+                code_digest: &self.code_digest,
+                environment_digest: &self.environment_digest,
+                provider_id: &self.provider_id,
+                model_digest: self.model_digest.as_deref(),
+                random_seed: self.random_seed,
+                validation_digest: self.validation_digest.as_deref(),
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    #[test]
+    fn receipt_sorts_inputs_and_binds_environment_and_workflow() {
+        let receipt = ResearchProvenanceReceiptV1::new(
+            "project-1",
+            1,
+            "run-1",
+            "artifact-1",
+            ResearchArtifactKindV1::Figure,
+            digest('a'),
+            vec![digest('c'), digest('b'), digest('c')],
+            digest('d'),
+            digest('e'),
+            digest('f'),
+            "local",
+            Some(digest('f')),
+            Some(7),
+            None,
+        )
+        .unwrap();
+        assert_eq!(receipt.input_digests, vec![digest('b'), digest('c')]);
+        assert!(receipt.validate().is_ok());
+    }
+
+    #[test]
+    fn receipt_rejects_duplicate_or_unsorted_mutation() {
+        let mut receipt = ResearchProvenanceReceiptV1::new(
+            "project-1",
+            1,
+            "run-1",
+            "artifact-1",
+            ResearchArtifactKindV1::Report,
+            digest('a'),
+            vec![digest('b'), digest('c')],
+            digest('d'),
+            digest('e'),
+            digest('f'),
+            "local",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        receipt.input_digests.reverse();
+        assert_eq!(
+            receipt.validate(),
+            Err(ResearchContractError::InvalidField("inputDigests"))
+        );
+    }
+}

--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -1,0 +1,343 @@
+use super::{
+    digest, validate_digest_field, validate_id, validate_text, ResearchContractError,
+    RESEARCH_MAX_DIGESTS, RESEARCH_MAX_TEXT_BYTES,
+};
+use serde::{Deserialize, Serialize};
+
+pub const RESEARCH_REVIEW_FINDING_SCHEMA_V1: &str = "a3s.code.review-finding.v1";
+const RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN: &str = "a3s.code.review-finding.identity.v1";
+
+/// Product-neutral classes that let a host render and route a finding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchReviewCategoryV1 {
+    Citation,
+    Numeric,
+    FigureCode,
+    Method,
+    Reproducibility,
+    Source,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchReviewSeverityV1 {
+    Info,
+    Warning,
+    Error,
+    Blocker,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchReviewStatusV1 {
+    Open,
+    Resolved,
+    Waived,
+}
+
+impl ResearchReviewStatusV1 {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Resolved => "resolved",
+            Self::Waived => "waived",
+        }
+    }
+}
+
+/// Bounded location of a reviewer observation in an artifact or source.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchReviewLocationV1 {
+    pub anchor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>,
+}
+
+impl ResearchReviewLocationV1 {
+    pub fn new(anchor: impl Into<String>) -> Result<Self, ResearchContractError> {
+        let location = Self {
+            anchor: anchor.into(),
+            line: None,
+            column: None,
+        };
+        validate_text("location.anchor", &location.anchor, 512)?;
+        Ok(location)
+    }
+
+    pub fn with_line(mut self, line: u32, column: Option<u32>) -> Self {
+        self.line = Some(line);
+        self.column = column;
+        self
+    }
+
+    fn validate(&self) -> Result<(), ResearchContractError> {
+        validate_text("location.anchor", &self.anchor, 512)
+    }
+}
+
+/// One host-produced scientific review observation bound to exact evidence.
+///
+/// Code validates identity and lifecycle shape only. A host or Use package
+/// supplies the rubric, model, thresholds, and final approval decision.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchReviewFindingV1 {
+    pub schema: String,
+    pub finding_id: String,
+    pub project_id: String,
+    pub run_id: String,
+    pub artifact_digest: String,
+    pub category: ResearchReviewCategoryV1,
+    pub severity: ResearchReviewSeverityV1,
+    pub status: ResearchReviewStatusV1,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<ResearchReviewLocationV1>,
+    pub evidence_digests: Vec<String>,
+    pub evaluator_id: String,
+    pub observed_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution_digest: Option<String>,
+    pub finding_digest: String,
+}
+
+impl ResearchReviewFindingV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        finding_id: impl Into<String>,
+        project_id: impl Into<String>,
+        run_id: impl Into<String>,
+        artifact_digest: impl Into<String>,
+        category: ResearchReviewCategoryV1,
+        severity: ResearchReviewSeverityV1,
+        message: impl Into<String>,
+        location: Option<ResearchReviewLocationV1>,
+        mut evidence_digests: Vec<String>,
+        evaluator_id: impl Into<String>,
+        observed_at_ms: u64,
+    ) -> Result<Self, ResearchContractError> {
+        evidence_digests.sort();
+        evidence_digests.dedup();
+        let mut finding = Self {
+            schema: RESEARCH_REVIEW_FINDING_SCHEMA_V1.to_owned(),
+            finding_id: finding_id.into(),
+            project_id: project_id.into(),
+            run_id: run_id.into(),
+            artifact_digest: artifact_digest.into(),
+            category,
+            severity,
+            status: ResearchReviewStatusV1::Open,
+            message: message.into(),
+            location,
+            evidence_digests,
+            evaluator_id: evaluator_id.into(),
+            observed_at_ms,
+            resolution_digest: None,
+            finding_digest: String::new(),
+        };
+        finding.validate_without_digest()?;
+        finding.finding_digest = finding.expected_digest()?;
+        Ok(finding)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("findingDigest", &self.finding_digest)?;
+        if self.finding_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("findingDigest"));
+        }
+        Ok(())
+    }
+
+    pub fn resolve(
+        &mut self,
+        resolution_digest: impl Into<String>,
+    ) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        let resolution_digest = resolution_digest.into();
+        validate_digest_field("resolutionDigest", &resolution_digest)?;
+        self.status = ResearchReviewStatusV1::Resolved;
+        self.resolution_digest = Some(resolution_digest);
+        self.finding_digest = self.expected_digest()?;
+        Ok(())
+    }
+
+    pub fn waive(
+        &mut self,
+        resolution_digest: impl Into<String>,
+    ) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        let resolution_digest = resolution_digest.into();
+        validate_digest_field("resolutionDigest", &resolution_digest)?;
+        self.status = ResearchReviewStatusV1::Waived;
+        self.resolution_digest = Some(resolution_digest);
+        self.finding_digest = self.expected_digest()?;
+        Ok(())
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_REVIEW_FINDING_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("findingId", &self.finding_id)?;
+        validate_id("projectId", &self.project_id)?;
+        validate_id("runId", &self.run_id)?;
+        validate_digest_field("artifactDigest", &self.artifact_digest)?;
+        validate_text("message", &self.message, RESEARCH_MAX_TEXT_BYTES)?;
+        if let Some(location) = &self.location {
+            location.validate()?;
+        }
+        if self.evidence_digests.is_empty() || self.evidence_digests.len() > RESEARCH_MAX_DIGESTS {
+            return Err(ResearchContractError::InvalidField("evidenceDigests"));
+        }
+        for pair in self.evidence_digests.windows(2) {
+            if pair[0] >= pair[1] {
+                return Err(ResearchContractError::InvalidField("evidenceDigests"));
+            }
+        }
+        for digest in &self.evidence_digests {
+            validate_digest_field("evidenceDigests", digest)?;
+        }
+        validate_id("evaluatorId", &self.evaluator_id)?;
+        if self.observed_at_ms == 0 {
+            return Err(ResearchContractError::InvalidField("observedAtMs"));
+        }
+        if matches!(self.status, ResearchReviewStatusV1::Open) && self.resolution_digest.is_some() {
+            return Err(ResearchContractError::InvalidField("resolutionDigest"));
+        }
+        if !matches!(self.status, ResearchReviewStatusV1::Open) && self.resolution_digest.is_none()
+        {
+            return Err(ResearchContractError::InvalidField("resolutionDigest"));
+        }
+        if let Some(resolution_digest) = &self.resolution_digest {
+            validate_digest_field("resolutionDigest", resolution_digest)?;
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            finding_id: &'a str,
+            project_id: &'a str,
+            run_id: &'a str,
+            artifact_digest: &'a str,
+            category: ResearchReviewCategoryV1,
+            severity: ResearchReviewSeverityV1,
+            status: ResearchReviewStatusV1,
+            message: &'a str,
+            location: &'a Option<ResearchReviewLocationV1>,
+            evidence_digests: &'a [String],
+            evaluator_id: &'a str,
+            observed_at_ms: u64,
+            resolution_digest: Option<&'a str>,
+        }
+        digest(
+            RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                finding_id: &self.finding_id,
+                project_id: &self.project_id,
+                run_id: &self.run_id,
+                artifact_digest: &self.artifact_digest,
+                category: self.category,
+                severity: self.severity,
+                status: self.status,
+                message: &self.message,
+                location: &self.location,
+                evidence_digests: &self.evidence_digests,
+                evaluator_id: &self.evaluator_id,
+                observed_at_ms: self.observed_at_ms,
+                resolution_digest: self.resolution_digest.as_deref(),
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    #[test]
+    fn finding_is_bound_to_evidence_and_resolution() {
+        let mut finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Citation,
+            ResearchReviewSeverityV1::Warning,
+            "Citation does not support the claim.",
+            Some(
+                ResearchReviewLocationV1::new("report.md")
+                    .unwrap()
+                    .with_line(4, None),
+            ),
+            vec![digest('c'), digest('b')],
+            "citation-reviewer",
+            1,
+        )
+        .unwrap();
+        assert_eq!(finding.evidence_digests, vec![digest('b'), digest('c')]);
+        let open_digest = finding.finding_digest.clone();
+        finding.resolve(digest('d')).unwrap();
+        assert_ne!(open_digest, finding.finding_digest);
+        assert!(finding.validate().is_ok());
+    }
+
+    #[test]
+    fn finding_rejects_open_resolution_without_digest() {
+        let mut finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Numeric,
+            ResearchReviewSeverityV1::Error,
+            "Numbers are not traceable.",
+            None,
+            vec![digest('b')],
+            "numeric-reviewer",
+            1,
+        )
+        .unwrap();
+        finding.status = ResearchReviewStatusV1::Resolved;
+        assert_eq!(
+            finding.validate(),
+            Err(ResearchContractError::InvalidField("resolutionDigest"))
+        );
+    }
+
+    #[test]
+    fn resolution_rejects_a_tampered_finding_before_rebinding_identity() {
+        let mut finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Method,
+            ResearchReviewSeverityV1::Warning,
+            "The method needs a bounded description.",
+            None,
+            vec![digest('b')],
+            "method-reviewer",
+            1,
+        )
+        .unwrap();
+        finding.message = "tampered".to_owned();
+        assert_eq!(
+            finding.resolve(digest('c')),
+            Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+}

--- a/core/src/research/run.rs
+++ b/core/src/research/run.rs
@@ -1,0 +1,342 @@
+use super::{
+    digest, validate_digest_field, validate_id, ResearchContractError, RESEARCH_MAX_TEXT_BYTES,
+};
+use crate::capability::RunCapabilityBindingV1;
+use serde::{Deserialize, Serialize};
+
+pub const RESEARCH_RUN_SCHEMA_V1: &str = "a3s.code.research-run.v1";
+const RESEARCH_RUN_DIGEST_DOMAIN: &str = "a3s.code.research-run.identity.v1";
+
+/// Reproducibility promise selected by a host for one research run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchReproducibilityV1 {
+    Exploratory,
+    Reproducible,
+    Deterministic,
+}
+
+impl ResearchReproducibilityV1 {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exploratory => "exploratory",
+            Self::Reproducible => "reproducible",
+            Self::Deterministic => "deterministic",
+        }
+    }
+}
+
+/// Durable lifecycle state for a research run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResearchRunStatusV1 {
+    Planned,
+    Admitted,
+    Running,
+    Checkpointed,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl ResearchRunStatusV1 {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::Admitted => "admitted",
+            Self::Running => "running",
+            Self::Checkpointed => "checkpointed",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+
+    pub const fn can_transition_to(self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Planned, Self::Admitted | Self::Cancelled)
+                | (Self::Admitted, Self::Running | Self::Cancelled)
+                | (
+                    Self::Running,
+                    Self::Checkpointed | Self::Completed | Self::Failed | Self::Cancelled
+                )
+                | (
+                    Self::Checkpointed,
+                    Self::Running | Self::Completed | Self::Failed | Self::Cancelled
+                )
+        )
+    }
+}
+
+/// Exact Code/Use identity and policy binding for one scientific run.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchRunV1 {
+    pub schema: String,
+    pub run_id: String,
+    pub project_id: String,
+    pub project_revision: u64,
+    pub source_snapshot_digest: String,
+    pub evidence_snapshot_digest: String,
+    pub capability_binding: RunCapabilityBindingV1,
+    pub provider_id: String,
+    pub model_id: String,
+    pub reproducibility: ResearchReproducibilityV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub random_seed: Option<u64>,
+    pub status: ResearchRunStatusV1,
+    pub run_digest: String,
+}
+
+impl ResearchRunV1 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        run_id: impl Into<String>,
+        project_id: impl Into<String>,
+        project_revision: u64,
+        source_snapshot_digest: impl Into<String>,
+        evidence_snapshot_digest: impl Into<String>,
+        capability_binding: RunCapabilityBindingV1,
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+        reproducibility: ResearchReproducibilityV1,
+        random_seed: Option<u64>,
+    ) -> Result<Self, ResearchContractError> {
+        let mut run = Self {
+            schema: RESEARCH_RUN_SCHEMA_V1.to_owned(),
+            run_id: run_id.into(),
+            project_id: project_id.into(),
+            project_revision,
+            source_snapshot_digest: source_snapshot_digest.into(),
+            evidence_snapshot_digest: evidence_snapshot_digest.into(),
+            capability_binding,
+            provider_id: provider_id.into(),
+            model_id: model_id.into(),
+            reproducibility,
+            random_seed,
+            status: ResearchRunStatusV1::Planned,
+            run_digest: String::new(),
+        };
+        run.validate_without_digest()?;
+        run.run_digest = run.expected_digest()?;
+        Ok(run)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("runDigest", &self.run_digest)?;
+        if self.run_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("runDigest"));
+        }
+        Ok(())
+    }
+
+    pub fn transition_to(
+        &mut self,
+        next: ResearchRunStatusV1,
+    ) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        if !self.status.can_transition_to(next) {
+            return Err(ResearchContractError::InvalidTransition {
+                from: self.status.as_str(),
+                to: next.as_str(),
+            });
+        }
+        self.status = next;
+        self.run_digest = self.expected_digest()?;
+        Ok(())
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_RUN_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("runId", &self.run_id)?;
+        validate_id("projectId", &self.project_id)?;
+        if self.project_revision == 0 {
+            return Err(ResearchContractError::InvalidField("projectRevision"));
+        }
+        validate_digest_field("sourceSnapshotDigest", &self.source_snapshot_digest)?;
+        validate_digest_field("evidenceSnapshotDigest", &self.evidence_snapshot_digest)?;
+        self.capability_binding
+            .validate()
+            .map_err(|_| ResearchContractError::InvalidField("capabilityBinding"))?;
+        validate_id("providerId", &self.provider_id)?;
+        if self.model_id.is_empty() || self.model_id.len() > RESEARCH_MAX_TEXT_BYTES {
+            return Err(ResearchContractError::InvalidField("modelId"));
+        }
+        if matches!(
+            self.reproducibility,
+            ResearchReproducibilityV1::Deterministic
+        ) && self.random_seed.is_none()
+        {
+            return Err(ResearchContractError::InvalidField("randomSeed"));
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            run_id: &'a str,
+            project_id: &'a str,
+            project_revision: u64,
+            source_snapshot_digest: &'a str,
+            evidence_snapshot_digest: &'a str,
+            capability_binding: &'a RunCapabilityBindingV1,
+            provider_id: &'a str,
+            model_id: &'a str,
+            reproducibility: ResearchReproducibilityV1,
+            random_seed: Option<u64>,
+            status: ResearchRunStatusV1,
+        }
+        digest(
+            RESEARCH_RUN_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                run_id: &self.run_id,
+                project_id: &self.project_id,
+                project_revision: self.project_revision,
+                source_snapshot_digest: &self.source_snapshot_digest,
+                evidence_snapshot_digest: &self.evidence_snapshot_digest,
+                capability_binding: &self.capability_binding,
+                provider_id: &self.provider_id,
+                model_id: &self.model_id,
+                reproducibility: self.reproducibility,
+                random_seed: self.random_seed,
+                status: self.status,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capability::{
+        CapabilityCeiling, CapabilityContribution, CapabilityDescriptor,
+        CapabilityExecutionCeiling, CapabilityKind, CapabilitySet, CapabilitySource,
+        CodeCatalogGeneration, GovernanceCapabilityCeiling, Sha256Digest,
+        WorkspaceCapabilityCeiling,
+    };
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    fn binding() -> RunCapabilityBindingV1 {
+        let source =
+            CapabilitySource::builtin("test", Sha256Digest::new(digest('c')).unwrap()).unwrap();
+        let descriptor = CapabilityDescriptor::new(
+            &source,
+            CapabilityKind::Tool,
+            "tool",
+            "tool",
+            Sha256Digest::new(digest('d')).unwrap(),
+            [],
+        )
+        .unwrap();
+        let contribution = CapabilityContribution::new(source, [descriptor]).unwrap();
+        let set = CapabilitySet::from_contributions(CodeCatalogGeneration::new(1), [contribution])
+            .unwrap();
+        let ceiling = CapabilityCeiling::all(
+            &set,
+            WorkspaceCapabilityCeiling::default(),
+            GovernanceCapabilityCeiling::default(),
+            CapabilityExecutionCeiling::new(1, 1, None, None, None).unwrap(),
+        )
+        .unwrap();
+        RunCapabilityBindingV1::from_set_and_ceiling(&set, &ceiling).unwrap()
+    }
+
+    #[test]
+    fn run_digest_changes_when_status_changes() {
+        let mut run = ResearchRunV1::new(
+            "run-1",
+            "project-1",
+            1,
+            digest('a'),
+            digest('b'),
+            binding(),
+            "local",
+            "model",
+            ResearchReproducibilityV1::Reproducible,
+            None,
+        )
+        .unwrap();
+        let before = run.run_digest.clone();
+        run.transition_to(ResearchRunStatusV1::Admitted).unwrap();
+        assert_ne!(before, run.run_digest);
+        assert!(run.validate().is_ok());
+    }
+
+    #[test]
+    fn deterministic_runs_require_a_seed_and_terminal_runs_cannot_resume() {
+        assert!(matches!(
+            ResearchRunV1::new(
+                "run-1",
+                "project-1",
+                1,
+                digest('a'),
+                digest('b'),
+                binding(),
+                "local",
+                "model",
+                ResearchReproducibilityV1::Deterministic,
+                None,
+            ),
+            Err(ResearchContractError::InvalidField("randomSeed"))
+        ));
+        let mut run = ResearchRunV1::new(
+            "run-1",
+            "project-1",
+            1,
+            digest('a'),
+            digest('b'),
+            binding(),
+            "local",
+            "model",
+            ResearchReproducibilityV1::Reproducible,
+            None,
+        )
+        .unwrap();
+        run.transition_to(ResearchRunStatusV1::Admitted).unwrap();
+        run.transition_to(ResearchRunStatusV1::Running).unwrap();
+        run.transition_to(ResearchRunStatusV1::Completed).unwrap();
+        assert!(matches!(
+            run.transition_to(ResearchRunStatusV1::Running),
+            Err(ResearchContractError::InvalidTransition {
+                from: "completed",
+                to: "running"
+            })
+        ));
+    }
+
+    #[test]
+    fn transition_rejects_a_tampered_run_before_rebinding_identity() {
+        let mut run = ResearchRunV1::new(
+            "run-1",
+            "project-1",
+            1,
+            digest('a'),
+            digest('b'),
+            binding(),
+            "local",
+            "model",
+            ResearchReproducibilityV1::Reproducible,
+            None,
+        )
+        .unwrap();
+        run.project_id = "other-project".to_owned();
+        assert_eq!(
+            run.transition_to(ResearchRunStatusV1::Admitted),
+            Err(ResearchContractError::DigestMismatch("runDigest"))
+        );
+    }
+}

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -1,0 +1,73 @@
+# Native Research Contracts
+
+`a3s-code-core::research` is the Code-side identity and evidence boundary for
+scientific workflows. It makes a research run replayable and reviewable
+without turning Code into a package manager, a scientific policy engine, or a
+second Cloud audit authority.
+
+## Ownership
+
+- Code owns bounded wire values, canonical serialization, domain-separated
+  digests, run lifecycle transitions, and fail-closed validation.
+- A3S Use owns signed package and environment selection. A host injects the
+  exact `RunCapabilityBindingV1` produced by that selection.
+- The host or Desktop owns project aggregates, source retrieval, reviewer
+  prompts and rubrics, severity thresholds, human decisions, retention, and
+  publication workflows.
+
+The contracts are intentionally compatible with a host-owned reviewer. Code
+does not depend on DeepSeek Harness or another foreign runtime and does not
+interpret a review finding as approval.
+
+## Versioned values
+
+| Value | Schema | Purpose |
+| --- | --- | --- |
+| `ResearchRunV1` | `a3s.code.research-run.v1` | Binds project revision, source/evidence snapshots, Code/Use capability identity, provider/model, reproducibility promise, and lifecycle status. |
+| `ResearchEvidenceFactV1` | `a3s.code.evidence-fact.v1` | Append-only, digest-only observation with a monotonic sequence and bounded metadata. |
+| `ResearchProvenanceReceiptV1` | `a3s.code.provenance-receipt.v1` | Binds an artifact to its inputs, workflow, code, environment, provider, optional model/seed, and validation output. |
+| `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; resolution and waiver are explicit lifecycle transitions. |
+| `ResearchEventV1` | `a3s.code.science-event.v1` | Digest-only project/run event projection for Desktop and other hosts. |
+
+All IDs and text are bounded. Digests use the existing Code SHA-256 format.
+Maps and digest lists are canonicalized before identity calculation, and every
+value uses `deny_unknown_fields` so an older host cannot silently accept a
+newer shape.
+
+## Lifecycle and integrity
+
+Research runs progress through `planned -> admitted -> running`, may pass
+through `checkpointed`, and then terminate as `completed`, `failed`, or
+`cancelled`. Terminal runs cannot resume. Every transition validates the
+previous digest before recalculating the new identity.
+
+Review findings start `open`; only `resolve` or `waive` with a content digest
+can close them. A finding or run whose fields were changed without updating its
+digest is rejected before any transition can rebind the tampered value.
+
+Evidence facts and events carry sequence numbers, but contiguous ordering and
+durability remain host responsibilities. The payloads intentionally contain
+digests and bounded metadata rather than prompts, source text, credentials, or
+raw model/tool output.
+
+## Host integration sequence
+
+1. Admit a Code `ResearchRunV1` with the exact capability binding and snapshot
+   digests selected by the host.
+2. Emit `ResearchEventV1` and append `ResearchEvidenceFactV1` values as the
+   run observes sources, claims, measurements, derivations, and artifacts.
+3. Materialize each output as a content-addressed artifact and publish a
+   `ResearchProvenanceReceiptV1`.
+4. Run a host-selected evaluator through the generic Code evaluation
+   substrate, then project its bounded observations into
+   `ResearchReviewFindingV1` values.
+5. Let the host apply its rubric, human approval, retention, and publication
+   policy; Code only validates the supplied identities and lifecycle.
+
+Focused contract tests live beside the implementations in
+`core/src/research/`. Run them with:
+
+```bash
+CARGO_TARGET_DIR=/tmp/a3s-code-target \
+  cargo test --locked --no-default-features -p a3s-code-core research:: --lib
+```


### PR DESCRIPTION
## Summary
- add native, versioned research run, evidence, provenance, review, and event contracts
- bind all identities to bounded canonical SHA-256 digests and exact Code capability bindings
- enforce fail-closed lifecycle transitions and document host/Use/Desktop ownership boundaries

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo test --locked --no-default-features -p a3s-code-core research:: --lib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo test --locked --no-default-features -p a3s-code-core --lib`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-default-features -p a3s-code-core --no-deps`
