### PR TITLE
refactor(core): bind replay identities to execution ledgers

### DIFF
--- a/core/src/evaluation/supervision.rs
+++ b/core/src/evaluation/supervision.rs
@@ -203,7 +203,7 @@ struct SupervisorState {
     /// Claims that have been admitted in the durable ledger and still need a
     /// terminal completion receipt. Values are request digests so a stale
     /// watcher can never remove a newer takeover claim.
-    ledger_claims: HashMap<String, String>,
+    ledger_claims: HashMap<String, crate::execution_identity::ExecutionClaimV1>,
 }
 
 struct DispatchReservation {
@@ -357,7 +357,11 @@ impl EvaluationSupervisor {
         self.cancel();
         let claims = {
             let mut state = lock_state(&self.state);
-            let claims = state.ledger_claims.drain().collect::<Vec<_>>();
+            let claims = state
+                .ledger_claims
+                .drain()
+                .map(|(_, claim)| claim)
+                .collect::<Vec<_>>();
             state.in_flight.clear();
             state.last_dispatch_ms.clear();
             state.admitting.clear();
@@ -365,13 +369,13 @@ impl EvaluationSupervisor {
             claims
         };
         if let Some(ledger) = &self.dispatch_ledger {
-            for (dispatch_id, request_digest) in claims {
+            for claim in claims {
                 if let Err(error) = ledger
-                    .release(&dispatch_id, &request_digest, &self.owner_id)
+                    .release(claim.record_id(), claim.ledger_key(), claim.owner_id())
                     .await
                 {
                     tracing::warn!(
-                        dispatch_id = %dispatch_id,
+                        dispatch_id = %claim.record_id(),
                         error = %error,
                         "failed to release evaluation dispatch claim during shutdown"
                     );
@@ -420,6 +424,20 @@ impl EvaluationSupervisor {
         );
         let dispatch_id = deterministic_auxiliary_id(&fact, &plan.purpose)?;
         let request_digest = dispatch_request_digest(&fact, &plan)?;
+        let execution_identity =
+            dispatch_execution_identity(&fact, &plan, &dispatch_id, &request_digest)?;
+        let claim = crate::execution_identity::ExecutionClaimV1::new(
+            execution_identity,
+            &dispatch_id,
+            &request_digest,
+            &self.owner_id,
+        )
+        .map_err(|error| SupervisorError::DispatchLedger(error.to_string()))?;
+        tracing::trace!(
+            dispatch_id = dispatch_id.as_str(),
+            identity = claim.identity().key(),
+            "Evaluation dispatch execution identity bound to claim ledger"
+        );
         let now = now_ms();
         {
             let mut state = lock_state(&self.state);
@@ -466,15 +484,21 @@ impl EvaluationSupervisor {
         let mut ledger_claimed = false;
         if let Some(ledger) = &self.dispatch_ledger {
             let lease_ms = dispatch_lease_ms(plan.timeout_ms);
-            let claim = ledger
-                .claim(&dispatch_id, &request_digest, &self.owner_id, now, lease_ms)
+            let claim_outcome = ledger
+                .claim(
+                    claim.record_id(),
+                    claim.ledger_key(),
+                    claim.owner_id(),
+                    now,
+                    lease_ms,
+                )
                 .await
                 .map_err(|error| SupervisorError::DispatchLedger(error.to_string()))?;
-            match claim {
+            match claim_outcome {
                 EvaluationDispatchClaimOutcome::Claimed { .. } => {
                     lock_state(&self.state)
                         .ledger_claims
-                        .insert(dispatch_id.clone(), request_digest.clone());
+                        .insert(dispatch_id.clone(), claim.clone());
                     ledger_claimed = true;
                 }
                 EvaluationDispatchClaimOutcome::Completed => {
@@ -515,8 +539,7 @@ impl EvaluationSupervisor {
             Ok(evidence) => evidence,
             Err(error) => {
                 if ledger_claimed {
-                    self.release_dispatch_claim(&dispatch_id, &request_digest)
-                        .await;
+                    self.release_dispatch_claim(&claim).await;
                 }
                 reservation.release();
                 return Err(SupervisorError::Evidence(error.to_string()));
@@ -524,8 +547,7 @@ impl EvaluationSupervisor {
         };
         if self.cancellation.is_cancelled() {
             if ledger_claimed {
-                self.release_dispatch_claim(&dispatch_id, &request_digest)
-                    .await;
+                self.release_dispatch_claim(&claim).await;
             }
             reservation.release();
             return Ok(EvaluationDispatch {
@@ -557,8 +579,7 @@ impl EvaluationSupervisor {
             Ok(handle) => handle,
             Err(error) => {
                 if ledger_claimed {
-                    self.release_dispatch_claim(&dispatch_id, &request_digest)
-                        .await;
+                    self.release_dispatch_claim(&claim).await;
                 }
                 reservation.release();
                 return Err(error.into());
@@ -568,9 +589,7 @@ impl EvaluationSupervisor {
         let state = Arc::clone(&self.state);
         let watcher = handle.clone();
         let ledger = self.dispatch_ledger.clone();
-        let owner_id = self.owner_id.clone();
-        let watcher_dispatch_id = dispatch_id.clone();
-        let watcher_request_digest = request_digest.clone();
+        let watcher_claim = claim.clone();
         let lease_ms = dispatch_lease_ms(plan.timeout_ms);
         tokio::spawn(async move {
             let mut claim_owned = ledger.is_some();
@@ -586,9 +605,9 @@ impl EvaluationSupervisor {
                         _ = heartbeat.tick() => {
                             match ledger
                                 .renew(
-                                    &watcher_dispatch_id,
-                                    &watcher_request_digest,
-                                    &owner_id,
+                                    watcher_claim.record_id(),
+                                    watcher_claim.ledger_key(),
+                                    watcher_claim.owner_id(),
                                     now_ms(),
                                     lease_ms,
                                 )
@@ -604,7 +623,7 @@ impl EvaluationSupervisor {
                                 }
                                 Err(error) => {
                                     tracing::warn!(
-                                        dispatch_id = %watcher_dispatch_id,
+                                        dispatch_id = %watcher_claim.record_id(),
                                         error = %error,
                                         "evaluation dispatch lease renewal failed"
                                     );
@@ -620,9 +639,9 @@ impl EvaluationSupervisor {
                 if claim_owned {
                     let _ = ledger
                         .complete(
-                            &watcher_dispatch_id,
-                            &watcher_request_digest,
-                            &owner_id,
+                            watcher_claim.record_id(),
+                            watcher_claim.ledger_key(),
+                            watcher_claim.owner_id(),
                             now_ms(),
                         )
                         .await;
@@ -639,10 +658,10 @@ impl EvaluationSupervisor {
             }
             if state
                 .ledger_claims
-                .get(&watcher_dispatch_id)
-                .is_some_and(|digest| digest == &watcher_request_digest)
+                .get(watcher_claim.record_id())
+                .is_some_and(|claim| claim.ledger_key() == watcher_claim.ledger_key())
             {
-                state.ledger_claims.remove(&watcher_dispatch_id);
+                state.ledger_claims.remove(watcher_claim.record_id());
             }
         });
         Ok(EvaluationDispatch {
@@ -652,14 +671,14 @@ impl EvaluationSupervisor {
         })
     }
 
-    async fn release_dispatch_claim(&self, dispatch_id: &str, request_digest: &str) {
+    async fn release_dispatch_claim(&self, claim: &crate::execution_identity::ExecutionClaimV1) {
         if let Some(ledger) = &self.dispatch_ledger {
             if let Err(error) = ledger
-                .release(dispatch_id, request_digest, &self.owner_id)
+                .release(claim.record_id(), claim.ledger_key(), claim.owner_id())
                 .await
             {
                 tracing::warn!(
-                    dispatch_id = %dispatch_id,
+                    dispatch_id = %claim.record_id(),
                     error = %error,
                     "failed to release evaluation dispatch claim"
                 );
@@ -668,10 +687,10 @@ impl EvaluationSupervisor {
         let mut state = lock_state(&self.state);
         if state
             .ledger_claims
-            .get(dispatch_id)
-            .is_some_and(|digest| digest == request_digest)
+            .get(claim.record_id())
+            .is_some_and(|current| current.ledger_key() == claim.ledger_key())
         {
-            state.ledger_claims.remove(dispatch_id);
+            state.ledger_claims.remove(claim.record_id());
         }
     }
 }
@@ -703,6 +722,26 @@ fn dispatch_request_digest(
             "fact_digest": &fact.fact_digest,
             "purpose": &plan.purpose,
             "plan_digest": plan_digest,
+        }),
+    )
+    .map_err(|error| SupervisorError::Evidence(error.to_string()))
+}
+
+fn dispatch_execution_identity(
+    fact: &ExecutionFactV1,
+    plan: &EvaluationPlanV1,
+    dispatch_id: &str,
+    request_digest: &str,
+) -> Result<crate::execution_identity::ExecutionIdentityV1, SupervisorError> {
+    crate::execution_identity::ExecutionIdentityV1::derive(
+        crate::execution_identity::EVALUATION_DISPATCH_IDENTITY_DOMAIN_V1,
+        &serde_json::json!({
+            "target": &fact.frame.target,
+            "sequence": fact.sequence,
+            "purpose": &plan.purpose,
+            "fact_digest": &fact.fact_digest,
+            "dispatch_id": dispatch_id,
+            "request_digest": request_digest,
         }),
     )
     .map_err(|error| SupervisorError::Evidence(error.to_string()))

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -13,6 +13,9 @@ use thiserror::Error;
 pub const EXECUTION_IDENTITY_SCHEMA_V1: &str = "a3s.code.execution-identity.v1";
 pub const MODEL_CALL_IDENTITY_DOMAIN_V1: &str = "a3s.code.model-call.identity.v1";
 pub const TOOL_INVOCATION_IDENTITY_DOMAIN_V1: &str = "a3s.code.tool-invocation.identity.v1";
+pub const FLOW_DECISION_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-decision.identity.v1";
+pub const EVALUATION_DISPATCH_IDENTITY_DOMAIN_V1: &str = "a3s.code.evaluation-dispatch.identity.v1";
+pub const EVALUATION_DISPATCH_REQUEST_DOMAIN_V1: &str = "a3s.code.evaluation-dispatch.request.v1";
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ExecutionIdentityError {
@@ -24,6 +27,8 @@ pub enum ExecutionIdentityError {
     InvalidDigest,
     #[error("execution identity digest does not match the value")]
     DigestMismatch,
+    #[error("execution claim field `{0}` is empty")]
+    InvalidClaimField(&'static str),
 }
 
 /// A portable, domain-separated content identity.
@@ -88,6 +93,63 @@ impl ExecutionIdentityV1 {
             return Err(ExecutionIdentityError::DigestMismatch);
         }
         Ok(())
+    }
+}
+
+/// Binds a semantic execution identity to the key used by an existing claim
+/// ledger. The ledger key is kept separate so old persisted receipts remain
+/// replay-compatible while new code can carry one typed identity through all
+/// claim, renewal, completion, and release operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExecutionClaimV1 {
+    identity: ExecutionIdentityV1,
+    record_id: String,
+    ledger_key: String,
+    owner_id: String,
+}
+
+impl ExecutionClaimV1 {
+    pub(crate) fn new(
+        identity: ExecutionIdentityV1,
+        record_id: impl Into<String>,
+        ledger_key: impl Into<String>,
+        owner_id: impl Into<String>,
+    ) -> Result<Self, ExecutionIdentityError> {
+        identity.validate()?;
+        let record_id = record_id.into();
+        let ledger_key = ledger_key.into();
+        let owner_id = owner_id.into();
+        if record_id.is_empty() {
+            return Err(ExecutionIdentityError::InvalidClaimField("record_id"));
+        }
+        if ledger_key.is_empty() {
+            return Err(ExecutionIdentityError::InvalidClaimField("ledger_key"));
+        }
+        if owner_id.is_empty() {
+            return Err(ExecutionIdentityError::InvalidClaimField("owner_id"));
+        }
+        Ok(Self {
+            identity,
+            record_id,
+            ledger_key,
+            owner_id,
+        })
+    }
+
+    pub(crate) fn identity(&self) -> &ExecutionIdentityV1 {
+        &self.identity
+    }
+
+    pub(crate) fn record_id(&self) -> &str {
+        &self.record_id
+    }
+
+    pub(crate) fn ledger_key(&self) -> &str {
+        &self.ledger_key
+    }
+
+    pub(crate) fn owner_id(&self) -> &str {
+        &self.owner_id
     }
 }
 
@@ -170,5 +232,20 @@ mod tests {
             identity.validate_for(&changed),
             Err(ExecutionIdentityError::DigestMismatch)
         ));
+    }
+
+    #[test]
+    fn claim_binds_canonical_identity_to_a_legacy_ledger_key() {
+        let payload = serde_json::json!({"secret": "do-not-persist"});
+        let identity = ExecutionIdentityV1::derive("a3s.test", &payload).unwrap();
+        let claim = ExecutionClaimV1::new(identity.clone(), "dispatch-1", "legacy-hash", "owner-1")
+            .unwrap();
+
+        assert_eq!(claim.identity(), &identity);
+        assert_eq!(claim.record_id(), "dispatch-1");
+        assert_eq!(claim.ledger_key(), "legacy-hash");
+        assert_eq!(claim.owner_id(), "owner-1");
+        let debug = format!("{claim:?}");
+        assert!(!debug.contains("do-not-persist"));
     }
 }

--- a/core/src/flow_graph/decision.rs
+++ b/core/src/flow_graph/decision.rs
@@ -206,12 +206,25 @@ impl FlowDecisionDispatcher {
         }
         let _dispatch_guard = self.dispatch_lock.lock().await;
         let request_hash = request_hash(request)?;
+        let execution_identity = request_identity(request)?;
+        let claim = crate::execution_identity::ExecutionClaimV1::new(
+            execution_identity,
+            &request.decision_id,
+            &request_hash,
+            &self.owner_id,
+        )
+        .map_err(|error| FlowDecisionDispatchError::Ledger(error.to_string()))?;
+        tracing::trace!(
+            decision_id = request.decision_id.as_str(),
+            identity = claim.identity().key(),
+            "Flow decision execution identity bound to claim ledger"
+        );
         match self
             .ledger
             .claim(
-                &request.decision_id,
-                &request_hash,
-                &self.owner_id,
+                claim.record_id(),
+                claim.ledger_key(),
+                claim.owner_id(),
                 now_ms(),
                 self.lease_ms,
             )
@@ -249,9 +262,9 @@ impl FlowDecisionDispatcher {
                 _ = heartbeat.tick() => {
                     let renewed = self.ledger
                         .renew(
-                            &request.decision_id,
-                            &request_hash,
-                            &self.owner_id,
+                            claim.record_id(),
+                            claim.ledger_key(),
+                            claim.owner_id(),
                             now_ms(),
                             self.lease_ms,
                         )
@@ -269,7 +282,7 @@ impl FlowDecisionDispatcher {
         if let Err(error) = submission_result {
             if let Err(release_error) = self
                 .ledger
-                .release(&request.decision_id, &request_hash, &self.owner_id)
+                .release(claim.record_id(), claim.ledger_key(), claim.owner_id())
                 .await
             {
                 tracing::warn!(decision_id = request.decision_id, error = %release_error, "failed to release Flow decision claim");
@@ -278,9 +291,9 @@ impl FlowDecisionDispatcher {
         }
         self.ledger
             .complete(
-                &request.decision_id,
-                &request_hash,
-                &self.owner_id,
+                claim.record_id(),
+                claim.ledger_key(),
+                claim.owner_id(),
                 now_ms(),
             )
             .await
@@ -414,6 +427,16 @@ fn request_hash(request: &FlowDecisionRequest) -> Result<String, FlowDecisionDis
         .map_err(|error| FlowDecisionDispatchError::Ledger(error.to_string()))
 }
 
+fn request_identity(
+    request: &FlowDecisionRequest,
+) -> Result<crate::execution_identity::ExecutionIdentityV1, FlowDecisionDispatchError> {
+    crate::execution_identity::ExecutionIdentityV1::derive(
+        crate::execution_identity::FLOW_DECISION_IDENTITY_DOMAIN_V1,
+        request,
+    )
+    .map_err(|error| FlowDecisionDispatchError::Ledger(error.to_string()))
+}
+
 fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -457,6 +480,26 @@ mod tests {
                 output: Value::Null,
             },
         }
+    }
+
+    #[test]
+    fn flow_claim_keeps_legacy_ledger_key_while_binding_typed_identity() {
+        let request = request("production");
+        let legacy = request_hash(&request).unwrap();
+        let identity = request_identity(&request).unwrap();
+        let claim = crate::execution_identity::ExecutionClaimV1::new(
+            identity.clone(),
+            &request.decision_id,
+            &legacy,
+            "owner-1",
+        )
+        .unwrap();
+
+        assert_eq!(legacy.len(), 64);
+        assert!(!legacy.starts_with("sha256:"));
+        assert_eq!(claim.ledger_key(), legacy);
+        assert_ne!(claim.identity().key(), legacy);
+        claim.identity().validate_for(&request).unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Preserve existing Flow and evaluation ledger keys while carrying one typed `ExecutionClaimV1` through claim, renewal, completion, and release.

Canonical semantic identities are derived, validated, and traced without persisting request or prompt plaintext. Existing deterministic Flow and evaluation keys remain unchanged so historical receipts and replay behavior stay compatible.

Validation:
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p a3s-code-core`
- Flow dispatcher tests: 14 passed
- Evaluation supervisor tests: 5 passed
- Execution identity tests: 4 passed
