### PR TITLE
refactor(core): centralize terminal run transitions

### DIFF
--- a/core/src/agent_api/conversation_runtime.rs
+++ b/core/src/agent_api/conversation_runtime.rs
@@ -5,9 +5,10 @@
 //! Lower-level runtime modules own run lifecycle and event forwarding.
 
 use super::{
-    agent_loop_runtime::build_pinned_agent_loop, command_runtime, run_admission,
-    run_lifecycle::RunControlState, runtime::BlockingRunContext, runtime::ConversationInput,
-    runtime::StreamRunContext, AgentRunSpawn, AgentSession,
+    agent_loop_runtime::build_pinned_agent_loop, command_runtime,
+    execution_coordinator::ExecutionCoordinator, run_admission, run_lifecycle::RunControlState,
+    runtime::BlockingRunContext, runtime::ConversationInput, runtime::StreamRunContext,
+    AgentRunSpawn, AgentSession,
 };
 use crate::agent::{AgentEvent, AgentLoop, AgentResult};
 use crate::error::{CodeError, Result};
@@ -38,53 +39,13 @@ pub(crate) struct PreparedExactRecovery {
     lease: run_admission::RunAdmissionLease,
 }
 
-fn bail_if_closed(session: &AgentSession) -> Result<()> {
-    if session.is_closed() {
-        return Err(CodeError::SessionClosed {
-            session_id: session.session_id.clone(),
-        });
-    }
-    Ok(())
-}
-
-async fn admit(
-    session: &AgentSession,
-    operation: &'static str,
-) -> Result<run_admission::RunAdmissionLease> {
-    bail_if_closed(session)?;
-    let lease = session.run_admission.try_acquire(&session.session_id)?;
-    let label = format!("{}:{operation}", session.session_id);
-    let task_lease = session
-        .task_scheduler
-        .acquire(session.task_priority, label, &session.session_cancel)
-        .await
-        .map_err(|error| match error {
-            crate::task_scheduler::TaskSchedulerError::Cancelled if session.is_closed() => {
-                CodeError::SessionClosed {
-                    session_id: session.session_id.clone(),
-                }
-            }
-            crate::task_scheduler::TaskSchedulerError::Cancelled => {
-                CodeError::TaskAdmissionCancelled {
-                    session_id: session.session_id.clone(),
-                }
-            }
-            crate::task_scheduler::TaskSchedulerError::Closed => CodeError::TaskSchedulerClosed,
-            crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
-                CodeError::Config(message)
-            }
-        })?;
-    bail_if_closed(session)?;
-    Ok(lease.attach_task_lease(task_lease))
-}
-
 pub(super) async fn send(
     session: &AgentSession,
     prompt: &str,
     history: Option<&[Message]>,
 ) -> Result<AgentResult> {
     // Admission must precede command dispatch and internal-history reads.
-    let _lease = admit(session, "send").await?;
+    let _lease = ExecutionCoordinator::admit(session, "send").await?;
 
     if let Some(result) = command_runtime::dispatch_blocking(session, prompt, history).await? {
         return Ok(result);
@@ -105,7 +66,7 @@ pub(super) async fn send_with_attachments(
     history: Option<&[Message]>,
 ) -> Result<AgentResult> {
     // Admission must precede the attachment message's internal-history clone.
-    let _lease = admit(session, "send-with-attachments").await?;
+    let _lease = ExecutionCoordinator::admit(session, "send-with-attachments").await?;
 
     // Build one user message containing text and images, then execute from the
     // resulting message list so the loop does not append a duplicate prompt.
@@ -122,14 +83,14 @@ pub(super) async fn stream_with_attachments(
     attachments: &[Attachment],
     history: Option<&[Message]>,
 ) -> Result<(mpsc::Receiver<AgentEvent>, JoinHandle<()>)> {
-    let lease = admit(session, "stream-with-attachments").await?;
+    let lease = ExecutionCoordinator::admit(session, "stream-with-attachments").await?;
 
     let input = ConversationInput::with_attachments(session, history, prompt, attachments);
     let stream_run = StreamRunContext::start(session, prompt, input.persistence).await?;
     let (rx, handle, worker_aborts) = stream_run.spawn_from_messages(input.messages);
     Ok((
         rx,
-        run_admission::guard_stream_handle(handle, worker_aborts, lease),
+        ExecutionCoordinator::supervise_stream(handle, worker_aborts, lease),
     ))
 }
 
@@ -140,13 +101,13 @@ pub(super) async fn stream(
 ) -> Result<(mpsc::Receiver<AgentEvent>, JoinHandle<()>)> {
     // Slash commands share admission because they read and may mutate the same
     // session state as model-backed operations.
-    let lease = admit(session, "stream").await?;
+    let lease = ExecutionCoordinator::admit(session, "stream").await?;
 
     if let Some((rx, handle)) = command_runtime::dispatch_streaming(session, prompt).await? {
         let worker_abort = handle.abort_handle();
         return Ok((
             rx,
-            run_admission::guard_stream_handle(handle, vec![worker_abort], lease),
+            ExecutionCoordinator::supervise_stream(handle, vec![worker_abort], lease),
         ));
     }
 
@@ -156,7 +117,7 @@ pub(super) async fn stream(
         stream_run.spawn_with_prompt(input.messages, prompt.to_string());
     Ok((
         rx,
-        run_admission::guard_stream_handle(handle, worker_aborts, lease),
+        ExecutionCoordinator::supervise_stream(handle, worker_aborts, lease),
     ))
 }
 
@@ -169,7 +130,7 @@ pub(super) async fn spawn_run_with_id(
     if let Some(replay) = exact_run_replay(session, run_id, prompt).await? {
         return Ok(replay);
     }
-    let lease = admit(session, "spawn-run").await?;
+    let lease = ExecutionCoordinator::admit(session, "spawn-run").await?;
     let input = ConversationInput::from_history(session, None);
     let run_control = RunControlState::from_session(session);
     let reservation = run_control.reserve_run_with_id(run_id, prompt).await?;
@@ -193,7 +154,7 @@ pub(super) async fn spawn_run_with_id(
     })?;
     let (events, worker, worker_aborts) =
         stream_run.spawn_with_prompt(input.messages, prompt.to_string());
-    let worker = run_admission::guard_stream_handle(worker, worker_aborts, lease);
+    let worker = ExecutionCoordinator::supervise_stream(worker, worker_aborts, lease);
     Ok(AgentRunSpawn::Started {
         snapshot,
         worker: drain_detached_events(events, worker),
@@ -211,7 +172,7 @@ pub(super) async fn spawn_recovery_with_run_id(
         return Ok(replay);
     }
 
-    let lease = admit(session, "spawn-recovery").await?;
+    let lease = ExecutionCoordinator::admit(session, "spawn-recovery").await?;
     let checkpoint = load_resume_checkpoint(session, checkpoint_run_id).await?;
     let cancel_token = session.session_cancel.child_token();
     let (agent_loop, capability_run) =
@@ -264,7 +225,7 @@ pub(super) async fn spawn_recovery_with_run_id(
     })?;
     let (events, worker, worker_aborts) =
         stream_run.spawn_from_messages_seeded(checkpoint.messages, Some(seed));
-    let worker = run_admission::guard_stream_handle(worker, worker_aborts, lease);
+    let worker = ExecutionCoordinator::supervise_stream(worker, worker_aborts, lease);
     Ok(AgentRunSpawn::Started {
         snapshot,
         worker: drain_detached_events(events, worker),
@@ -322,7 +283,7 @@ async fn prepare_exact_recovery(
         return Ok(ExactRecoveryPreparation::Replayed(replay));
     }
 
-    let lease = admit(session, "prepare-exact-recovery").await?;
+    let lease = ExecutionCoordinator::admit(session, "prepare-exact-recovery").await?;
     let checkpoint = match supplied_checkpoint {
         Some(checkpoint) => checkpoint,
         None => load_resume_checkpoint(session, &evidence.source_run_id).await?,
@@ -425,7 +386,7 @@ pub(super) async fn spawn_prepared_recovery(
     })?;
     let (events, worker, worker_aborts) =
         stream_run.spawn_from_messages_seeded(checkpoint.messages, Some(seed));
-    let worker = run_admission::guard_stream_handle(worker, worker_aborts, lease);
+    let worker = ExecutionCoordinator::supervise_stream(worker, worker_aborts, lease);
     Ok(AgentRunSpawn::Started {
         snapshot,
         worker: drain_detached_events(events, worker),
@@ -446,7 +407,7 @@ pub(super) async fn resume_run(
     session: &AgentSession,
     checkpoint_run_id: &str,
 ) -> Result<crate::agent::AgentResult> {
-    let _lease = admit(session, "resume-run").await?;
+    let _lease = ExecutionCoordinator::admit(session, "resume-run").await?;
     let checkpoint = load_resume_checkpoint(session, checkpoint_run_id).await?;
 
     let persistence =

--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -7,12 +7,18 @@
 //! terminal cleanup remain in the mode-specific lifecycle adapters until their
 //! state machines can be migrated safely.
 
-use super::{run_lifecycle::RunControlState, AgentSession};
+use super::{
+    run_admission::{self, RunAdmissionLease},
+    run_lifecycle::RunControlState,
+    AgentSession,
+};
 use crate::agent::{AgentEvent, AgentLoop, InvocationContext};
+use crate::error::{CodeError, Result};
 use crate::run_control::RunControlInbox;
 use crate::tools::AgentEventBarrier;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
+use tokio::task::{AbortHandle, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 /// Shared identity boundary for one admitted Agent Run.
@@ -29,6 +35,61 @@ pub(super) struct ExecutionCoordinator {
 }
 
 impl ExecutionCoordinator {
+    /// Admit one session operation before it can inspect or mutate run state.
+    ///
+    /// Admission is deliberately part of the coordinator boundary so every
+    /// public execution entrypoint uses the same close check, task-scheduler
+    /// lease, and single-flight semantics.
+    pub(super) async fn admit(
+        session: &AgentSession,
+        operation: &'static str,
+    ) -> Result<RunAdmissionLease> {
+        if session.is_closed() {
+            return Err(CodeError::SessionClosed {
+                session_id: session.session_id.clone(),
+            });
+        }
+        let lease = session.run_admission.try_acquire(&session.session_id)?;
+        let label = format!("{}:{operation}", session.session_id);
+        let task_lease = session
+            .task_scheduler
+            .acquire(session.task_priority, label, &session.session_cancel)
+            .await
+            .map_err(|error| match error {
+                crate::task_scheduler::TaskSchedulerError::Cancelled if session.is_closed() => {
+                    CodeError::SessionClosed {
+                        session_id: session.session_id.clone(),
+                    }
+                }
+                crate::task_scheduler::TaskSchedulerError::Cancelled => {
+                    CodeError::TaskAdmissionCancelled {
+                        session_id: session.session_id.clone(),
+                    }
+                }
+                crate::task_scheduler::TaskSchedulerError::Closed => CodeError::TaskSchedulerClosed,
+                crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
+                    CodeError::Config(message)
+                }
+            })?;
+        if session.is_closed() {
+            return Err(CodeError::SessionClosed {
+                session_id: session.session_id.clone(),
+            });
+        }
+        Ok(lease.attach_task_lease(task_lease))
+    }
+
+    /// Keep a stream's admission lease until its worker and event forwarder
+    /// have both settled. The public stream handle may be dropped without
+    /// accidentally admitting a second operation while detached work remains.
+    pub(super) fn supervise_stream(
+        handle: JoinHandle<()>,
+        worker_aborts: Vec<AbortHandle>,
+        lease: RunAdmissionLease,
+    ) -> JoinHandle<()> {
+        run_admission::guard_stream_handle(handle, worker_aborts, lease)
+    }
+
     /// Attach one run's control and checkpoint identity to its pinned loop.
     pub(super) async fn prepare(
         session: &AgentSession,

--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -21,17 +21,31 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::task::{AbortHandle, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
+/// Terminal state selected exactly once for an admitted Run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum RunTerminalTransition {
+    /// Agent execution returned a result without cancellation.
+    Completed,
+    /// Cancellation won the race with a result or an execution error.
+    Cancelled,
+    /// Execution failed and the Run can retain a bounded error message.
+    Failed(String),
+}
+
 /// Shared identity boundary for one admitted Agent Run.
 ///
 /// A coordinator is created after the Run has been reserved and before any
 /// provider call is started. Both blocking and streaming execution paths use
 /// this value, so run control, checkpoint identity, and cancellation cannot
 /// silently diverge between the two modes.
+#[derive(Clone)]
 pub(super) struct ExecutionCoordinator {
     session_id: String,
     run_id: String,
     cancellation: CancellationToken,
     run_control: Arc<RunControlInbox>,
+    run_store: Arc<crate::run::InMemoryRunStore>,
+    terminal_settled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl ExecutionCoordinator {
@@ -114,6 +128,56 @@ impl ExecutionCoordinator {
             run_id,
             cancellation,
             run_control,
+            run_store: Arc::clone(&session.run_store),
+            terminal_settled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    pub(super) fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Select the terminal state for one execution result.
+    ///
+    /// Cancellation is sampled from the coordinator-owned token before any
+    /// lifecycle adapter clears the Session's active-token slot. This keeps
+    /// blocking and streaming paths identical when cancellation races with a
+    /// provider result or error.
+    pub(super) fn terminal_for(
+        &self,
+        succeeded: bool,
+        error: Option<String>,
+    ) -> RunTerminalTransition {
+        if self.cancellation.is_cancelled() {
+            RunTerminalTransition::Cancelled
+        } else if succeeded {
+            RunTerminalTransition::Completed
+        } else {
+            RunTerminalTransition::Failed(error.unwrap_or_else(|| "execution failed".to_owned()))
+        }
+    }
+
+    /// Apply the one terminal RunStore transition. Successful Runs are already
+    /// finalized by the normal `End` event path, so `Completed` intentionally
+    /// performs no second write. The atomic guard makes accidental duplicate
+    /// cleanup calls harmless and prevents a late failure from rewriting a
+    /// terminal cancellation.
+    pub(super) async fn settle_terminal(&self, transition: RunTerminalTransition) {
+        if self
+            .terminal_settled
+            .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            tracing::debug!(run_id = %self.run_id, "Ignored duplicate Run terminal transition");
+            return;
+        }
+        match transition {
+            RunTerminalTransition::Completed => {}
+            RunTerminalTransition::Cancelled => {
+                let _ = self.run_store.mark_cancelled(&self.run_id).await;
+            }
+            RunTerminalTransition::Failed(error) => {
+                let _ = self.run_store.mark_failed(&self.run_id, error).await;
+            }
         }
     }
 
@@ -159,8 +223,75 @@ mod tests {
             run_id: "run-1".to_owned(),
             cancellation,
             run_control,
+            run_store: Arc::new(crate::run::InMemoryRunStore::new()),
+            terminal_settled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         assert_eq!(coordinator.identity(), ("session-1", "run-1"));
+    }
+
+    #[test]
+    fn terminal_transition_is_deterministic_and_cancellation_wins() {
+        let cancellation = CancellationToken::new();
+        let run_control = RunControlInbox::new(
+            "session-1".to_owned(),
+            "run-1".to_owned(),
+            cancellation.clone(),
+        );
+        let coordinator = ExecutionCoordinator {
+            session_id: "session-1".to_owned(),
+            run_id: "run-1".to_owned(),
+            cancellation: cancellation.clone(),
+            run_control,
+            run_store: Arc::new(crate::run::InMemoryRunStore::new()),
+            terminal_settled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+
+        assert_eq!(
+            coordinator.terminal_for(true, None),
+            RunTerminalTransition::Completed
+        );
+        assert_eq!(
+            coordinator.terminal_for(false, Some("boom".to_owned())),
+            RunTerminalTransition::Failed("boom".to_owned())
+        );
+        cancellation.cancel();
+        assert_eq!(
+            coordinator.terminal_for(true, None),
+            RunTerminalTransition::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_transition_updates_the_run_store_once() {
+        let cancellation = CancellationToken::new();
+        let run_control = RunControlInbox::new(
+            "session-1".to_owned(),
+            "run-1".to_owned(),
+            cancellation.clone(),
+        );
+        let run_store = Arc::new(crate::run::InMemoryRunStore::new());
+        run_store
+            .create_run_with_id("run-1".to_owned(), "session-1", "prompt")
+            .await;
+        let coordinator = ExecutionCoordinator {
+            session_id: "session-1".to_owned(),
+            run_id: "run-1".to_owned(),
+            cancellation,
+            run_control,
+            run_store: Arc::clone(&run_store),
+            terminal_settled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+
+        coordinator
+            .settle_terminal(RunTerminalTransition::Failed("boom".to_owned()))
+            .await;
+        coordinator
+            .settle_terminal(RunTerminalTransition::Cancelled)
+            .await;
+
+        let snapshot = run_store.snapshot("run-1").await.unwrap();
+        assert_eq!(snapshot.status, crate::run::RunStatus::Failed);
+        assert_eq!(snapshot.error.as_deref(), Some("boom"));
     }
 }

--- a/core/src/agent_api/run_lifecycle.rs
+++ b/core/src/agent_api/run_lifecycle.rs
@@ -5,7 +5,8 @@
 //! knowing how run handles, current-run state, persistence, and cleanup interact.
 
 use super::{
-    runtime_events::RunCleanupState, session_persistence::SessionPersistenceContext, AgentSession,
+    execution_coordinator::ExecutionCoordinator, runtime_events::RunCleanupState,
+    session_persistence::SessionPersistenceContext, AgentSession,
 };
 use crate::agent::AgentResult;
 use crate::error::{CodeError, Result};
@@ -14,14 +15,9 @@ use tokio::task::{AbortHandle, JoinHandle};
 
 #[derive(Clone)]
 pub(super) struct StreamRunWorkerState {
-    run_store: Arc<crate::run::InMemoryRunStore>,
-    run_id: String,
+    coordinator: ExecutionCoordinator,
     persistence: Option<SessionPersistenceContext>,
     should_auto_save: Arc<std::sync::atomic::AtomicBool>,
-    /// Shared per-run cancel token slot (populated by lifecycle's
-    /// `set_cancel_token`). Used to classify a failed run as `Cancelled`
-    /// when the token was fired (e.g., by `session_cancel.cancel()`).
-    cancel_token: Arc<tokio::sync::Mutex<Option<tokio_util::sync::CancellationToken>>>,
 }
 
 impl StreamRunWorkerState {
@@ -29,36 +25,18 @@ impl StreamRunWorkerState {
     where
         E: std::fmt::Display,
     {
-        let cancelled = self
-            .cancel_token
-            .lock()
-            .await
-            .as_ref()
-            .map(|t| t.is_cancelled())
-            .unwrap_or(false);
-        match result {
-            Ok(result) => {
-                if let Some(persistence) = &self.persistence {
-                    persistence.record_result(&result);
-                    self.should_auto_save
-                        .store(true, std::sync::atomic::Ordering::Release);
-                }
-                if cancelled {
-                    let _ = self.run_store.mark_cancelled(&self.run_id).await;
-                }
-            }
-            Err(error) => {
-                if cancelled {
-                    let _ = self.run_store.mark_cancelled(&self.run_id).await;
-                } else {
-                    let error_message = error.to_string();
-                    let _ = self
-                        .run_store
-                        .mark_failed(&self.run_id, error_message)
-                        .await;
-                }
+        let terminal = self.coordinator.terminal_for(
+            result.is_ok(),
+            result.as_ref().err().map(ToString::to_string),
+        );
+        if let Ok(result) = result {
+            if let Some(persistence) = &self.persistence {
+                persistence.record_result(&result);
+                self.should_auto_save
+                    .store(true, std::sync::atomic::Ordering::Release);
             }
         }
+        self.coordinator.settle_terminal(terminal).await;
     }
 }
 
@@ -335,7 +313,7 @@ impl RunControlState {
 }
 
 pub(super) struct BlockingRunLifecycle {
-    run_store: Arc<crate::run::InMemoryRunStore>,
+    coordinator: ExecutionCoordinator,
     persistence: Option<SessionPersistenceContext>,
     cleanup: RunCleanupState,
 }
@@ -343,13 +321,13 @@ pub(super) struct BlockingRunLifecycle {
 impl BlockingRunLifecycle {
     pub(super) fn from_session(
         session: &AgentSession,
-        run_id: &str,
+        coordinator: ExecutionCoordinator,
         persistence: Option<SessionPersistenceContext>,
     ) -> Self {
         Self {
-            run_store: Arc::clone(&session.run_store),
+            cleanup: RunCleanupState::from_session(session, coordinator.run_id()),
+            coordinator,
             persistence,
-            cleanup: RunCleanupState::from_session(session, run_id),
         }
     }
 
@@ -365,9 +343,10 @@ impl BlockingRunLifecycle {
     where
         E: std::fmt::Display + Into<CodeError>,
     {
-        // Sample the cancellation flag *before* clearing the token so we can
-        // distinguish cancellation-driven errors from genuine failures.
-        let cancelled = self.cleanup.was_cancelled().await;
+        let terminal = self.coordinator.terminal_for(
+            result.is_ok(),
+            result.as_ref().err().map(ToString::to_string),
+        );
         self.cleanup.clear_cancel_token().await;
         let _ = runtime_collector.await;
 
@@ -386,22 +365,12 @@ impl BlockingRunLifecycle {
                     persistence.record_result(&result);
                     persistence.auto_save_if_enabled().await;
                 }
-                if cancelled {
-                    let _ = self.run_store.mark_cancelled(self.cleanup.run_id()).await;
-                }
+                self.coordinator.settle_terminal(terminal).await;
                 self.cleanup.finish().await;
                 Ok(result)
             }
             Err(error) => {
-                if cancelled {
-                    let _ = self.run_store.mark_cancelled(self.cleanup.run_id()).await;
-                } else {
-                    let error_message = error.to_string();
-                    let _ = self
-                        .run_store
-                        .mark_failed(self.cleanup.run_id(), error_message)
-                        .await;
-                }
+                self.coordinator.settle_terminal(terminal).await;
                 self.cleanup.finish().await;
                 Err(error.into())
             }
@@ -410,7 +379,7 @@ impl BlockingRunLifecycle {
 }
 
 pub(super) struct StreamRunLifecycle {
-    run_store: Arc<crate::run::InMemoryRunStore>,
+    coordinator: ExecutionCoordinator,
     persistence: Option<SessionPersistenceContext>,
     should_auto_save: Arc<std::sync::atomic::AtomicBool>,
     cleanup: RunCleanupState,
@@ -419,14 +388,14 @@ pub(super) struct StreamRunLifecycle {
 impl StreamRunLifecycle {
     pub(super) fn from_session(
         session: &AgentSession,
-        run_id: &str,
+        coordinator: ExecutionCoordinator,
         persistence: Option<SessionPersistenceContext>,
     ) -> Self {
         Self {
-            run_store: Arc::clone(&session.run_store),
+            cleanup: RunCleanupState::from_session(session, coordinator.run_id()),
+            coordinator,
             persistence,
             should_auto_save: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            cleanup: RunCleanupState::from_session(session, run_id),
         }
     }
 
@@ -436,11 +405,9 @@ impl StreamRunLifecycle {
 
     pub(super) fn worker_state(&self) -> StreamRunWorkerState {
         StreamRunWorkerState {
-            run_store: Arc::clone(&self.run_store),
-            run_id: self.cleanup.run_id().to_string(),
+            coordinator: self.coordinator.clone(),
             persistence: self.persistence.clone(),
             should_auto_save: Arc::clone(&self.should_auto_save),
-            cancel_token: self.cleanup.cancel_token_slot(),
         }
     }
 

--- a/core/src/agent_api/runtime.rs
+++ b/core/src/agent_api/runtime.rs
@@ -116,7 +116,8 @@ impl BlockingRunContext {
             agent_loop = agent_loop.with_checkpoint_sink(checkpoint_sink);
         }
         let (runtime_tx, runtime_rx) = mpsc::channel(2048);
-        let lifecycle = BlockingRunLifecycle::from_session(session, &run_id, persistence);
+        let lifecycle =
+            BlockingRunLifecycle::from_session(session, coordinator.clone(), persistence);
         lifecycle.set_cancel_token(cancel_token.clone()).await;
         let (agent_event_tx, agent_event_barrier, agent_events) = run_agent_event_channel(2048);
         let invocation = coordinator.invocation(
@@ -336,7 +337,7 @@ impl StreamRunContext {
         if let Some(checkpoint_sink) = checkpoint_sink {
             agent_loop = agent_loop.with_checkpoint_sink(checkpoint_sink);
         }
-        let lifecycle = StreamRunLifecycle::from_session(session, &run_id, persistence);
+        let lifecycle = StreamRunLifecycle::from_session(session, coordinator.clone(), persistence);
         lifecycle.set_cancel_token(cancel_token.clone()).await;
         let (agent_event_tx, agent_event_barrier, agent_events) = run_agent_event_channel(2048);
         let invocation = coordinator.invocation(

--- a/core/src/agent_api/runtime_events.rs
+++ b/core/src/agent_api/runtime_events.rs
@@ -611,29 +611,8 @@ impl RunCleanupState {
         *self.cancel_token.lock().await = Some(token);
     }
 
-    /// Share the per-run cancel-token slot. Used by stream worker state to
-    /// observe cancellation when classifying a failed run.
-    pub(super) fn cancel_token_slot(
-        &self,
-    ) -> Arc<tokio::sync::Mutex<Option<tokio_util::sync::CancellationToken>>> {
-        Arc::clone(&self.cancel_token)
-    }
-
     pub(super) async fn clear_cancel_token(&self) {
         *self.cancel_token.lock().await = None;
-    }
-
-    /// Returns `true` when the per-run cancellation token (or any parent it
-    /// was derived from, such as the session-level token) has been fired.
-    /// Used by lifecycle `complete()` to classify a failed run as `Cancelled`
-    /// vs `Failed` when an `Err` comes back from the agent loop.
-    pub(super) async fn was_cancelled(&self) -> bool {
-        self.cancel_token
-            .lock()
-            .await
-            .as_ref()
-            .map(|t| t.is_cancelled())
-            .unwrap_or(false)
     }
 
     pub(super) async fn finish(&self) {

--- a/core/src/agent_api/session_save.rs
+++ b/core/src/agent_api/session_save.rs
@@ -4,14 +4,17 @@
 //! the public `save()` entrypoint thin without exposing snapshot construction to
 //! the facade.
 
-use super::{session_persistence::SessionPersistenceContext, AgentSession};
+use super::{
+    execution_coordinator::ExecutionCoordinator, session_persistence::SessionPersistenceContext,
+    AgentSession,
+};
 use crate::error::Result;
 
 pub(super) async fn save(session: &AgentSession) -> Result<()> {
     // A manual save must not sample history, usage, tasks, and artifacts from
     // different points in an active conversation. Auto-save runs inside the
     // admitted run lifecycle and calls `SessionPersistenceContext` directly.
-    let _lease = session.run_admission.try_acquire(&session.session_id)?;
+    let _lease = ExecutionCoordinator::admit(session, "save").await?;
     SessionPersistenceContext::from_session(session)
         .save()
         .await


### PR DESCRIPTION
## Summary
- introduce one coordinator-owned `RunTerminalTransition` for success, cancellation, and failure
- move RunStore terminal writes out of blocking/stream worker lifecycle implementations
- make terminal settlement idempotent and remove duplicate cancellation classification helpers

## Architecture
This is the terminal-lifecycle slice of KRN-2/P1.2. The coordinator owns Run identity, cancellation sampling, and the single terminal write; lifecycle adapters retain persistence snapshots, event draining, and cleanup ordering. Public APIs and event envelopes remain unchanged.

## Verification
- `cargo fmt --all -- --check`
- focused terminal, blocking, streaming, cancellation, and error tests
- full Core library suite: 3103 passed, 0 failed, 13 ignored (3116 total)
