### PR TITLE
fix(core): harden research contract transitions

### DIFF
--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -159,6 +159,12 @@ impl ResearchReviewFindingV1 {
         resolution_digest: impl Into<String>,
     ) -> Result<(), ResearchContractError> {
         self.validate()?;
+        if !matches!(self.status, ResearchReviewStatusV1::Open) {
+            return Err(ResearchContractError::InvalidTransition {
+                from: self.status.as_str(),
+                to: ResearchReviewStatusV1::Resolved.as_str(),
+            });
+        }
         let resolution_digest = resolution_digest.into();
         validate_digest_field("resolutionDigest", &resolution_digest)?;
         self.status = ResearchReviewStatusV1::Resolved;
@@ -172,6 +178,12 @@ impl ResearchReviewFindingV1 {
         resolution_digest: impl Into<String>,
     ) -> Result<(), ResearchContractError> {
         self.validate()?;
+        if !matches!(self.status, ResearchReviewStatusV1::Open) {
+            return Err(ResearchContractError::InvalidTransition {
+                from: self.status.as_str(),
+                to: ResearchReviewStatusV1::Waived.as_str(),
+            });
+        }
         let resolution_digest = resolution_digest.into();
         validate_digest_field("resolutionDigest", &resolution_digest)?;
         self.status = ResearchReviewStatusV1::Waived;
@@ -338,6 +350,39 @@ mod tests {
         assert_eq!(
             finding.resolve(digest('c')),
             Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+
+    #[test]
+    fn a_closed_finding_cannot_be_resolved_or_waived_again() {
+        let mut finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Reproducibility,
+            ResearchReviewSeverityV1::Blocker,
+            "The environment receipt is missing.",
+            None,
+            vec![digest('b')],
+            "reproducibility-reviewer",
+            1,
+        )
+        .unwrap();
+        finding.resolve(digest('c')).unwrap();
+        assert_eq!(
+            finding.resolve(digest('d')),
+            Err(ResearchContractError::InvalidTransition {
+                from: "resolved",
+                to: "resolved"
+            })
+        );
+        assert_eq!(
+            finding.waive(digest('e')),
+            Err(ResearchContractError::InvalidTransition {
+                from: "resolved",
+                to: "waived"
+            })
         );
     }
 }

--- a/core/src/research/run.rs
+++ b/core/src/research/run.rs
@@ -1,6 +1,4 @@
-use super::{
-    digest, validate_digest_field, validate_id, ResearchContractError, RESEARCH_MAX_TEXT_BYTES,
-};
+use super::{digest, validate_digest_field, validate_id, ResearchContractError};
 use crate::capability::RunCapabilityBindingV1;
 use serde::{Deserialize, Serialize};
 
@@ -167,9 +165,7 @@ impl ResearchRunV1 {
             .validate()
             .map_err(|_| ResearchContractError::InvalidField("capabilityBinding"))?;
         validate_id("providerId", &self.provider_id)?;
-        if self.model_id.is_empty() || self.model_id.len() > RESEARCH_MAX_TEXT_BYTES {
-            return Err(ResearchContractError::InvalidField("modelId"));
-        }
+        validate_id("modelId", &self.model_id)?;
         if matches!(
             self.reproducibility,
             ResearchReproducibilityV1::Deterministic
@@ -337,6 +333,25 @@ mod tests {
         assert_eq!(
             run.transition_to(ResearchRunStatusV1::Admitted),
             Err(ResearchContractError::DigestMismatch("runDigest"))
+        );
+    }
+
+    #[test]
+    fn model_id_uses_the_same_single_line_identity_bound_as_provider_id() {
+        assert_eq!(
+            ResearchRunV1::new(
+                "run-1",
+                "project-1",
+                1,
+                digest('a'),
+                digest('b'),
+                binding(),
+                "local",
+                "model\nwith-newline",
+                ResearchReproducibilityV1::Exploratory,
+                None,
+            ),
+            Err(ResearchContractError::InvalidField("modelId"))
         );
     }
 }


### PR DESCRIPTION
## Summary
- reject multiline model IDs using the same identity validation as provider IDs
- prevent closed research review findings from being resolved or waived again
- add regression coverage for both fail-closed invariants

## Validation
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo test --locked --no-default-features -p a3s-code-core research:: --lib -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo test --locked --no-default-features -p a3s-code-core --lib`
- `CARGO_TARGET_DIR=/tmp/a3s-code-research-target cargo clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings`
