### PR TITLE
feat(core): expose structured model cancellation boundary

### DIFF
--- a/core/src/evaluation/auxiliary_run.rs
+++ b/core/src/evaluation/auxiliary_run.rs
@@ -297,9 +297,13 @@ impl AuxiliaryExecutor for StructuredAuxiliaryExecutor {
             return Err(AuxiliaryRunError::Cancelled);
         }
         let request = (self.request_factory)(&context);
-        let result = crate::llm::structured::generate_blocking(self.client.as_ref(), &request)
-            .await
-            .map_err(|error| AuxiliaryRunError::Executor(error.to_string()))?;
+        let result = crate::llm::structured::generate_blocking_with_cancellation(
+            self.client.as_ref(),
+            &request,
+            context.cancellation.clone(),
+        )
+        .await
+        .map_err(|error| AuxiliaryRunError::Executor(error.to_string()))?;
         if context.cancellation.is_cancelled() {
             return Err(AuxiliaryRunError::Cancelled);
         }

--- a/core/src/llm/structured.rs
+++ b/core/src/llm/structured.rs
@@ -330,6 +330,20 @@ pub async fn generate_blocking(
     client: &dyn LlmClient,
     req: &StructuredRequest,
 ) -> Result<StructuredResult> {
+    generate_blocking_with_cancellation(client, req, CancellationToken::new()).await
+}
+
+/// Generate a structured object while honoring the caller's cancellation token.
+///
+/// This is the explicit model-call boundary for non-streaming structured
+/// generation. The client remains the only provider gateway; cancellation is
+/// enforced around every initial and repair call without mutating the caller's
+/// token.
+pub async fn generate_blocking_with_cancellation(
+    client: &dyn LlmClient,
+    req: &StructuredRequest,
+    cancellation: CancellationToken,
+) -> Result<StructuredResult> {
     let mode = resolve_mode(req.mode, client.native_structured_support());
     let envelope = SchemaEnvelope::for_schema(&req.schema);
     let mut messages = build_initial_messages(req, mode);
@@ -341,10 +355,12 @@ pub async fn generate_blocking(
     let mut repair_rounds: u8 = 0;
 
     loop {
-        let resp = client
-            .complete_structured(&messages, Some(&system), &tools, &directive)
-            .await
-            .context("LLM call failed during structured generation")?;
+        let resp = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => bail!("Operation cancelled by user"),
+            response = client.complete_structured(&messages, Some(&system), &tools, &directive) => response,
+        }
+        .context("LLM call failed during structured generation")?;
 
         accumulate_usage(&mut total_usage, &resp.usage);
 
@@ -415,6 +431,21 @@ pub async fn generate_streaming(
     req: &StructuredRequest,
     on_partial: PartialObjectCallback,
 ) -> Result<StructuredResult> {
+    generate_streaming_with_cancellation(client, req, on_partial, CancellationToken::new()).await
+}
+
+/// Generate a structured object with streaming partial updates while honoring
+/// the caller's cancellation token.
+///
+/// A child token is passed to the provider so cancelling this operation can
+/// abort provider I/O without ever cancelling a host-owned token. Repair calls
+/// use the same cancellation boundary as the initial stream.
+pub async fn generate_streaming_with_cancellation(
+    client: &dyn LlmClient,
+    req: &StructuredRequest,
+    on_partial: PartialObjectCallback,
+    cancellation: CancellationToken,
+) -> Result<StructuredResult> {
     let mode = resolve_mode(req.mode, client.native_structured_support());
     let envelope = SchemaEnvelope::for_schema(&req.schema);
     let mut messages = build_initial_messages(req, mode);
@@ -422,17 +453,19 @@ pub async fn generate_streaming(
     let tools = build_tools(req, mode);
     let directive = build_directive(req, mode);
 
-    let cancel_token = CancellationToken::new();
-    let mut rx = client
-        .complete_streaming_structured(
+    let provider_cancellation = cancellation.child_token();
+    let mut rx = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => bail!("Operation cancelled by user"),
+        response = client.complete_streaming_structured(
             &messages,
             Some(&system),
             &tools,
             &directive,
-            cancel_token.clone(),
-        )
-        .await
-        .context("LLM streaming call failed during structured generation")?;
+            provider_cancellation.clone(),
+        ) => response,
+    }
+    .context("LLM streaming call failed during structured generation")?;
 
     let mut json_buffer = String::new();
     let mut last_valid_partial: Option<Value> = None;
@@ -449,13 +482,15 @@ pub async fn generate_streaming(
     loop {
         let event = if let Some((_, _, deadline)) = complete_candidate.as_ref() {
             tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => bail!("Operation cancelled by user"),
                 event = rx.recv() => event,
                 _ = tokio::time::sleep_until(*deadline) => {
-                    let candidate = complete_candidate
-                        .take()
-                        .expect("complete streamed candidate exists");
+                    let Some(candidate) = complete_candidate.take() else {
+                        continue;
+                    };
                     let (value, raw_text, _) = candidate;
-                    cancel_token.cancel();
+                    provider_cancellation.cancel();
                     on_partial(&value);
                     return Ok(StructuredResult {
                         object: value,
@@ -467,11 +502,15 @@ pub async fn generate_streaming(
                 }
             }
         } else {
-            rx.recv().await
+            tokio::select! {
+                biased;
+                _ = cancellation.cancelled() => bail!("Operation cancelled by user"),
+                event = rx.recv() => event,
+            }
         };
         let Some(event) = event else {
             if let Some((value, raw_text, _)) = complete_candidate.take() {
-                cancel_token.cancel();
+                provider_cancellation.cancel();
                 on_partial(&value);
                 return Ok(StructuredResult {
                     object: value,
@@ -555,6 +594,7 @@ pub async fn generate_streaming(
         }
     }
 
+    provider_cancellation.cancel();
     let mut resp = final_response.context("Stream ended without Done event")?;
     let mut total_usage = TokenUsage::default();
     accumulate_usage(&mut total_usage, &resp.usage);
@@ -600,10 +640,12 @@ pub async fn generate_streaming(
             mode,
             &raw_for_context,
         );
-        resp = client
-            .complete_structured(&messages, Some(&system), &tools, &directive)
-            .await
-            .context("LLM call failed while repairing streamed structured output")?;
+        resp = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => bail!("Operation cancelled by user"),
+            response = client.complete_structured(&messages, Some(&system), &tools, &directive) => response,
+        }
+        .context("LLM call failed while repairing streamed structured output")?;
         accumulate_usage(&mut total_usage, &resp.usage);
         resolution = resolve_structured(
             &extract_raw_candidates(&resp.message, mode),

--- a/core/src/llm/structured_tests.rs
+++ b/core/src/llm/structured_tests.rs
@@ -209,6 +209,48 @@ impl LlmClient for CompleteObjectWithoutDoneClient {
     }
 }
 
+struct CancellationBoundaryClient;
+
+#[async_trait]
+impl LlmClient for CancellationBoundaryClient {
+    async fn complete(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+    ) -> anyhow::Result<LlmResponse> {
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+        anyhow::bail!("unexpected completion after cancellation")
+    }
+
+    async fn complete_streaming(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<mpsc::Receiver<StreamEvent>> {
+        cancel_token.cancelled().await;
+        anyhow::bail!("provider observed cancellation")
+    }
+}
+
+fn cancellation_request() -> StructuredRequest {
+    StructuredRequest {
+        prompt: "Generate a value".to_string(),
+        system: None,
+        schema: serde_json::json!({
+            "type": "object",
+            "required": ["value"],
+            "properties": {"value": {"type": "string"}}
+        }),
+        schema_name: "cancellation_test".to_string(),
+        schema_description: None,
+        mode: StructuredMode::Prompt,
+        max_repair_attempts: 1,
+    }
+}
+
 // ========================================================================
 // extract_json_value tests
 // ========================================================================
@@ -483,6 +525,30 @@ fn test_validate_nested_object() {
 // ========================================================================
 
 #[tokio::test]
+async fn test_generate_blocking_with_cancellation_aborts_provider_call() {
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
+    let task = tokio::spawn(async move {
+        generate_blocking_with_cancellation(
+            &CancellationBoundaryClient,
+            &cancellation_request(),
+            task_cancellation,
+        )
+        .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    cancellation.cancel();
+    let error = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        .await
+        .expect("cancellation must finish the model call")
+        .expect("generation task must not panic")
+        .expect_err("cancelled generation must fail");
+
+    assert!(error.to_string().contains("Operation cancelled by user"));
+}
+
+#[tokio::test]
 async fn test_generate_blocking_tool_mode_success() {
     let client = MockStructuredClient::new(vec![MockStructuredClient::tool_call_response(
         "emit_invoice",
@@ -732,6 +798,31 @@ async fn test_generate_blocking_exhausts_repairs() {
 // ========================================================================
 // generate_streaming tests
 // ========================================================================
+
+#[tokio::test]
+async fn test_generate_streaming_with_cancellation_aborts_provider_setup() {
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
+    let task = tokio::spawn(async move {
+        generate_streaming_with_cancellation(
+            &CancellationBoundaryClient,
+            &cancellation_request(),
+            Box::new(|_| {}),
+            task_cancellation,
+        )
+        .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    cancellation.cancel();
+    let error = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+        .await
+        .expect("cancellation must finish provider setup")
+        .expect("generation task must not panic")
+        .expect_err("cancelled generation must fail");
+
+    assert!(error.to_string().contains("Operation cancelled by user"));
+}
 
 #[tokio::test]
 async fn test_generate_streaming_tool_mode() {

--- a/core/src/tools/builtin/generate_object.rs
+++ b/core/src/tools/builtin/generate_object.rs
@@ -306,9 +306,20 @@ impl Tool for GenerateObjectTool {
                     let delta_str = serde_json::to_string(&delta).unwrap_or_default();
                     let _ = tx_clone.try_send(ToolStreamEvent::OutputDelta(delta_str));
                 });
-                structured::generate_streaming(&*llm_client, &req, callback).await
+                structured::generate_streaming_with_cancellation(
+                    &*llm_client,
+                    &req,
+                    callback,
+                    cancellation.clone(),
+                )
+                .await
             } else {
-                structured::generate_blocking(&*llm_client, &req).await
+                structured::generate_blocking_with_cancellation(
+                    &*llm_client,
+                    &req,
+                    cancellation.clone(),
+                )
+                .await
             }
         };
         let execution = run_generation_with_admission(

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -16,7 +16,7 @@
 
 use crate::agent::{AgentConfig, AgentEvent, AgentLoop};
 use crate::llm::structured::{
-    generate_blocking, parse_validated_output, StructuredMode, StructuredRequest,
+    generate_blocking_with_cancellation, parse_validated_output, StructuredMode, StructuredRequest,
 };
 use crate::llm::{LlmClient, ToolDefinition};
 use crate::mcp::{McpBinding, McpManager};

--- a/core/src/tools/task/parallel_execution.rs
+++ b/core/src/tools/task/parallel_execution.rs
@@ -580,11 +580,8 @@ impl TaskExecutor {
             mode: StructuredMode::Tool,
             max_repair_attempts: 2,
         };
-        let result = tokio::select! {
-            biased;
-            _ = cancellation.cancelled() => anyhow::bail!("Operation cancelled by user"),
-            result = generate_blocking(llm_client, &req) => result?,
-        };
+        let result =
+            generate_blocking_with_cancellation(llm_client, &req, cancellation.clone()).await?;
         Ok(result.object)
     }
 
@@ -607,11 +604,8 @@ impl TaskExecutor {
             mode: StructuredMode::Tool,
             max_repair_attempts: 2,
         };
-        let result = tokio::select! {
-            biased;
-            _ = cancellation.cancelled() => anyhow::bail!("Operation cancelled by user"),
-            result = generate_blocking(llm_client, &req) => result?,
-        };
+        let result =
+            generate_blocking_with_cancellation(llm_client, &req, cancellation.clone()).await?;
         Ok(result.object)
     }
 }


### PR DESCRIPTION
## Summary
- expose explicit cancellation-aware structured blocking and streaming model-call APIs
- propagate existing run cancellation into generate_object, auxiliary, and delegated task schema generation
- preserve the legacy helpers while using child provider tokens and bounded repair-call cancellation
- add regression coverage for cancellation during blocking provider calls and streaming setup

## Validation
- cargo fmt --all
- cargo test -p a3s-code-core llm::structured -- --nocapture
- cargo test -p a3s-code-core
