### PR TITLE
refactor(core): share execution coordination boundary

### DIFF
--- a/core/src/agent_api.rs
+++ b/core/src/agent_api.rs
@@ -49,6 +49,7 @@ pub(crate) use conversation_runtime::{
 };
 mod direct_tool_facade;
 mod direct_tools;
+mod execution_coordinator;
 mod governance_facade;
 mod hook_control;
 mod project_instructions;

--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -1,0 +1,105 @@
+//! Shared run identity and invocation assembly for Agent execution.
+//!
+//! This is the first incremental boundary of the execution coordinator. It
+//! owns the pieces that must be identical for blocking and streaming runs:
+//! attaching the run control inbox, binding checkpoint identity, and deriving
+//! an invocation from one run-owned cancellation token. Event collection and
+//! terminal cleanup remain in the mode-specific lifecycle adapters until their
+//! state machines can be migrated safely.
+
+use super::{run_lifecycle::RunControlState, AgentSession};
+use crate::agent::{AgentEvent, AgentLoop, InvocationContext};
+use crate::run_control::RunControlInbox;
+use crate::tools::AgentEventBarrier;
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+/// Shared identity boundary for one admitted Agent Run.
+///
+/// A coordinator is created after the Run has been reserved and before any
+/// provider call is started. Both blocking and streaming execution paths use
+/// this value, so run control, checkpoint identity, and cancellation cannot
+/// silently diverge between the two modes.
+pub(super) struct ExecutionCoordinator {
+    session_id: String,
+    run_id: String,
+    cancellation: CancellationToken,
+    run_control: Arc<RunControlInbox>,
+}
+
+impl ExecutionCoordinator {
+    /// Attach one run's control and checkpoint identity to its pinned loop.
+    pub(super) async fn prepare(
+        session: &AgentSession,
+        run_id: impl Into<String>,
+        agent_loop: &mut AgentLoop,
+        cancellation: CancellationToken,
+    ) -> Self {
+        let run_id = run_id.into();
+        let run_control = RunControlInbox::new_with_hook_executor(
+            session.session_id.clone(),
+            run_id.clone(),
+            cancellation.clone(),
+            agent_loop.hook_executor(),
+        );
+        RunControlState::from_session(session)
+            .attach_run_control(&run_id, run_control.clone())
+            .await;
+        agent_loop.set_checkpoint_run(&run_id);
+
+        Self {
+            session_id: session.session_id.clone(),
+            run_id,
+            cancellation,
+            run_control,
+        }
+    }
+
+    /// Build the invocation context used by blocking and streaming workers.
+    pub(super) fn invocation(
+        &self,
+        agent_loop: &AgentLoop,
+        runtime_tx: Option<mpsc::Sender<AgentEvent>>,
+        agent_event_tx: broadcast::Sender<AgentEvent>,
+        agent_event_barrier: AgentEventBarrier,
+    ) -> InvocationContext {
+        agent_loop
+            .invocation_context(
+                self.run_id.clone(),
+                Some(&self.session_id),
+                runtime_tx,
+                self.cancellation.clone(),
+            )
+            .with_agent_events(agent_event_tx, agent_event_barrier)
+            .with_run_control(self.run_control.clone())
+    }
+
+    #[cfg(test)]
+    fn identity(&self) -> (&str, &str) {
+        (&self.session_id, &self.run_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coordinator_stores_one_session_and_run_identity() {
+        let cancellation = CancellationToken::new();
+        let run_control = RunControlInbox::new(
+            "session-1".to_owned(),
+            "run-1".to_owned(),
+            cancellation.clone(),
+        );
+        let coordinator = ExecutionCoordinator {
+            session_id: "session-1".to_owned(),
+            run_id: "run-1".to_owned(),
+            cancellation,
+            run_control,
+        };
+
+        assert_eq!(coordinator.identity(), ("session-1", "run-1"));
+    }
+}

--- a/core/src/agent_api/runtime.rs
+++ b/core/src/agent_api/runtime.rs
@@ -1,5 +1,6 @@
 use super::{
     agent_loop_runtime::build_pinned_agent_loop,
+    execution_coordinator::ExecutionCoordinator,
     run_lifecycle::{
         BlockingRunLifecycle, RunControlState, StreamRunLifecycle, StreamRunWorkerState,
     },
@@ -103,16 +104,13 @@ impl BlockingRunContext {
             }
         };
         let run_id = run.id().to_string();
-        let run_control = crate::run_control::RunControlInbox::new_with_hook_executor(
-            session.session_id.clone(),
+        let coordinator = ExecutionCoordinator::prepare(
+            session,
             run_id.clone(),
+            &mut agent_loop,
             cancel_token.clone(),
-            agent_loop.hook_executor(),
-        );
-        RunControlState::from_session(session)
-            .attach_run_control(&run_id, run_control.clone())
-            .await;
-        agent_loop.set_checkpoint_run(&run_id);
+        )
+        .await;
         let (checkpoint_sink, checkpoints) = runtime_checkpoint_channel(session);
         if let Some(checkpoint_sink) = checkpoint_sink {
             agent_loop = agent_loop.with_checkpoint_sink(checkpoint_sink);
@@ -121,15 +119,12 @@ impl BlockingRunContext {
         let lifecycle = BlockingRunLifecycle::from_session(session, &run_id, persistence);
         lifecycle.set_cancel_token(cancel_token.clone()).await;
         let (agent_event_tx, agent_event_barrier, agent_events) = run_agent_event_channel(2048);
-        let invocation = agent_loop
-            .invocation_context(
-                run_id.clone(),
-                Some(&session.session_id),
-                Some(runtime_tx),
-                cancel_token,
-            )
-            .with_agent_events(agent_event_tx, agent_event_barrier)
-            .with_run_control(run_control);
+        let invocation = coordinator.invocation(
+            &agent_loop,
+            Some(runtime_tx),
+            agent_event_tx,
+            agent_event_barrier,
+        );
         let runtime_collector = RuntimeEventSink::from_session(session, &run_id).spawn_collector(
             runtime_rx,
             Some(agent_events),
@@ -328,18 +323,15 @@ impl StreamRunContext {
         capability_run: crate::capability::SessionCapabilityRun,
         cancel_token: tokio_util::sync::CancellationToken,
     ) -> Self {
-        let run_control = crate::run_control::RunControlInbox::new_with_hook_executor(
-            session.session_id.clone(),
+        let coordinator = ExecutionCoordinator::prepare(
+            session,
             run_id.clone(),
+            &mut agent_loop,
             cancel_token.clone(),
-            agent_loop.hook_executor(),
-        );
-        RunControlState::from_session(session)
-            .attach_run_control(&run_id, run_control.clone())
-            .await;
+        )
+        .await;
         let (tx, rx) = mpsc::channel(256);
         let (runtime_tx, runtime_rx) = mpsc::channel(256);
-        agent_loop.set_checkpoint_run(&run_id);
         let (checkpoint_sink, checkpoints) = runtime_checkpoint_channel(session);
         if let Some(checkpoint_sink) = checkpoint_sink {
             agent_loop = agent_loop.with_checkpoint_sink(checkpoint_sink);
@@ -347,15 +339,12 @@ impl StreamRunContext {
         let lifecycle = StreamRunLifecycle::from_session(session, &run_id, persistence);
         lifecycle.set_cancel_token(cancel_token.clone()).await;
         let (agent_event_tx, agent_event_barrier, agent_events) = run_agent_event_channel(2048);
-        let invocation = agent_loop
-            .invocation_context(
-                run_id.clone(),
-                Some(&session.session_id),
-                Some(runtime_tx),
-                cancel_token,
-            )
-            .with_agent_events(agent_event_tx, agent_event_barrier)
-            .with_run_control(run_control);
+        let invocation = coordinator.invocation(
+            &agent_loop,
+            Some(runtime_tx),
+            agent_event_tx,
+            agent_event_barrier,
+        );
         let worker_state = lifecycle.worker_state();
         let forwarder = RuntimeEventSink::from_session(session, &run_id).spawn_forwarder(
             runtime_rx,


### PR DESCRIPTION
## Summary
- add the first internal `ExecutionCoordinator` boundary
- share Run control, checkpoint identity, and cancellation binding across blocking and streaming execution
- keep event forwarding and terminal cleanup in existing mode-specific lifecycle adapters

## Architecture
This is an incremental KRN-2/P1.2 slice. The coordinator is an identity and invocation assembly boundary, not a second Run store or lifecycle authority. Public facades and existing persistence/event envelopes remain unchanged.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p a3s-code-core --lib agent_api::execution_coordinator::tests`
- `cargo test --locked -p a3s-code-core --lib test_send_records_run_snapshot_and_events`
- `cargo test --locked -p a3s-code-core --lib test_stream_updates_history_and_auto_saves`
- `cargo test --locked -p a3s-code-core --lib test_stream_cancel_records_interrupted_history_and_auto_saves`
- full Core library test run completed locally (3114 tests; output truncated by runner)
