### PR TITLE
refactor(core): bind trust labels and execution identities

### DIFF
--- a/core/src/agent/completion_runtime.rs
+++ b/core/src/agent/completion_runtime.rs
@@ -198,7 +198,7 @@ impl AgentLoop {
 
     fn sanitize_final_text(&self, text: &str) -> String {
         if let Some(ref sp) = self.config.security_provider {
-            sp.sanitize_output(text)
+            crate::security::sanitize_text(sp.as_ref(), text)
         } else {
             text.to_string()
         }

--- a/core/src/agent/llm_invoker.rs
+++ b/core/src/agent/llm_invoker.rs
@@ -103,6 +103,23 @@ impl<'a> ModelCallRequest<'a> {
             presentation_application,
         )
     }
+
+    fn idempotency_identity(
+        &self,
+        scope: &str,
+    ) -> Result<
+        crate::execution_identity::ExecutionIdentityV1,
+        crate::execution_identity::ExecutionIdentityError,
+    > {
+        model_request_identity(
+            scope,
+            self.kind,
+            self.messages,
+            self.system,
+            self.tools,
+            self.directive,
+        )
+    }
 }
 
 /// Typed output of one admitted non-streaming model call.
@@ -199,6 +216,23 @@ impl<'a> ModelStreamRequest<'a> {
             presentation_application,
         )
     }
+
+    fn idempotency_identity(
+        &self,
+        scope: &str,
+    ) -> Result<
+        crate::execution_identity::ExecutionIdentityV1,
+        crate::execution_identity::ExecutionIdentityError,
+    > {
+        model_request_identity(
+            scope,
+            self.kind,
+            self.messages,
+            self.system,
+            self.tools,
+            self.directive,
+        )
+    }
 }
 
 /// Typed output of the streaming middleware. The receiver owns the proxy
@@ -211,6 +245,48 @@ impl ModelStreamOutcome {
     fn into_receiver(self) -> mpsc::Receiver<StreamEvent> {
         self.receiver
     }
+}
+
+fn model_request_identity(
+    scope: &str,
+    kind: impl std::fmt::Debug,
+    messages: &[Message],
+    system: Option<&str>,
+    tools: &[ToolDefinition],
+    directive: Option<&StructuredDirective>,
+) -> Result<
+    crate::execution_identity::ExecutionIdentityV1,
+    crate::execution_identity::ExecutionIdentityError,
+> {
+    let directive = directive.map(|directive| {
+        let response_format = directive
+            .response_format
+            .as_ref()
+            .map(|format| match format {
+                crate::llm::structured::ResponseFormat::JsonObject => {
+                    serde_json::json!({"kind": "json_object"})
+                }
+                crate::llm::structured::ResponseFormat::JsonSchema { name, schema } => {
+                    serde_json::json!({"kind": "json_schema", "name": name, "schema": schema})
+                }
+            });
+        serde_json::json!({
+            "force_tool": directive.force_tool,
+            "response_format": response_format,
+            "validation_schema": directive.validation_schema,
+        })
+    });
+    crate::execution_identity::ExecutionIdentityV1::derive(
+        crate::execution_identity::MODEL_CALL_IDENTITY_DOMAIN_V1,
+        &serde_json::json!({
+            "scope": scope,
+            "kind": format!("{kind:?}"),
+            "messages": messages,
+            "system": system,
+            "tools": tools,
+            "directive": directive,
+        }),
+    )
 }
 
 impl LlmInvoker {
@@ -277,6 +353,10 @@ impl LlmInvoker {
         &self,
         request: ModelCallRequest<'_>,
     ) -> anyhow::Result<ModelCallOutcome> {
+        let identity = request
+            .idempotency_identity(self.invocation.session_id())
+            .map_err(|error| anyhow::anyhow!("derive model call identity: {error}"))?;
+        debug_assert!(identity.validate().is_ok());
         let observation = request.observation(self.presentation_application);
         let response = match request.kind {
             ModelCallKind::Completion => {
@@ -476,6 +556,10 @@ impl LlmInvoker {
         &self,
         request: ModelStreamRequest<'_>,
     ) -> anyhow::Result<ModelStreamOutcome> {
+        let identity = request
+            .idempotency_identity(self.invocation.session_id())
+            .map_err(|error| anyhow::anyhow!("derive streaming model call identity: {error}"))?;
+        debug_assert!(identity.validate().is_ok());
         let observation = request.observation(self.presentation_application);
         let caller_cancellation = request.caller_cancellation.clone();
         let receiver = match request.kind {

--- a/core/src/agent/llm_invoker/tests.rs
+++ b/core/src/agent/llm_invoker/tests.rs
@@ -27,6 +27,16 @@ fn typed_model_requests_bind_their_evidence_kind() {
     let structured_observation = structured.observation(ModelPresentationApplicationV1::Auxiliary);
     assert_eq!(structured_observation.kind, ModelInputKindV1::Structured);
     assert!(structured_observation.directive.is_some());
+
+    let retry = ModelCallRequest::completion(&messages, None, &tools);
+    assert_eq!(
+        completion.idempotency_identity("session-1").unwrap(),
+        retry.idempotency_identity("session-1").unwrap()
+    );
+    assert_ne!(
+        completion.idempotency_identity("session-1").unwrap(),
+        completion.idempotency_identity("session-2").unwrap()
+    );
 }
 
 #[test]
@@ -48,6 +58,11 @@ fn typed_stream_requests_bind_their_evidence_kind() {
     let observation = structured.observation(ModelPresentationApplicationV1::Auxiliary);
     assert_eq!(observation.kind, ModelInputKindV1::StreamingStructured);
     assert!(observation.directive.is_some());
+
+    assert_ne!(
+        streaming.idempotency_identity("session-1").unwrap(),
+        structured.idempotency_identity("session-1").unwrap()
+    );
 }
 
 #[async_trait]

--- a/core/src/agent/tool_invoker.rs
+++ b/core/src/agent/tool_invoker.rs
@@ -104,6 +104,14 @@ impl ScopedToolInvoker {
     }
 
     async fn emit_tool_request_bound(&self, invocation: &ToolInvocation) -> Result<(), String> {
+        let identity = invocation
+            .idempotency_identity((!self.session_id.is_empty()).then_some(self.session_id.as_str()))
+            .map_err(|error| format!("Failed to derive Tool request identity: {error}"))?;
+        tracing::trace!(
+            tool_id = invocation.id.as_str(),
+            idempotency_key = identity.key(),
+            "Tool request identity bound at the governed value boundary"
+        );
         let Some(tx) = &self.event_tx else {
             return Ok(());
         };
@@ -411,7 +419,12 @@ impl ScopedToolInvoker {
 
         let mut result = normalized.into_tool_result(invocation.name.clone());
         if let Some(provider) = &self.agent.config.security_provider {
-            result.output = provider.sanitize_output(&result.output);
+            result.output = crate::security::sanitize_tainted_text(
+                provider.as_ref(),
+                crate::security::TaintedValue::untrusted(result.output),
+            )
+            .into_parts()
+            .0;
             result.error_kind = result
                 .error_kind
                 .as_ref()

--- a/core/src/agent_api/command_runtime.rs
+++ b/core/src/agent_api/command_runtime.rs
@@ -80,7 +80,7 @@ fn sanitize_text(session: &AgentSession, text: &str) -> String {
         .config
         .security_provider
         .as_deref()
-        .map(|provider| provider.sanitize_output(text))
+        .map(|provider| crate::security::sanitize_text(provider, text))
         .unwrap_or_else(|| text.to_string())
 }
 

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -1,0 +1,174 @@
+//! Stable identities for replayable execution boundaries.
+//!
+//! The identity is deliberately content-addressed and domain-separated. It
+//! is suitable for deduplication and fencing, but it does not itself claim a
+//! lease or persist an outcome; those responsibilities remain with the
+//! caller's ledger.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use thiserror::Error;
+
+pub const EXECUTION_IDENTITY_SCHEMA_V1: &str = "a3s.code.execution-identity.v1";
+pub const MODEL_CALL_IDENTITY_DOMAIN_V1: &str = "a3s.code.model-call.identity.v1";
+pub const TOOL_INVOCATION_IDENTITY_DOMAIN_V1: &str = "a3s.code.tool-invocation.identity.v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ExecutionIdentityError {
+    #[error("execution identity domain is empty or invalid")]
+    InvalidDomain,
+    #[error("execution identity serialization failed: {0}")]
+    Serialization(String),
+    #[error("execution identity digest is invalid")]
+    InvalidDigest,
+    #[error("execution identity digest does not match the value")]
+    DigestMismatch,
+}
+
+/// A portable, domain-separated content identity.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionIdentityV1 {
+    pub schema: String,
+    pub domain: String,
+    pub digest: String,
+}
+
+impl ExecutionIdentityV1 {
+    pub fn derive<T: Serialize>(
+        domain: impl Into<String>,
+        value: &T,
+    ) -> Result<Self, ExecutionIdentityError> {
+        let domain = domain.into();
+        validate_domain(&domain)?;
+        let canonical = serde_json::to_value(value)
+            .map(canonicalize)
+            .map_err(|error| ExecutionIdentityError::Serialization(error.to_string()))?;
+        let bytes = serde_json::to_vec(&canonical)
+            .map_err(|error| ExecutionIdentityError::Serialization(error.to_string()))?;
+        let mut hasher = Sha256::new();
+        hasher.update(domain.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        let digest = format!("sha256:{:x}", hasher.finalize());
+        Ok(Self {
+            schema: EXECUTION_IDENTITY_SCHEMA_V1.to_string(),
+            domain,
+            digest,
+        })
+    }
+
+    pub fn validate(&self) -> Result<(), ExecutionIdentityError> {
+        if self.schema != EXECUTION_IDENTITY_SCHEMA_V1 {
+            return Err(ExecutionIdentityError::InvalidDomain);
+        }
+        validate_domain(&self.domain)?;
+        let Some(hex) = self.digest.strip_prefix("sha256:") else {
+            return Err(ExecutionIdentityError::InvalidDigest);
+        };
+        if hex.len() != 64
+            || !hex
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(ExecutionIdentityError::InvalidDigest);
+        }
+        Ok(())
+    }
+
+    pub fn key(&self) -> &str {
+        &self.digest
+    }
+
+    pub fn validate_for<T: Serialize>(&self, value: &T) -> Result<(), ExecutionIdentityError> {
+        self.validate()?;
+        let expected = Self::derive(&self.domain, value)?;
+        if expected.digest != self.digest {
+            return Err(ExecutionIdentityError::DigestMismatch);
+        }
+        Ok(())
+    }
+}
+
+fn canonicalize(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(values) => {
+            serde_json::Value::Array(values.into_iter().map(canonicalize).collect())
+        }
+        serde_json::Value::Object(values) => {
+            let values = values
+                .into_iter()
+                .map(|(key, value)| (key, canonicalize(value)))
+                .collect::<BTreeMap<_, _>>();
+            serde_json::Value::Object(values.into_iter().collect())
+        }
+        value => value,
+    }
+}
+
+fn validate_domain(domain: &str) -> Result<(), ExecutionIdentityError> {
+    if domain.is_empty()
+        || domain.len() > 128
+        || domain.contains('\0')
+        || domain.lines().count() != 1
+        || !domain.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-' | b'_')
+        })
+    {
+        return Err(ExecutionIdentityError::InvalidDomain);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_is_domain_separated_and_replay_stable() {
+        let value = serde_json::json!({"name": "read", "args": {"path": "src/lib.rs"}});
+        let first =
+            ExecutionIdentityV1::derive(TOOL_INVOCATION_IDENTITY_DOMAIN_V1, &value).unwrap();
+        let second =
+            ExecutionIdentityV1::derive(TOOL_INVOCATION_IDENTITY_DOMAIN_V1, &value).unwrap();
+        let other = ExecutionIdentityV1::derive(MODEL_CALL_IDENTITY_DOMAIN_V1, &value).unwrap();
+
+        assert_eq!(first, second);
+        assert_ne!(first.digest, other.digest);
+        first.validate().unwrap();
+        first.validate_for(&value).unwrap();
+
+        let left = serde_json::json!({"a": 1, "b": 2});
+        let right = serde_json::json!({"b": 2, "a": 1});
+        assert_eq!(
+            ExecutionIdentityV1::derive("a3s.test", &left).unwrap(),
+            ExecutionIdentityV1::derive("a3s.test", &right).unwrap()
+        );
+    }
+
+    #[test]
+    fn identity_rejects_malformed_domains_and_digests() {
+        assert!(matches!(
+            ExecutionIdentityV1::derive("Bad Domain", &"value"),
+            Err(ExecutionIdentityError::InvalidDomain)
+        ));
+        let mut identity = ExecutionIdentityV1::derive("a3s.test", &"value").unwrap();
+        identity.digest = "sha256:ABC".to_string();
+        assert!(matches!(
+            identity.validate(),
+            Err(ExecutionIdentityError::InvalidDigest)
+        ));
+    }
+
+    #[test]
+    fn identity_validation_detects_content_tampering() {
+        let value = serde_json::json!({"a": 1, "b": {"c": true}});
+        let identity = ExecutionIdentityV1::derive("a3s.test", &value).unwrap();
+        let changed = serde_json::json!({"a": 2, "b": {"c": true}});
+        assert!(matches!(
+            identity.validate_for(&changed),
+            Err(ExecutionIdentityError::DigestMismatch)
+        ));
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -95,6 +95,7 @@ pub mod embedding;
 pub mod error;
 pub mod evaluation;
 pub mod event_protocol;
+pub mod execution_identity;
 pub mod flow_graph;
 pub(crate) mod git;
 pub mod harness_evidence;

--- a/core/src/security/mod.rs
+++ b/core/src/security/mod.rs
@@ -7,10 +7,15 @@
 pub mod config;
 pub mod default;
 mod event_sanitizer;
+mod value;
 
 pub use config::{RedactionStrategy, SecurityConfig, SensitivityLevel};
 pub use default::{DefaultSecurityConfig, DefaultSecurityProvider, SensitivePattern};
 pub(crate) use event_sanitizer::AgentEventStreamSanitizer;
+pub use value::{
+    sanitize_tainted_json, sanitize_tainted_text, sanitize_text, SanitizationState, SecurityLabel,
+    TaintLabel, TaintedValue, TrustLevel,
+};
 
 use crate::hooks::HookEngine;
 
@@ -22,7 +27,7 @@ pub(crate) fn sanitize_tool_error_kind(
 ) -> crate::tools::ToolErrorKind {
     use crate::tools::ToolErrorKind;
 
-    let text = |value: &str| provider.sanitize_output(value);
+    let text = |value: &str| sanitize_text(provider, value);
     match kind {
         ToolErrorKind::VersionConflict {
             path,
@@ -82,7 +87,7 @@ pub fn sanitize_agent_event(
     use crate::agent::AgentEvent;
 
     fn text(provider: &dyn SecurityProvider, value: &str) -> String {
-        provider.sanitize_output(value)
+        sanitize_text(provider, value)
     }
 
     fn optional_text(provider: &dyn SecurityProvider, value: &Option<String>) -> Option<String> {
@@ -94,19 +99,9 @@ pub fn sanitize_agent_event(
     }
 
     fn json(provider: &dyn SecurityProvider, value: &serde_json::Value) -> serde_json::Value {
-        match value {
-            serde_json::Value::String(value) => serde_json::Value::String(text(provider, value)),
-            serde_json::Value::Array(values) => {
-                serde_json::Value::Array(values.iter().map(|value| json(provider, value)).collect())
-            }
-            serde_json::Value::Object(values) => serde_json::Value::Object(
-                values
-                    .iter()
-                    .map(|(key, value)| (key.clone(), json(provider, value)))
-                    .collect(),
-            ),
-            value => value.clone(),
-        }
+        sanitize_tainted_json(provider, TaintedValue::untrusted(value.clone()))
+            .into_parts()
+            .0
     }
 
     fn optional_json(

--- a/core/src/security/value.rs
+++ b/core/src/security/value.rs
@@ -1,0 +1,211 @@
+//! Typed provenance for values crossing runtime security boundaries.
+
+use super::SecurityProvider;
+use serde::{Deserialize, Serialize};
+
+/// Trust provenance assigned by the owning adapter, never inferred from text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustLevel {
+    Untrusted,
+    Derived,
+    Trusted,
+}
+
+/// Taint classification is independent of instruction authority and redaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaintLabel {
+    Unknown,
+    Sensitive,
+    Secret,
+    PromptInjection,
+}
+
+/// Whether the configured provider has processed the complete value.
+///
+/// `Applied` is not a guarantee that the value is public or safe to execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SanitizationState {
+    Pending,
+    Applied,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecurityLabel {
+    pub trust: TrustLevel,
+    pub taint: TaintLabel,
+    pub sanitization: SanitizationState,
+}
+
+impl SecurityLabel {
+    pub const fn untrusted() -> Self {
+        Self {
+            trust: TrustLevel::Untrusted,
+            taint: TaintLabel::Unknown,
+            sanitization: SanitizationState::Pending,
+        }
+    }
+
+    pub const fn trusted() -> Self {
+        Self {
+            trust: TrustLevel::Trusted,
+            ..Self::untrusted()
+        }
+    }
+
+    pub const fn derived(taint: TaintLabel) -> Self {
+        Self {
+            trust: TrustLevel::Derived,
+            taint,
+            sanitization: SanitizationState::Pending,
+        }
+    }
+
+    fn sanitized(self) -> Self {
+        Self {
+            sanitization: SanitizationState::Applied,
+            ..self
+        }
+    }
+}
+
+/// A label travels with its value until an explicit boundary consumes it.
+/// These labels describe provenance; they never grant execution permission.
+#[must_use]
+#[derive(Clone, PartialEq, Eq)]
+pub struct TaintedValue<T> {
+    value: T,
+    label: SecurityLabel,
+}
+
+impl<T> std::fmt::Debug for TaintedValue<T> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TaintedValue")
+            .field("label", &self.label)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> TaintedValue<T> {
+    pub fn new(value: T, label: SecurityLabel) -> Self {
+        Self { value, label }
+    }
+
+    pub fn untrusted(value: T) -> Self {
+        Self::new(value, SecurityLabel::untrusted())
+    }
+
+    pub fn trusted(value: T) -> Self {
+        Self::new(value, SecurityLabel::trusted())
+    }
+
+    pub fn label(&self) -> SecurityLabel {
+        self.label
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn into_parts(self) -> (T, SecurityLabel) {
+        (self.value, self.label)
+    }
+}
+
+/// Apply output sanitization without promoting trust or declassifying taint.
+pub fn sanitize_tainted_text(
+    provider: &dyn SecurityProvider,
+    value: TaintedValue<String>,
+) -> TaintedValue<String> {
+    let (value, label) = value.into_parts();
+    TaintedValue::new(provider.sanitize_output(&value), label.sanitized())
+}
+
+/// Convenience adapter for text values that enter the egress boundary without
+/// an existing wrapper.
+pub fn sanitize_text(provider: &dyn SecurityProvider, value: &str) -> String {
+    sanitize_tainted_text(provider, TaintedValue::untrusted(value.to_owned()))
+        .into_parts()
+        .0
+}
+
+/// Process complete JSON string values while retaining keys and protocol shape.
+/// Keys are protocol field names, not a channel for arbitrary output text.
+pub fn sanitize_tainted_json(
+    provider: &dyn SecurityProvider,
+    value: TaintedValue<serde_json::Value>,
+) -> TaintedValue<serde_json::Value> {
+    fn sanitize(provider: &dyn SecurityProvider, value: serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::String(value) => {
+                serde_json::Value::String(provider.sanitize_output(&value))
+            }
+            serde_json::Value::Array(values) => serde_json::Value::Array(
+                values
+                    .into_iter()
+                    .map(|value| sanitize(provider, value))
+                    .collect(),
+            ),
+            serde_json::Value::Object(values) => serde_json::Value::Object(
+                values
+                    .into_iter()
+                    .map(|(key, value)| (key, sanitize(provider, value)))
+                    .collect(),
+            ),
+            value => value,
+        }
+    }
+
+    let (value, label) = value.into_parts();
+    TaintedValue::new(sanitize(provider, value), label.sanitized())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::DefaultSecurityProvider;
+
+    #[test]
+    fn typed_value_boundary_preserves_provenance_and_redacts_nested_json() {
+        let provider = DefaultSecurityProvider::new();
+        let value = TaintedValue::untrusted(serde_json::json!({
+            "email": "user@example.com",
+            "nested": ["123-45-6789"],
+        }));
+        assert_eq!(value.label(), SecurityLabel::untrusted());
+
+        let (sanitized, label) = sanitize_tainted_json(&provider, value).into_parts();
+        assert_eq!(label.trust, TrustLevel::Untrusted);
+        assert_eq!(label.taint, TaintLabel::Unknown);
+        assert_eq!(label.sanitization, SanitizationState::Applied);
+        assert_eq!(sanitized["email"], "[REDACTED:EMAIL]");
+        assert_eq!(sanitized["nested"][0], "[REDACTED:SSN]");
+    }
+
+    #[test]
+    fn redaction_does_not_declassify_secrets_or_grant_instruction_authority() {
+        let value = TaintedValue::new(
+            "user@example.com".to_string(),
+            SecurityLabel {
+                taint: TaintLabel::Secret,
+                ..SecurityLabel::untrusted()
+            },
+        );
+        let sanitized = sanitize_tainted_text(&DefaultSecurityProvider::new(), value);
+        assert_eq!(sanitized.label().trust, TrustLevel::Untrusted);
+        assert_eq!(sanitized.label().taint, TaintLabel::Secret);
+        assert_eq!(sanitized.label().sanitization, SanitizationState::Applied);
+        assert_eq!(sanitized.value(), "[REDACTED:EMAIL]");
+    }
+
+    #[test]
+    fn value_debug_never_exposes_content() {
+        let value = TaintedValue::trusted("private-canary".to_string());
+        assert_eq!(value.label(), SecurityLabel::trusted());
+        assert!(!format!("{value:?}").contains("private-canary"));
+    }
+}

--- a/core/src/tools/invocation.rs
+++ b/core/src/tools/invocation.rs
@@ -225,6 +225,48 @@ impl ToolInvocation {
             recent_tools: Vec::new(),
         }
     }
+
+    /// Derive a replay-stable identity for this logical tool request.
+    ///
+    /// The transport `id` is intentionally excluded: providers and nested
+    /// orchestrators may assign a fresh delivery id while retrying the same
+    /// name/arguments at the same scope. The caller still owns the ledger that
+    /// decides whether this identity is currently claimable or completed.
+    pub(crate) fn idempotency_identity(
+        &self,
+        scope: Option<&str>,
+    ) -> Result<
+        crate::execution_identity::ExecutionIdentityV1,
+        crate::execution_identity::ExecutionIdentityError,
+    > {
+        let origin = match self.origin {
+            InvocationOrigin::Agent => "agent",
+            InvocationOrigin::Nested => "nested",
+            InvocationOrigin::RuntimeInternal => "runtime_internal",
+            InvocationOrigin::HostDirect(HostDirectPolicy::TrustedControlPlane) => {
+                "host_direct_trusted"
+            }
+            InvocationOrigin::HostDirect(HostDirectPolicy::GovernedControlPlane) => {
+                "host_direct_governed"
+            }
+            InvocationOrigin::HostDirectNested(HostDirectPolicy::TrustedControlPlane) => {
+                "host_direct_nested_trusted"
+            }
+            InvocationOrigin::HostDirectNested(HostDirectPolicy::GovernedControlPlane) => {
+                "host_direct_nested_governed"
+            }
+        };
+        crate::execution_identity::ExecutionIdentityV1::derive(
+            crate::execution_identity::TOOL_INVOCATION_IDENTITY_DOMAIN_V1,
+            &serde_json::json!({
+                "scope": scope,
+                "origin": origin,
+                "name": self.name,
+                "args": self.args,
+                "recent_tools": self.recent_tools,
+            }),
+        )
+    }
 }
 
 /// Execution boundary used by orchestrator tools instead of a raw registry.
@@ -328,6 +370,31 @@ mod tests {
 
         assert!(lifetime.upgrade().is_some());
         assert!(invoker.available_tools().is_empty());
+    }
+
+    #[test]
+    fn tool_identity_is_stable_across_delivery_ids() {
+        let first = ToolInvocation::agent(
+            "delivery-a",
+            "read",
+            serde_json::json!({"path": "src/lib.rs"}),
+            vec!["batch".to_string()],
+        );
+        let second = ToolInvocation::agent(
+            "delivery-b",
+            "read",
+            serde_json::json!({"path": "src/lib.rs"}),
+            vec!["batch".to_string()],
+        );
+
+        assert_eq!(
+            first.idempotency_identity(Some("session-1")).unwrap(),
+            second.idempotency_identity(Some("session-1")).unwrap()
+        );
+        assert_ne!(
+            first.idempotency_identity(Some("session-1")).unwrap(),
+            first.idempotency_identity(Some("session-2")).unwrap()
+        );
     }
 
     #[test]

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -904,7 +904,7 @@ impl TaskExecutor {
             }
         }
         if let Some(provider) = child_security_provider.as_deref() {
-            output = provider.sanitize_output(&output);
+            output = crate::security::sanitize_text(provider, &output);
             if let Some(value) = structured.take() {
                 let sanitized = output_schema.as_ref().map_or_else(
                     || sanitize_task_json(provider, &value),

--- a/core/src/tools/task/result_projection.rs
+++ b/core/src/tools/task/result_projection.rs
@@ -106,7 +106,7 @@ pub(super) fn sanitize_task_json(
 ) -> serde_json::Value {
     match value {
         serde_json::Value::String(value) => {
-            serde_json::Value::String(provider.sanitize_output(value))
+            serde_json::Value::String(crate::security::sanitize_text(provider, value))
         }
         serde_json::Value::Array(values) => serde_json::Value::Array(
             values
@@ -134,7 +134,7 @@ pub(super) fn sanitize_task_json_with_schema(
 ) -> serde_json::Value {
     match value {
         serde_json::Value::String(value) => {
-            let sanitized = provider.sanitize_output(value);
+            let sanitized = crate::security::sanitize_text(provider, value);
             if sanitized != *value && schema_authorizes_literal(schema, value) {
                 serde_json::Value::String(value.clone())
             } else {


### PR DESCRIPTION
Add the next P3/KRN-5 boundary without introducing a foreign runtime or a second ledger.

- add canonical, domain-separated ExecutionIdentityV1 with replay validation
- derive stable model-call and Tool invocation identities at middleware/evidence boundaries
- add typed trust, taint, and sanitization labels that never declassify values
- route model, tool, task, command, event, and structured JSON egress through the typed sanitizer

Validation:
- cargo fmt --all -- --check
- cargo check -p a3s-code-core
- focused tests: execution_identity (3), security (32), agent::llm_invoker (14), tools::invocation (5), tools::task (118)
