### PR TITLE
refactor(core): share task admission adapter

### DIFF
--- a/core/src/agent_api/direct_tools.rs
+++ b/core/src/agent_api/direct_tools.rs
@@ -4,7 +4,10 @@
 //! control-plane calls. Keeping argument shaping and result projection here
 //! prevents the public session facade from duplicating tool-specific knowledge.
 
-use super::{agent_loop_runtime::build_agent_loop, AgentSession, ReadFileOptions, ToolCallResult};
+use super::{
+    agent_loop_runtime::build_agent_loop, execution_coordinator::ExecutionCoordinator,
+    AgentSession, ReadFileOptions, ToolCallResult,
+};
 use crate::agent::{AgentEvent, AgentLoop};
 use crate::error::Result;
 use crate::llm::ToolDefinition;
@@ -152,11 +155,11 @@ impl DirectToolRuntime {
     async fn call_invocation(&self, invocation: ToolInvocation) -> Result<ToolCallResult> {
         self.ensure_open()?;
         let cancel = self.session_cancel.child_token();
-        let _task_lease = acquire_task_admission(
+        let _task_lease = ExecutionCoordinator::acquire_optional_task(
             self.task_scheduler.as_deref(),
             self.task_priority,
+            format!("{}:tool:{}", self.session_id, invocation.name),
             &self.session_id,
-            &invocation.name,
             &cancel,
             &self.closed,
         )
@@ -183,47 +186,6 @@ impl DirectToolRuntime {
         }
         Ok(())
     }
-}
-
-async fn acquire_task_admission(
-    scheduler: Option<&crate::task_scheduler::TaskScheduler>,
-    priority: crate::task_scheduler::TaskPriority,
-    session_id: &str,
-    operation: &str,
-    cancellation: &tokio_util::sync::CancellationToken,
-    closed: &AtomicBool,
-) -> Result<Option<crate::task_scheduler::TaskLease>> {
-    let Some(scheduler) = scheduler else {
-        return Ok(None);
-    };
-    scheduler
-        .acquire(
-            priority,
-            format!("{session_id}:tool:{operation}"),
-            cancellation,
-        )
-        .await
-        .map(Some)
-        .map_err(|error| match error {
-            crate::task_scheduler::TaskSchedulerError::Cancelled
-                if closed.load(Ordering::Acquire) =>
-            {
-                crate::error::CodeError::SessionClosed {
-                    session_id: session_id.to_string(),
-                }
-            }
-            crate::task_scheduler::TaskSchedulerError::Cancelled => {
-                crate::error::CodeError::TaskAdmissionCancelled {
-                    session_id: session_id.to_string(),
-                }
-            }
-            crate::task_scheduler::TaskSchedulerError::Closed => {
-                crate::error::CodeError::TaskSchedulerClosed
-            }
-            crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
-                crate::error::CodeError::Config(message)
-            }
-        })
 }
 
 fn project_tool_result(result: crate::tools::ToolResult) -> ToolCallResult {

--- a/core/src/agent_api/direct_tools/event_stream.rs
+++ b/core/src/agent_api/direct_tools/event_stream.rs
@@ -116,11 +116,11 @@ impl DirectToolRuntime {
         let event_tx = Some(runtime_tx);
         let security_provider = self.security_provider;
         let handle = tokio::spawn(async move {
-            let _task_lease = acquire_task_admission(
+            let _task_lease = ExecutionCoordinator::acquire_optional_task(
                 task_scheduler.as_deref(),
                 task_priority,
+                format!("{session_id}:tool:{tool_name}"),
                 &session_id,
-                &tool_name,
                 &cancel,
                 &closed,
             )

--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -16,6 +16,7 @@ use crate::agent::{AgentEvent, AgentLoop, InvocationContext};
 use crate::error::{CodeError, Result};
 use crate::run_control::RunControlInbox;
 use crate::tools::AgentEventBarrier;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::{AbortHandle, JoinHandle};
@@ -49,6 +50,61 @@ pub(super) struct ExecutionCoordinator {
 }
 
 impl ExecutionCoordinator {
+    /// Acquire a task-scheduler lease using the coordinator's canonical error
+    /// mapping. Direct Tool calls use this primitive without taking the
+    /// transcript's single-flight Run lease.
+    pub(super) async fn acquire_task(
+        scheduler: &crate::task_scheduler::TaskScheduler,
+        priority: crate::task_scheduler::TaskPriority,
+        label: String,
+        session_id: &str,
+        cancellation: &CancellationToken,
+        closed: &AtomicBool,
+    ) -> Result<crate::task_scheduler::TaskLease> {
+        scheduler
+            .acquire(priority, label, cancellation)
+            .await
+            .map_err(|error| match error {
+                crate::task_scheduler::TaskSchedulerError::Cancelled
+                    if closed.load(Ordering::Acquire) =>
+                {
+                    CodeError::SessionClosed {
+                        session_id: session_id.to_owned(),
+                    }
+                }
+                crate::task_scheduler::TaskSchedulerError::Cancelled => {
+                    CodeError::TaskAdmissionCancelled {
+                        session_id: session_id.to_owned(),
+                    }
+                }
+                crate::task_scheduler::TaskSchedulerError::Closed => CodeError::TaskSchedulerClosed,
+                crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
+                    CodeError::Config(message)
+                }
+            })
+    }
+
+    /// Acquire an optional scheduler lease for control-plane operations that
+    /// may be constructed without a Session-owned scheduler (for example,
+    /// low-level direct-tool tests).
+    pub(super) async fn acquire_optional_task(
+        scheduler: Option<&crate::task_scheduler::TaskScheduler>,
+        priority: crate::task_scheduler::TaskPriority,
+        label: String,
+        session_id: &str,
+        cancellation: &CancellationToken,
+        closed: &AtomicBool,
+    ) -> Result<Option<crate::task_scheduler::TaskLease>> {
+        match scheduler {
+            Some(scheduler) => {
+                Self::acquire_task(scheduler, priority, label, session_id, cancellation, closed)
+                    .await
+                    .map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
     /// Admit one session operation before it can inspect or mutate run state.
     ///
     /// Admission is deliberately part of the coordinator boundary so every
@@ -65,26 +121,15 @@ impl ExecutionCoordinator {
         }
         let lease = session.run_admission.try_acquire(&session.session_id)?;
         let label = format!("{}:{operation}", session.session_id);
-        let task_lease = session
-            .task_scheduler
-            .acquire(session.task_priority, label, &session.session_cancel)
-            .await
-            .map_err(|error| match error {
-                crate::task_scheduler::TaskSchedulerError::Cancelled if session.is_closed() => {
-                    CodeError::SessionClosed {
-                        session_id: session.session_id.clone(),
-                    }
-                }
-                crate::task_scheduler::TaskSchedulerError::Cancelled => {
-                    CodeError::TaskAdmissionCancelled {
-                        session_id: session.session_id.clone(),
-                    }
-                }
-                crate::task_scheduler::TaskSchedulerError::Closed => CodeError::TaskSchedulerClosed,
-                crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
-                    CodeError::Config(message)
-                }
-            })?;
+        let task_lease = Self::acquire_task(
+            &session.task_scheduler,
+            session.task_priority,
+            label,
+            &session.session_id,
+            &session.session_cancel,
+            &session.closed,
+        )
+        .await?;
         if session.is_closed() {
             return Err(CodeError::SessionClosed {
                 session_id: session.session_id.clone(),


### PR DESCRIPTION
## Summary
- centralize TaskScheduler lease acquisition and error mapping in `ExecutionCoordinator`
- route synchronous and event-streaming direct-tool paths through the shared adapter
- preserve direct-tool's control-plane semantics without taking the transcript Run lease

## Architecture
This is an incremental KRN-2/P1.2 admission slice. `RunAdmission` remains the single-flight primitive for transcript-affecting operations; direct tools retain their independent task lease. No second store, scheduler, or event authority is introduced.

## Verification
- `cargo fmt --all -- --check`
- direct-tool tests: 16 passed
- coordinator and single-flight tests passed
- full Core library suite: 3103 passed, 0 failed, 13 ignored (3116 total)
