### PR TITLE
refactor(core): make tool invocation lifecycle explicit

### DIFF
--- a/core/src/agent/tool_invoker.rs
+++ b/core/src/agent/tool_invoker.rs
@@ -11,8 +11,8 @@ use crate::tool_confirmation::{
     ToolConfirmationRequest, ToolConfirmationResolution, ToolConfirmationRuntime,
 };
 use crate::tools::{
-    HostDirectPolicy, InvocationOrigin, ToolCapabilities, ToolContext, ToolInvocation, ToolInvoker,
-    ToolResult,
+    HostDirectPolicy, InvocationOrigin, ToolCapabilities, ToolContext, ToolInvocation,
+    ToolInvocationLifecycle, ToolInvocationState, ToolInvocationTerminal, ToolInvoker, ToolResult,
 };
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -148,6 +148,7 @@ impl ScopedToolInvoker {
         &self,
         invocation: &ToolInvocation,
         ctx: &ToolContext,
+        lifecycle: &mut ToolInvocationLifecycle,
         decision: ToolGateDecision,
     ) -> NormalizedToolResult {
         match decision {
@@ -164,6 +165,7 @@ impl ScopedToolInvoker {
                     "Tool denied by invocation gateway"
                 );
                 self.emit_permission_denied(invocation, event_reason).await;
+                lifecycle.terminal(ToolInvocationTerminal::Rejected);
                 NormalizedToolResult::denied_with_error_kind(output, error_kind)
             }
             ToolGateDecision::Execute { reason } => {
@@ -173,7 +175,7 @@ impl ScopedToolInvoker {
                     origin = ?invocation.origin,
                     "Tool approved by invocation gateway"
                 );
-                self.execute_budgeted(invocation, ctx).await
+                self.execute_budgeted(invocation, ctx, lifecycle).await
             }
             ToolGateDecision::Confirm {
                 timeout_ms,
@@ -190,11 +192,12 @@ impl ScopedToolInvoker {
                     .await
                 {
                     PermissionHookDecision::Allow => {
-                        return self.execute_budgeted(invocation, ctx).await;
+                        return self.execute_budgeted(invocation, ctx, lifecycle).await;
                     }
                     PermissionHookDecision::Deny(reason) => {
                         self.emit_permission_denied(invocation, reason.clone())
                             .await;
+                        lifecycle.terminal(ToolInvocationTerminal::Rejected);
                         return NormalizedToolResult::denied(format!(
                             "Tool '{}' denied by permission hook: {reason}",
                             invocation.name
@@ -230,9 +233,14 @@ impl ScopedToolInvoker {
 
                 match confirmation {
                     ToolConfirmationResolution::Approved => {
-                        self.execute_budgeted(invocation, ctx).await
+                        self.execute_budgeted(invocation, ctx, lifecycle).await
                     }
                     ToolConfirmationResolution::Rejected { output } => {
+                        if ctx.is_cancelled() {
+                            lifecycle.terminal(ToolInvocationTerminal::Cancelled);
+                        } else {
+                            lifecycle.terminal(ToolInvocationTerminal::Rejected);
+                        }
                         NormalizedToolResult::denied(output)
                     }
                 }
@@ -244,10 +252,14 @@ impl ScopedToolInvoker {
         &self,
         invocation: &ToolInvocation,
         ctx: &ToolContext,
+        lifecycle: &mut ToolInvocationLifecycle,
     ) -> NormalizedToolResult {
         if let Some(denied) = self.check_before_tool(invocation).await {
+            lifecycle.terminal(ToolInvocationTerminal::Rejected);
             return denied;
         }
+
+        debug_assert!(lifecycle.transition(ToolInvocationState::Running).is_ok());
 
         if let Some(tx) = &self.event_tx {
             tx.send(AgentEvent::ToolExecutionStart {
@@ -291,11 +303,20 @@ impl ScopedToolInvoker {
             &invocation.id,
             &invocation.name,
         );
-        NormalizedToolResult::from_execution(
+        let result = NormalizedToolResult::from_execution(
             self.agent
                 .execute_tool_queued_or_direct(&invocation.name, &invocation.args, &stream_ctx)
                 .await,
-        )
+        );
+        let terminal = if ctx.is_cancelled() {
+            ToolInvocationTerminal::Cancelled
+        } else if result.is_error {
+            ToolInvocationTerminal::Failed
+        } else {
+            ToolInvocationTerminal::Completed
+        };
+        lifecycle.terminal(terminal);
+        result
     }
 
     async fn check_before_tool(&self, invocation: &ToolInvocation) -> Option<NormalizedToolResult> {
@@ -418,10 +439,12 @@ impl ScopedToolInvoker {
 impl ToolInvoker for ScopedToolInvoker {
     async fn invoke(&self, mut invocation: ToolInvocation, ctx: &ToolContext) -> ToolResult {
         let started = Instant::now();
+        let mut lifecycle = ToolInvocationLifecycle::new();
         let cancellation = ctx.cancellation_token();
         let invocation_ctx = match ctx.enter_tool_invocation(&invocation.name) {
             Ok(ctx) => ctx,
             Err(message) => {
+                lifecycle.terminal(ToolInvocationTerminal::Failed);
                 let result = self
                     .finish(
                         &invocation,
@@ -434,6 +457,7 @@ impl ToolInvoker for ScopedToolInvoker {
                 return result;
             }
         };
+        debug_assert!(lifecycle.transition(ToolInvocationState::Admitted).is_ok());
         let cancellation = invocation_ctx.cancellation_token();
         if let Err(message) = self
             .agent
@@ -441,6 +465,7 @@ impl ToolInvoker for ScopedToolInvoker {
             .registry()
             .validate_arguments(&invocation.name, &invocation.args)
         {
+            lifecycle.terminal(ToolInvocationTerminal::Failed);
             let result = self
                 .finish(
                     &invocation,
@@ -452,6 +477,9 @@ impl ToolInvoker for ScopedToolInvoker {
             self.emit_nested_tool_end(&invocation, &result).await;
             return result;
         }
+        debug_assert!(lifecycle
+            .transition(ToolInvocationState::GatePending)
+            .is_ok());
         let decision = tokio::select! {
             biased;
             _ = cancellation.cancelled() => {
@@ -465,17 +493,25 @@ impl ToolInvoker for ScopedToolInvoker {
                 // cancellation and settlement. Do not drop that future from an
                 // outer select: blocking VMs and process-backed tools need a
                 // chance to observe their invocation token and terminate.
-                self.resolve_gate(&invocation, &invocation_ctx, decision)
+                self.resolve_gate(&invocation, &invocation_ctx, &mut lifecycle, decision)
                     .await
             }
             Some(Err(message)) => {
+                lifecycle.terminal(ToolInvocationTerminal::Failed);
                 NormalizedToolResult::invalid_arguments(&invocation.name, message)
             }
-            None => NormalizedToolResult::denied(format!(
-                "Tool '{}' cancelled by caller",
-                invocation.name
-            )),
+            None => {
+                lifecycle.terminal(ToolInvocationTerminal::Cancelled);
+                NormalizedToolResult::denied(format!(
+                    "Tool '{}' cancelled by caller",
+                    invocation.name
+                ))
+            }
         };
+        debug_assert!(matches!(
+            lifecycle.state(),
+            ToolInvocationState::Terminal(_)
+        ));
         let result = self
             .finish(&invocation, started, normalized, &cancellation)
             .await;

--- a/core/src/tools/invocation.rs
+++ b/core/src/tools/invocation.rs
@@ -56,6 +56,89 @@ impl InvocationOrigin {
     }
 }
 
+/// Terminal outcome of a governed tool invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolInvocationTerminal {
+    Completed,
+    Rejected,
+    Cancelled,
+    Failed,
+}
+
+/// Lifecycle states for one governed tool invocation.
+///
+/// The state machine is intentionally independent of any concrete tool
+/// backend. Built-ins, MCP, Flow, and Use Runtime Tasks all cross the same
+/// admission and terminal boundary in the scoped invoker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolInvocationState {
+    Created,
+    Admitted,
+    GatePending,
+    Running,
+    Terminal(ToolInvocationTerminal),
+}
+
+/// Internal state machine for one invocation's ownership and settlement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ToolInvocationLifecycle {
+    state: ToolInvocationState,
+}
+
+impl ToolInvocationLifecycle {
+    pub(crate) const fn new() -> Self {
+        Self {
+            state: ToolInvocationState::Created,
+        }
+    }
+
+    pub(crate) const fn state(self) -> ToolInvocationState {
+        self.state
+    }
+
+    pub(crate) fn transition(&mut self, next: ToolInvocationState) -> Result<(), &'static str> {
+        let allowed = matches!(
+            (self.state, next),
+            (ToolInvocationState::Created, ToolInvocationState::Admitted)
+                | (
+                    ToolInvocationState::Created,
+                    ToolInvocationState::Terminal(_)
+                )
+                | (
+                    ToolInvocationState::Admitted,
+                    ToolInvocationState::GatePending
+                )
+                | (
+                    ToolInvocationState::Admitted,
+                    ToolInvocationState::Terminal(_)
+                )
+                | (
+                    ToolInvocationState::GatePending,
+                    ToolInvocationState::Running
+                )
+                | (
+                    ToolInvocationState::GatePending,
+                    ToolInvocationState::Terminal(_)
+                )
+                | (
+                    ToolInvocationState::Running,
+                    ToolInvocationState::Terminal(_)
+                )
+        );
+        if !allowed {
+            return Err("invalid tool invocation lifecycle transition");
+        }
+        self.state = next;
+        Ok(())
+    }
+
+    pub(crate) fn terminal(&mut self, outcome: ToolInvocationTerminal) {
+        debug_assert!(self
+            .transition(ToolInvocationState::Terminal(outcome))
+            .is_ok());
+    }
+}
+
 /// Owned invocation data so calls can be dispatched across async tasks.
 #[derive(Debug, Clone)]
 pub(crate) struct ToolInvocation {
@@ -260,5 +343,36 @@ mod tests {
         assert!(invoker
             .capabilities("read", &serde_json::json!({}))
             .is_none());
+    }
+
+    #[test]
+    fn lifecycle_accepts_one_terminal_transition_and_rejects_late_work() {
+        let mut lifecycle = ToolInvocationLifecycle::new();
+        assert_eq!(lifecycle.state(), ToolInvocationState::Created);
+        lifecycle.transition(ToolInvocationState::Admitted).unwrap();
+        lifecycle
+            .transition(ToolInvocationState::GatePending)
+            .unwrap();
+        lifecycle.transition(ToolInvocationState::Running).unwrap();
+        lifecycle.terminal(ToolInvocationTerminal::Completed);
+        assert_eq!(
+            lifecycle.state(),
+            ToolInvocationState::Terminal(ToolInvocationTerminal::Completed)
+        );
+        assert!(lifecycle.transition(ToolInvocationState::Running).is_err());
+    }
+
+    #[test]
+    fn lifecycle_allows_rejection_before_execution() {
+        let mut lifecycle = ToolInvocationLifecycle::new();
+        lifecycle.transition(ToolInvocationState::Admitted).unwrap();
+        lifecycle
+            .transition(ToolInvocationState::GatePending)
+            .unwrap();
+        lifecycle.terminal(ToolInvocationTerminal::Rejected);
+        assert_eq!(
+            lifecycle.state(),
+            ToolInvocationState::Terminal(ToolInvocationTerminal::Rejected)
+        );
     }
 }

--- a/core/src/tools/mod.rs
+++ b/core/src/tools/mod.rs
@@ -45,7 +45,8 @@ pub use immutable_content::{
 };
 pub(crate) use invocation::{
     registry_bound_tool_invoker, registry_tool_invoker, HostDirectPolicy, InvocationOrigin,
-    ToolInvocation, ToolInvoker,
+    ToolInvocation, ToolInvocationLifecycle, ToolInvocationState, ToolInvocationTerminal,
+    ToolInvoker,
 };
 pub(crate) use presentation::{
     canonical_source as canonical_presentation_source, estimated_definition_tokens,


### PR DESCRIPTION
## Summary
- add a pure ToolInvocationLifecycle FSM with explicit admission, gate, running, and terminal states
- integrate the FSM into the governed ScopedToolInvoker for rejection, cancellation, success, and failure settlement
- re-export the internal lifecycle types without changing public tool protocol shapes
- add transition and terminality regression tests

## Validation
- cargo fmt --all -- --check
- cargo test -p a3s-code-core tools::invocation --lib -- --nocapture (4 passed)
- cargo test -p a3s-code-core tool_executor_registry --lib -- --nocapture (1 passed)
- cargo test -p a3s-code-core nested_tool_governance_tests --lib -- --nocapture (13 passed)
