### PR TITLE
refactor(core): centralize terminal transition storage

### DIFF
--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::agent::{AgentEvent, AgentLoop, InvocationContext};
 use crate::error::{CodeError, Result};
+use crate::run::RunTerminalTransition;
 use crate::run_control::RunControlInbox;
 use crate::tools::AgentEventBarrier;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,17 +22,6 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::{AbortHandle, JoinHandle};
 use tokio_util::sync::CancellationToken;
-
-/// Terminal state selected exactly once for an admitted Run.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) enum RunTerminalTransition {
-    /// Agent execution returned a result without cancellation.
-    Completed,
-    /// Cancellation won the race with a result or an execution error.
-    Cancelled,
-    /// Execution failed and the Run can retain a bounded error message.
-    Failed(String),
-}
 
 /// Shared identity boundary for one admitted Agent Run.
 ///
@@ -215,15 +205,10 @@ impl ExecutionCoordinator {
             tracing::debug!(run_id = %self.run_id, "Ignored duplicate Run terminal transition");
             return;
         }
-        match transition {
-            RunTerminalTransition::Completed => {}
-            RunTerminalTransition::Cancelled => {
-                let _ = self.run_store.mark_cancelled(&self.run_id).await;
-            }
-            RunTerminalTransition::Failed(error) => {
-                let _ = self.run_store.mark_failed(&self.run_id, error).await;
-            }
-        }
+        let _ = self
+            .run_store
+            .settle_terminal(&self.run_id, transition)
+            .await;
     }
 
     /// Build the invocation context used by blocking and streaming workers.

--- a/core/src/agent_api/run_lifecycle.rs
+++ b/core/src/agent_api/run_lifecycle.rs
@@ -157,7 +157,10 @@ impl RunControlState {
         {
             let _ = self
                 .run_store
-                .mark_failed(&snapshot.id, error.to_string())
+                .settle_terminal(
+                    &snapshot.id,
+                    crate::run::RunTerminalTransition::Failed(error.to_string()),
+                )
                 .await;
             return Err(error);
         }
@@ -165,7 +168,10 @@ impl RunControlState {
             if let Err(error) = self.bind_cognitive_package(&snapshot.id, binding).await {
                 let _ = self
                     .run_store
-                    .mark_failed(&snapshot.id, error.to_string())
+                    .settle_terminal(
+                        &snapshot.id,
+                        crate::run::RunTerminalTransition::Failed(error.to_string()),
+                    )
                     .await;
                 return Err(error);
             }
@@ -247,7 +253,10 @@ impl RunControlState {
                 )
         );
         if cancelled {
-            let _ = self.run_store.mark_cancelled(run_id).await;
+            let _ = self
+                .run_store
+                .settle_terminal(run_id, crate::run::RunTerminalTransition::Cancelled)
+                .await;
             if let Some(executor) = &self.hook_executor {
                 executor
                     .record_run_cancelled(
@@ -258,7 +267,13 @@ impl RunControlState {
                     .await;
             }
         } else {
-            let _ = self.run_store.mark_failed(run_id, error.to_string()).await;
+            let _ = self
+                .run_store
+                .settle_terminal(
+                    run_id,
+                    crate::run::RunTerminalTransition::Failed(error.to_string()),
+                )
+                .await;
         }
 
         let mut current = self.current_run_id.lock().await;
@@ -272,7 +287,10 @@ impl RunControlState {
         if let Some(token) = token {
             token.cancel();
             if let Some(run_id) = self.current_run_id.lock().await.clone() {
-                let _ = self.run_store.mark_cancelled(&run_id).await;
+                let _ = self
+                    .run_store
+                    .settle_terminal(&run_id, crate::run::RunTerminalTransition::Cancelled)
+                    .await;
                 if let Some(executor) = &self.hook_executor {
                     executor
                         .record_run_cancelled(&run_id, &self.session_id, Some("cancelled by host"))

--- a/core/src/agent_api/session_close.rs
+++ b/core/src/agent_api/session_close.rs
@@ -194,7 +194,10 @@ impl SessionCloseHandle {
         let had_active_token = self.cancel_token.lock().await.is_some();
         if had_active_token {
             if let Some(run_id) = self.current_run_id.lock().await.clone() {
-                let _ = self.run_store.mark_cancelled(&run_id).await;
+                let _ = self
+                    .run_store
+                    .settle_terminal(&run_id, crate::run::RunTerminalTransition::Cancelled)
+                    .await;
                 if let Some(hook) = &self.hook_executor {
                     hook.record_run_cancelled(&run_id, &self.session_id, Some("cancelled by host"))
                         .await;

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -28,6 +28,19 @@ impl RunStatus {
     }
 }
 
+/// One terminal outcome applied to an admitted Run.
+///
+/// `Completed` is normally materialized by the authoritative `End` event,
+/// while cancellation and failure are applied by control or lifecycle
+/// boundaries that may finish before an event arrives. Keeping the transition
+/// type beside the Run store gives every caller one typed write primitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RunTerminalTransition {
+    Completed,
+    Cancelled,
+    Failed(String),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunEventRecord {
     pub sequence: usize,
@@ -404,6 +417,26 @@ impl InMemoryRunStore {
         run.status = RunStatus::Cancelled;
         run.updated_at_ms = now_ms().max(run.updated_at_ms);
         Some(run.clone())
+    }
+
+    /// Apply one terminal transition without allowing a late outcome to
+    /// rewrite an already terminal Run.
+    ///
+    /// Successful Runs are finalized by `AgentEvent::End`, so the
+    /// `Completed` transition is intentionally a read-only acknowledgement.
+    /// Cancellation and failure share the same monotonic primitives used by
+    /// the rest of the Run API, which keeps host cancellation and lifecycle
+    /// cleanup on one typed storage boundary.
+    pub(crate) async fn settle_terminal(
+        &self,
+        run_id: &str,
+        transition: RunTerminalTransition,
+    ) -> Option<RunSnapshot> {
+        match transition {
+            RunTerminalTransition::Completed => self.snapshot(run_id).await,
+            RunTerminalTransition::Cancelled => self.mark_cancelled(run_id).await,
+            RunTerminalTransition::Failed(error) => self.mark_failed(run_id, error).await,
+        }
     }
 
     pub async fn snapshot(&self, run_id: &str) -> Option<RunSnapshot> {
@@ -1204,7 +1237,10 @@ impl RunHandle {
         let token = self.cancel_token.lock().await.clone();
         if let Some(token) = token {
             token.cancel();
-            let _ = self.store.mark_cancelled(&self.id).await;
+            let _ = self
+                .store
+                .settle_terminal(&self.id, RunTerminalTransition::Cancelled)
+                .await;
             if let Some(executor) = &self.hook_executor {
                 executor
                     .record_run_cancelled(&self.id, &self.session_id, Some("cancelled by host"))
@@ -1570,5 +1606,48 @@ mod tests {
             store.mark_cancelled(&failed.id).await.unwrap().status,
             RunStatus::Failed
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_sink_preserves_event_completion_and_rejects_late_outcomes() {
+        let store = InMemoryRunStore::new();
+        let completed = store.create_run("session-1", "done").await;
+        store
+            .record_event(
+                &completed.id,
+                AgentEvent::End {
+                    text: "done".to_string(),
+                    usage: Default::default(),
+                    verification_summary: Box::new(
+                        crate::verification::VerificationSummary::from_reports(&[]),
+                    ),
+                    meta: None,
+                },
+            )
+            .await;
+
+        let acknowledged = store
+            .settle_terminal(&completed.id, RunTerminalTransition::Completed)
+            .await
+            .expect("completed Run remains observable");
+        assert_eq!(acknowledged.status, RunStatus::Completed);
+
+        let failed = store.create_run("session-1", "fails").await;
+        let failed = store
+            .settle_terminal(
+                &failed.id,
+                RunTerminalTransition::Failed("provider failed".to_string()),
+            )
+            .await
+            .expect("failed Run remains observable");
+        assert_eq!(failed.status, RunStatus::Failed);
+        assert_eq!(failed.error.as_deref(), Some("provider failed"));
+
+        let unchanged = store
+            .settle_terminal(&failed.id, RunTerminalTransition::Cancelled)
+            .await
+            .expect("late cancellation remains observable");
+        assert_eq!(unchanged.status, RunStatus::Failed);
+        assert_eq!(unchanged.error.as_deref(), Some("provider failed"));
     }
 }


### PR DESCRIPTION
## Summary\n- move the typed terminal transition beside the Code-owned Run store\n- route coordinator, cancellation, close, and admission-failure paths through one storage sink\n- preserve End-event completion semantics and add monotonic transition coverage\n\n## Validation\n- cargo fmt --all -- --check\n- cargo test -p a3s-code-core\n- 3104 passed, 0 failed, 13 ignored (library and integration tests)\n- protocol Host/Harness tests pass\n