### PR TITLE
feat(core): persist evidence-bound execution result receipts

### DIFF
--- a/core/src/evaluation/dispatch_ledger.rs
+++ b/core/src/evaluation/dispatch_ledger.rs
@@ -1,12 +1,13 @@
 //! Durable, provider-neutral dispatch claims for auxiliary evaluations.
 //!
-//! The ledger records only an evaluator dispatch identity and its lease.  It
-//! does not record prompts, rubric decisions, tenant data, or business audit
-//! state.  A host may use the in-memory implementation for a process-scoped
-//! supervisor or the file implementation when replay protection must survive
-//! a restart.
+//! The ledger records only an evaluator dispatch identity, its lease, and an
+//! optional digest-only terminal result receipt. It does not record prompts,
+//! rubric decisions, tenant data, or business audit state. A host may use the
+//! in-memory implementation for a process-scoped supervisor or the file
+//! implementation when replay protection must survive a restart.
 
 use super::identity::validate_digest;
+use crate::execution_identity::{ExecutionIdentityV1, ExecutionResultReceiptV1};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -57,6 +58,25 @@ pub trait EvaluationDispatchLedger: Send + Sync {
         lease_ms: u64,
     ) -> Result<EvaluationDispatchClaimOutcome, EvaluationDispatchLedgerError>;
 
+    /// Claim a dispatch while binding its canonical execution identity. The
+    /// default keeps third-party ledgers source-compatible; built-in ledgers
+    /// persist and fence on the identity.
+    async fn claim_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<EvaluationDispatchClaimOutcome, EvaluationDispatchLedgerError> {
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.claim(dispatch_id, request_digest, owner_id, now_ms, lease_ms)
+            .await
+    }
+
     async fn renew(
         &self,
         dispatch_id: &str,
@@ -66,6 +86,24 @@ pub trait EvaluationDispatchLedger: Send + Sync {
         lease_ms: u64,
     ) -> Result<bool, EvaluationDispatchLedgerError>;
 
+    /// Renew a claim only when both its legacy ledger key and canonical
+    /// identity still match the admitted worker.
+    async fn renew_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<bool, EvaluationDispatchLedgerError> {
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.renew(dispatch_id, request_digest, owner_id, now_ms, lease_ms)
+            .await
+    }
+
     async fn complete(
         &self,
         dispatch_id: &str,
@@ -74,12 +112,58 @@ pub trait EvaluationDispatchLedger: Send + Sync {
         completed_at_ms: u64,
     ) -> Result<(), EvaluationDispatchLedgerError>;
 
+    /// Complete a claim with a bounded digest-only result receipt.
+    async fn complete_with_receipt(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        receipt: &ExecutionResultReceiptV1,
+        completed_at_ms: u64,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        receipt
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("result_receipt"))?;
+        if &receipt.identity != identity {
+            return Err(EvaluationDispatchLedgerError::Conflict);
+        }
+        self.complete(dispatch_id, request_digest, owner_id, completed_at_ms)
+            .await
+    }
+
     async fn release(
         &self,
         dispatch_id: &str,
         request_digest: &str,
         owner_id: &str,
     ) -> Result<(), EvaluationDispatchLedgerError>;
+
+    /// Release a claim only when its canonical identity also matches. Legacy
+    /// implementations fall back to the existing request/owner fence.
+    async fn release_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.release(dispatch_id, request_digest, owner_id).await
+    }
+
+    /// Read the terminal receipt when the ledger supports result persistence.
+    async fn completed_receipt(
+        &self,
+        _dispatch_id: &str,
+    ) -> Result<Option<ExecutionResultReceiptV1>, EvaluationDispatchLedgerError> {
+        Ok(None)
+    }
 
     async fn prune_completed(&self, before_ms: u64)
         -> Result<usize, EvaluationDispatchLedgerError>;
@@ -96,6 +180,8 @@ enum DispatchClaimStatus {
 #[serde(deny_unknown_fields)]
 struct DispatchClaimRecord {
     request_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    execution_identity: Option<ExecutionIdentityV1>,
     status: DispatchClaimStatus,
     owner_id: String,
     lease_expires_at_ms: u64,
@@ -103,6 +189,8 @@ struct DispatchClaimRecord {
     created_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     completed_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    result_receipt: Option<ExecutionResultReceiptV1>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -139,6 +227,32 @@ impl EvaluationDispatchLedger for MemoryEvaluationDispatchLedger {
             &mut records,
             dispatch_id,
             request_digest,
+            None,
+            owner_id,
+            now_ms,
+            lease_ms,
+        )
+    }
+
+    async fn claim_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<EvaluationDispatchClaimOutcome, EvaluationDispatchLedgerError> {
+        validate_claim_args(dispatch_id, request_digest, owner_id, now_ms, lease_ms)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        let mut records = self.records.lock().await;
+        claim_record(
+            &mut records,
+            dispatch_id,
+            request_digest,
+            Some(identity),
             owner_id,
             now_ms,
             lease_ms,
@@ -159,6 +273,32 @@ impl EvaluationDispatchLedger for MemoryEvaluationDispatchLedger {
             &mut records,
             dispatch_id,
             request_digest,
+            None,
+            owner_id,
+            now_ms,
+            lease_ms,
+        ))
+    }
+
+    async fn renew_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<bool, EvaluationDispatchLedgerError> {
+        validate_claim_args(dispatch_id, request_digest, owner_id, now_ms, lease_ms)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        let mut records = self.records.lock().await;
+        Ok(renew_record(
+            &mut records,
+            dispatch_id,
+            request_digest,
+            Some(identity),
             owner_id,
             now_ms,
             lease_ms,
@@ -178,7 +318,40 @@ impl EvaluationDispatchLedger for MemoryEvaluationDispatchLedger {
             &mut records,
             dispatch_id,
             request_digest,
+            None,
             owner_id,
+            None,
+            completed_at_ms,
+        )
+    }
+
+    async fn complete_with_receipt(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        receipt: &ExecutionResultReceiptV1,
+        completed_at_ms: u64,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        validate_identity_args(dispatch_id, request_digest, owner_id)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        receipt
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("result_receipt"))?;
+        if &receipt.identity != identity {
+            return Err(EvaluationDispatchLedgerError::Conflict);
+        }
+        let mut records = self.records.lock().await;
+        complete_record(
+            &mut records,
+            dispatch_id,
+            request_digest,
+            Some(identity),
+            owner_id,
+            Some(receipt),
             completed_at_ms,
         )
     }
@@ -191,7 +364,38 @@ impl EvaluationDispatchLedger for MemoryEvaluationDispatchLedger {
     ) -> Result<(), EvaluationDispatchLedgerError> {
         validate_identity_args(dispatch_id, request_digest, owner_id)?;
         let mut records = self.records.lock().await;
-        release_record(&mut records, dispatch_id, request_digest, owner_id)
+        release_record(&mut records, dispatch_id, request_digest, None, owner_id)
+    }
+
+    async fn release_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        validate_identity_args(dispatch_id, request_digest, owner_id)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        let mut records = self.records.lock().await;
+        release_record(
+            &mut records,
+            dispatch_id,
+            request_digest,
+            Some(identity),
+            owner_id,
+        )
+    }
+
+    async fn completed_receipt(
+        &self,
+        dispatch_id: &str,
+    ) -> Result<Option<ExecutionResultReceiptV1>, EvaluationDispatchLedgerError> {
+        let records = self.records.lock().await;
+        Ok(records
+            .get(dispatch_id)
+            .and_then(|record| record.result_receipt.clone()))
     }
 
     async fn prune_completed(
@@ -384,6 +588,7 @@ impl EvaluationDispatchLedger for FileEvaluationDispatchLedger {
                 records,
                 dispatch_id,
                 request_digest,
+                None,
                 owner_id,
                 now_ms,
                 lease_ms,
@@ -406,6 +611,7 @@ impl EvaluationDispatchLedger for FileEvaluationDispatchLedger {
                 records,
                 dispatch_id,
                 request_digest,
+                None,
                 owner_id,
                 now_ms,
                 lease_ms,
@@ -427,7 +633,9 @@ impl EvaluationDispatchLedger for FileEvaluationDispatchLedger {
                 records,
                 dispatch_id,
                 request_digest,
+                None,
                 owner_id,
+                None,
                 completed_at_ms,
             )
         })
@@ -441,8 +649,129 @@ impl EvaluationDispatchLedger for FileEvaluationDispatchLedger {
         owner_id: &str,
     ) -> Result<(), EvaluationDispatchLedgerError> {
         validate_identity_args(dispatch_id, request_digest, owner_id)?;
-        self.mutate(|records| release_record(records, dispatch_id, request_digest, owner_id))
+        self.mutate(|records| release_record(records, dispatch_id, request_digest, None, owner_id))
             .await
+    }
+
+    async fn claim_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<EvaluationDispatchClaimOutcome, EvaluationDispatchLedgerError> {
+        validate_claim_args(dispatch_id, request_digest, owner_id, now_ms, lease_ms)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.mutate(|records| {
+            claim_record(
+                records,
+                dispatch_id,
+                request_digest,
+                Some(identity),
+                owner_id,
+                now_ms,
+                lease_ms,
+            )
+        })
+        .await
+    }
+
+    async fn renew_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        now_ms: u64,
+        lease_ms: u64,
+    ) -> Result<bool, EvaluationDispatchLedgerError> {
+        validate_claim_args(dispatch_id, request_digest, owner_id, now_ms, lease_ms)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.mutate(|records| {
+            Ok(renew_record(
+                records,
+                dispatch_id,
+                request_digest,
+                Some(identity),
+                owner_id,
+                now_ms,
+                lease_ms,
+            ))
+        })
+        .await
+    }
+
+    async fn complete_with_receipt(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        receipt: &ExecutionResultReceiptV1,
+        completed_at_ms: u64,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        validate_identity_args(dispatch_id, request_digest, owner_id)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        receipt
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("result_receipt"))?;
+        if &receipt.identity != identity {
+            return Err(EvaluationDispatchLedgerError::Conflict);
+        }
+        self.mutate(|records| {
+            complete_record(
+                records,
+                dispatch_id,
+                request_digest,
+                Some(identity),
+                owner_id,
+                Some(receipt),
+                completed_at_ms,
+            )
+        })
+        .await
+    }
+
+    async fn release_with_identity(
+        &self,
+        dispatch_id: &str,
+        request_digest: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+    ) -> Result<(), EvaluationDispatchLedgerError> {
+        validate_identity_args(dispatch_id, request_digest, owner_id)?;
+        identity
+            .validate()
+            .map_err(|_| EvaluationDispatchLedgerError::InvalidField("execution_identity"))?;
+        self.mutate(|records| {
+            release_record(
+                records,
+                dispatch_id,
+                request_digest,
+                Some(identity),
+                owner_id,
+            )
+        })
+        .await
+    }
+
+    async fn completed_receipt(
+        &self,
+        dispatch_id: &str,
+    ) -> Result<Option<ExecutionResultReceiptV1>, EvaluationDispatchLedgerError> {
+        Ok(self
+            .read_records()
+            .await?
+            .get(dispatch_id)
+            .and_then(|record| record.result_receipt.clone()))
     }
 
     async fn prune_completed(
@@ -493,6 +822,7 @@ fn claim_record(
     records: &mut BTreeMap<String, DispatchClaimRecord>,
     dispatch_id: &str,
     request_digest: &str,
+    identity: Option<&ExecutionIdentityV1>,
     owner_id: &str,
     now_ms: u64,
     lease_ms: u64,
@@ -504,17 +834,29 @@ fn claim_record(
                 dispatch_id.to_string(),
                 DispatchClaimRecord {
                     request_digest: request_digest.to_string(),
+                    execution_identity: identity.cloned(),
                     status: DispatchClaimStatus::Pending,
                     owner_id: owner_id.to_string(),
                     lease_expires_at_ms,
                     attempts: 1,
                     created_at_ms: now_ms,
                     completed_at_ms: None,
+                    result_receipt: None,
                 },
             );
             Ok(EvaluationDispatchClaimOutcome::Claimed { attempt: 1 })
         }
         Some(record) if record.request_digest != request_digest => {
+            Ok(EvaluationDispatchClaimOutcome::Conflict)
+        }
+        Some(record)
+            if identity.is_some_and(|identity| {
+                record
+                    .execution_identity
+                    .as_ref()
+                    .is_some_and(|record_identity| record_identity != identity)
+            }) =>
+        {
             Ok(EvaluationDispatchClaimOutcome::Conflict)
         }
         Some(record) if record.status == DispatchClaimStatus::Completed => {
@@ -526,6 +868,9 @@ fn claim_record(
             })
         }
         Some(record) => {
+            if record.execution_identity.is_none() {
+                record.execution_identity = identity.cloned();
+            }
             record.owner_id = owner_id.to_string();
             record.lease_expires_at_ms = lease_expires_at_ms;
             record.attempts = record.attempts.saturating_add(1);
@@ -540,6 +885,7 @@ fn renew_record(
     records: &mut BTreeMap<String, DispatchClaimRecord>,
     dispatch_id: &str,
     request_digest: &str,
+    identity: Option<&ExecutionIdentityV1>,
     owner_id: &str,
     now_ms: u64,
     lease_ms: u64,
@@ -548,6 +894,12 @@ fn renew_record(
         return false;
     };
     if record.request_digest != request_digest
+        || identity.is_some_and(|identity| {
+            record
+                .execution_identity
+                .as_ref()
+                .is_some_and(|record_identity| record_identity != identity)
+        })
         || record.status != DispatchClaimStatus::Pending
         || record.owner_id != owner_id
         || record.lease_expires_at_ms <= now_ms
@@ -562,7 +914,9 @@ fn complete_record(
     records: &mut BTreeMap<String, DispatchClaimRecord>,
     dispatch_id: &str,
     request_digest: &str,
+    identity: Option<&ExecutionIdentityV1>,
     owner_id: &str,
+    result_receipt: Option<&ExecutionResultReceiptV1>,
     completed_at_ms: u64,
 ) -> Result<(), EvaluationDispatchLedgerError> {
     let record = records
@@ -571,7 +925,20 @@ fn complete_record(
     if record.request_digest != request_digest {
         return Err(EvaluationDispatchLedgerError::Conflict);
     }
+    if identity.is_some_and(|identity| {
+        record
+            .execution_identity
+            .as_ref()
+            .is_some_and(|record_identity| record_identity != identity)
+    }) {
+        return Err(EvaluationDispatchLedgerError::Conflict);
+    }
     if record.status == DispatchClaimStatus::Completed {
+        if let (Some(expected), Some(actual)) = (record.result_receipt.as_ref(), result_receipt) {
+            if expected != actual {
+                return Err(EvaluationDispatchLedgerError::Conflict);
+            }
+        }
         return Ok(());
     }
     if record.owner_id != owner_id {
@@ -588,6 +955,10 @@ fn complete_record(
     if record.lease_expires_at_ms <= completed_at_ms {
         return Err(EvaluationDispatchLedgerError::Conflict);
     }
+    if let Some(identity) = identity {
+        record.execution_identity = Some(identity.clone());
+    }
+    record.result_receipt = result_receipt.cloned();
     record.status = DispatchClaimStatus::Completed;
     record.lease_expires_at_ms = 0;
     record.completed_at_ms = Some(completed_at_ms);
@@ -598,12 +969,21 @@ fn release_record(
     records: &mut BTreeMap<String, DispatchClaimRecord>,
     dispatch_id: &str,
     request_digest: &str,
+    identity: Option<&ExecutionIdentityV1>,
     owner_id: &str,
 ) -> Result<(), EvaluationDispatchLedgerError> {
     let Some(record) = records.get_mut(dispatch_id) else {
         return Ok(());
     };
-    if record.request_digest != request_digest || record.status == DispatchClaimStatus::Completed {
+    if record.request_digest != request_digest
+        || identity.is_some_and(|identity| {
+            record
+                .execution_identity
+                .as_ref()
+                .is_some_and(|record_identity| record_identity != identity)
+        })
+        || record.status == DispatchClaimStatus::Completed
+    {
         return Ok(());
     }
     if record.owner_id == owner_id {
@@ -669,6 +1049,25 @@ async fn read_records_from_path(
         validate_text("dispatch_id", dispatch_id)?;
         validate_digest(&record.request_digest)
             .map_err(|_| EvaluationDispatchLedgerError::InvalidField("request_digest"))?;
+        if let Some(identity) = &record.execution_identity {
+            identity.validate().map_err(|_| {
+                EvaluationDispatchLedgerError::Corrupt("execution identity is invalid".to_string())
+            })?;
+        }
+        if let Some(receipt) = &record.result_receipt {
+            receipt.validate().map_err(|_| {
+                EvaluationDispatchLedgerError::Corrupt("result receipt is invalid".to_string())
+            })?;
+            if record
+                .execution_identity
+                .as_ref()
+                .is_some_and(|identity| identity != &receipt.identity)
+            {
+                return Err(EvaluationDispatchLedgerError::Corrupt(
+                    "result receipt identity does not match claim".to_string(),
+                ));
+            }
+        }
         if !record.owner_id.is_empty() {
             validate_text("owner_id", &record.owner_id)?;
         }
@@ -685,6 +1084,7 @@ async fn read_records_from_path(
         match record.status {
             DispatchClaimStatus::Pending
                 if record.completed_at_ms.is_some()
+                    || record.result_receipt.is_some()
                     || (record.owner_id.is_empty() && record.lease_expires_at_ms != 0)
                     || (!record.owner_id.is_empty() && record.lease_expires_at_ms == 0) =>
             {
@@ -709,4 +1109,100 @@ async fn read_records_from_path(
 
 fn storage_error(operation: &str, error: impl std::fmt::Display) -> EvaluationDispatchLedgerError {
     EvaluationDispatchLedgerError::Storage(format!("{operation}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution_identity::{ExecutionResultOutcomeV1, EXECUTION_RESULT_RECEIPT_SCHEMA_V1};
+
+    fn identity(domain: &str) -> ExecutionIdentityV1 {
+        ExecutionIdentityV1::derive(domain, &serde_json::json!({"request": "bounded"})).unwrap()
+    }
+
+    fn receipt(identity: ExecutionIdentityV1) -> ExecutionResultReceiptV1 {
+        ExecutionResultReceiptV1 {
+            schema: EXECUTION_RESULT_RECEIPT_SCHEMA_V1.to_string(),
+            identity,
+            evidence_digest:
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_string(),
+            outcome: ExecutionResultOutcomeV1::Succeeded,
+            result_digest: Some(
+                "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+            ),
+            result_bytes: 1,
+        }
+    }
+
+    #[test]
+    fn legacy_claim_record_deserializes_without_identity_or_receipt() {
+        let value = serde_json::json!({
+            "request_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "status": "pending",
+            "owner_id": "owner-1",
+            "lease_expires_at_ms": 101,
+            "attempts": 1,
+            "created_at_ms": 1
+        });
+        let record: DispatchClaimRecord = serde_json::from_value(value).unwrap();
+        assert!(record.execution_identity.is_none());
+        assert!(record.result_receipt.is_none());
+    }
+
+    #[tokio::test]
+    async fn identity_fences_claim_renewal_and_terminal_receipt() {
+        let ledger = MemoryEvaluationDispatchLedger::new();
+        let canonical = identity("a3s.test.identity");
+        let wrong = identity("a3s.test.other");
+        let request_digest =
+            "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+        assert!(matches!(
+            ledger
+                .claim_with_identity("dispatch-1", request_digest, &canonical, "owner-1", 1, 100)
+                .await
+                .unwrap(),
+            EvaluationDispatchClaimOutcome::Claimed { attempt: 1 }
+        ));
+        assert!(!ledger
+            .renew_with_identity("dispatch-1", request_digest, &wrong, "owner-1", 2, 100)
+            .await
+            .unwrap());
+        assert!(ledger
+            .renew_with_identity("dispatch-1", request_digest, &canonical, "owner-1", 2, 100)
+            .await
+            .unwrap());
+
+        let result = receipt(canonical.clone());
+        ledger
+            .complete_with_receipt(
+                "dispatch-1",
+                request_digest,
+                &canonical,
+                "owner-1",
+                &result,
+                3,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            ledger.completed_receipt("dispatch-1").await.unwrap(),
+            Some(result)
+        );
+        assert!(matches!(
+            ledger
+                .complete_with_receipt(
+                    "dispatch-1",
+                    request_digest,
+                    &wrong,
+                    "owner-1",
+                    &receipt(wrong.clone()),
+                    4,
+                )
+                .await,
+            Err(EvaluationDispatchLedgerError::Conflict)
+        ));
+    }
 }

--- a/core/src/evaluation/mod.rs
+++ b/core/src/evaluation/mod.rs
@@ -15,6 +15,10 @@ mod protocol;
 mod result;
 mod supervision;
 
+pub use crate::execution_identity::{
+    ExecutionIdentityV1, ExecutionResultOutcomeV1, ExecutionResultReceiptV1,
+    EXECUTION_RESULT_MAX_BYTES, EXECUTION_RESULT_RECEIPT_SCHEMA_V1,
+};
 pub use auxiliary_run::{
     AuxiliaryCapabilityProfileV1, AuxiliaryExecutor, AuxiliaryModeV1, AuxiliaryRunContextV1,
     AuxiliaryRunError, AuxiliaryRunHandle, AuxiliaryRunOutputV1, AuxiliaryRunService,

--- a/core/src/evaluation/supervision.rs
+++ b/core/src/evaluation/supervision.rs
@@ -2,7 +2,7 @@
 
 use super::auxiliary_run::{
     AuxiliaryCapabilityProfileV1, AuxiliaryModeV1, AuxiliaryRunError, AuxiliaryRunHandle,
-    AuxiliaryRunService, AuxiliaryRunSpecV1,
+    AuxiliaryRunOutputV1, AuxiliaryRunService, AuxiliaryRunSpecV1,
 };
 use super::dispatch_ledger::{
     EvaluationDispatchClaimOutcome, EvaluationDispatchLedger, EVALUATION_DISPATCH_LEASE_GRACE_MS,
@@ -13,6 +13,9 @@ use super::evidence::{
 };
 use super::identity::{digest_json, ExecutionFrameV1, ExecutionTargetV1};
 use super::journal::{ExecutionFactJournal, ExecutionFactV1, JournalError};
+use crate::execution_identity::{
+    ExecutionClaimV1, ExecutionResultOutcomeV1, ExecutionResultReceiptV1,
+};
 use crate::run::RunEventRecord;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -201,8 +204,9 @@ struct SupervisorState {
     /// hole.
     admitting: HashSet<(ExecutionTargetV1, u64, String)>,
     /// Claims that have been admitted in the durable ledger and still need a
-    /// terminal completion receipt. Values are request digests so a stale
-    /// watcher can never remove a newer takeover claim.
+    /// terminal completion receipt. The typed claim keeps canonical identity,
+    /// the legacy request digest, and owner together so a stale watcher can
+    /// never remove a newer takeover claim.
     ledger_claims: HashMap<String, crate::execution_identity::ExecutionClaimV1>,
 }
 
@@ -371,7 +375,12 @@ impl EvaluationSupervisor {
         if let Some(ledger) = &self.dispatch_ledger {
             for claim in claims {
                 if let Err(error) = ledger
-                    .release(claim.record_id(), claim.ledger_key(), claim.owner_id())
+                    .release_with_identity(
+                        claim.record_id(),
+                        claim.ledger_key(),
+                        claim.identity(),
+                        claim.owner_id(),
+                    )
                     .await
                 {
                     tracing::warn!(
@@ -485,9 +494,10 @@ impl EvaluationSupervisor {
         if let Some(ledger) = &self.dispatch_ledger {
             let lease_ms = dispatch_lease_ms(plan.timeout_ms);
             let claim_outcome = ledger
-                .claim(
+                .claim_with_identity(
                     claim.record_id(),
                     claim.ledger_key(),
+                    claim.identity(),
                     claim.owner_id(),
                     now,
                     lease_ms,
@@ -571,6 +581,7 @@ impl EvaluationSupervisor {
         spec.timeout_ms = plan.timeout_ms;
         spec.output_schema = plan.output_schema;
         spec.id = dispatch_id.clone();
+        let evidence_digest = evidence.snapshot_digest.clone();
         let handle = match self
             .auxiliary
             .spawn(spec, evidence, Some(self.cancellation.child_token()))
@@ -599,14 +610,15 @@ impl EvaluationSupervisor {
                 // `interval` ticks immediately once; the initial claim already
                 // has a full lease, so the first renewal can wait one period.
                 heartbeat.tick().await;
-                loop {
+                let result = loop {
                     tokio::select! {
-                        _ = watcher.wait() => break,
+                        result = watcher.wait() => break result,
                         _ = heartbeat.tick() => {
                             match ledger
-                                .renew(
+                                .renew_with_identity(
                                     watcher_claim.record_id(),
                                     watcher_claim.ledger_key(),
+                                    watcher_claim.identity(),
                                     watcher_claim.owner_id(),
                                     now_ms(),
                                     lease_ms,
@@ -632,19 +644,38 @@ impl EvaluationSupervisor {
                         }
                     }
                     if !claim_owned {
-                        let _ = watcher.wait().await;
-                        break;
+                        break watcher.wait().await;
                     }
-                }
+                };
                 if claim_owned {
-                    let _ = ledger
-                        .complete(
-                            watcher_claim.record_id(),
-                            watcher_claim.ledger_key(),
-                            watcher_claim.owner_id(),
-                            now_ms(),
-                        )
-                        .await;
+                    match result_receipt(&watcher_claim, &evidence_digest, &result) {
+                        Ok(receipt) => {
+                            if let Err(error) = ledger
+                                .complete_with_receipt(
+                                    watcher_claim.record_id(),
+                                    watcher_claim.ledger_key(),
+                                    watcher_claim.identity(),
+                                    watcher_claim.owner_id(),
+                                    &receipt,
+                                    now_ms(),
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    dispatch_id = %watcher_claim.record_id(),
+                                    error = %error,
+                                    "failed to persist evaluation result receipt"
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                dispatch_id = %watcher_claim.record_id(),
+                                error = %error,
+                                "failed to build evaluation result receipt"
+                            );
+                        }
+                    }
                 }
             } else {
                 let _ = watcher.wait().await;
@@ -674,7 +705,12 @@ impl EvaluationSupervisor {
     async fn release_dispatch_claim(&self, claim: &crate::execution_identity::ExecutionClaimV1) {
         if let Some(ledger) = &self.dispatch_ledger {
             if let Err(error) = ledger
-                .release(claim.record_id(), claim.ledger_key(), claim.owner_id())
+                .release_with_identity(
+                    claim.record_id(),
+                    claim.ledger_key(),
+                    claim.identity(),
+                    claim.owner_id(),
+                )
                 .await
             {
                 tracing::warn!(
@@ -745,6 +781,31 @@ fn dispatch_execution_identity(
         }),
     )
     .map_err(|error| SupervisorError::Evidence(error.to_string()))
+}
+
+fn result_receipt(
+    claim: &ExecutionClaimV1,
+    evidence_digest: &str,
+    result: &Result<AuxiliaryRunOutputV1, AuxiliaryRunError>,
+) -> Result<ExecutionResultReceiptV1, crate::execution_identity::ExecutionIdentityError> {
+    match result {
+        Ok(output) => claim.result_receipt(
+            evidence_digest,
+            ExecutionResultOutcomeV1::Succeeded,
+            Some(output.output_digest.clone()),
+            output.output_bytes,
+        ),
+        Err(AuxiliaryRunError::Cancelled) => claim.result_receipt(
+            evidence_digest,
+            ExecutionResultOutcomeV1::Cancelled,
+            None,
+            0,
+        ),
+        Err(AuxiliaryRunError::TimedOut) => {
+            claim.result_receipt(evidence_digest, ExecutionResultOutcomeV1::TimedOut, None, 0)
+        }
+        Err(_) => claim.result_receipt(evidence_digest, ExecutionResultOutcomeV1::Failed, None, 0),
+    }
 }
 
 fn dispatch_lease_ms(timeout_ms: Option<u64>) -> u64 {

--- a/core/src/evaluation/supervision_tests.rs
+++ b/core/src/evaluation/supervision_tests.rs
@@ -7,6 +7,7 @@ use crate::evaluation::evidence::RunEvidenceReader;
 use crate::evaluation::evidence::{EvidenceError, EvidenceReadRequestV1};
 use crate::evaluation::identity::ExecutionTargetV1;
 use crate::evaluation::journal::InMemoryExecutionFactJournal;
+use crate::evaluation::{EvaluationDispatchLedger, InMemoryEvaluationDispatchLedger};
 use crate::run::InMemoryRunStore;
 use async_trait::async_trait;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -84,6 +85,60 @@ async fn policy_is_boundary_and_replay_safe() {
         .await
         .unwrap();
     assert_eq!(replay.outcome, EvaluationDispatchOutcome::Ignored);
+}
+
+#[tokio::test]
+async fn dispatch_persists_an_evidence_bound_result_receipt() {
+    let runs = Arc::new(InMemoryRunStore::new());
+    let run = runs
+        .create_run_with_id("receipt-run".into(), "receipt-session", "prompt")
+        .await;
+    let target = ExecutionTargetV1::new("receipt-session", &run.id);
+    let ledger = Arc::new(InMemoryEvaluationDispatchLedger::new());
+    let supervisor = EvaluationSupervisor::with_dispatch_ledger(
+        Arc::new(InMemoryExecutionFactJournal::new()),
+        Arc::new(RunEvidenceReader::new(runs)),
+        Arc::new(InMemoryAuxiliaryRunService::new(Arc::new(
+            RecordingExecutor,
+        ))),
+        Arc::new(TurnPolicy),
+        ledger.clone(),
+    );
+    let record = RunEventRecord {
+        sequence: 0,
+        timestamp_ms: 1,
+        event: AgentEvent::TurnEnd {
+            turn: 1,
+            usage: crate::llm::TokenUsage::default(),
+        },
+    };
+    let dispatched = supervisor
+        .observe_event(ExecutionFrameV1::root(target), &record)
+        .await
+        .unwrap();
+    let handle = dispatched.handle.unwrap();
+    let dispatch_id = handle.id().to_string();
+    handle.wait().await.unwrap();
+
+    let receipt = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if let Some(receipt) = ledger.completed_receipt(&dispatch_id).await.unwrap() {
+                break receipt;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("evaluation watcher must persist a terminal receipt");
+    receipt.validate().unwrap();
+    assert_eq!(
+        receipt.identity.domain,
+        crate::execution_identity::EVALUATION_DISPATCH_IDENTITY_DOMAIN_V1
+    );
+    assert!(receipt.evidence_digest.starts_with("sha256:"));
+    assert!(receipt.result_digest.is_some());
+    assert!(receipt.result_bytes > 0);
+    assert!(!format!("{receipt:?}").contains("inspect the bounded evidence"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -16,6 +16,8 @@ pub const TOOL_INVOCATION_IDENTITY_DOMAIN_V1: &str = "a3s.code.tool-invocation.i
 pub const FLOW_DECISION_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-decision.identity.v1";
 pub const EVALUATION_DISPATCH_IDENTITY_DOMAIN_V1: &str = "a3s.code.evaluation-dispatch.identity.v1";
 pub const EVALUATION_DISPATCH_REQUEST_DOMAIN_V1: &str = "a3s.code.evaluation-dispatch.request.v1";
+pub const EXECUTION_RESULT_RECEIPT_SCHEMA_V1: &str = "a3s.code.execution-result-receipt.v1";
+pub const EXECUTION_RESULT_MAX_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ExecutionIdentityError {
@@ -29,6 +31,10 @@ pub enum ExecutionIdentityError {
     DigestMismatch,
     #[error("execution claim field `{0}` is empty")]
     InvalidClaimField(&'static str),
+    #[error("execution result receipt field `{0}` is invalid")]
+    InvalidReceiptField(&'static str),
+    #[error("execution result receipt exceeds its byte limit")]
+    ReceiptSizeLimit,
 }
 
 /// A portable, domain-separated content identity.
@@ -96,6 +102,57 @@ impl ExecutionIdentityV1 {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionResultOutcomeV1 {
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+}
+
+/// A bounded, digest-only terminal result bound to one execution claim and
+/// the evidence snapshot consumed by that execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExecutionResultReceiptV1 {
+    pub schema: String,
+    pub identity: ExecutionIdentityV1,
+    pub evidence_digest: String,
+    pub outcome: ExecutionResultOutcomeV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<String>,
+    pub result_bytes: u64,
+}
+
+impl ExecutionResultReceiptV1 {
+    pub fn validate(&self) -> Result<(), ExecutionIdentityError> {
+        if self.schema != EXECUTION_RESULT_RECEIPT_SCHEMA_V1 {
+            return Err(ExecutionIdentityError::InvalidReceiptField("schema"));
+        }
+        self.identity.validate()?;
+        validate_digest(&self.evidence_digest)
+            .map_err(|_| ExecutionIdentityError::InvalidReceiptField("evidence_digest"))?;
+        if self.result_bytes > EXECUTION_RESULT_MAX_BYTES {
+            return Err(ExecutionIdentityError::ReceiptSizeLimit);
+        }
+        match (&self.result_digest, self.result_bytes, self.outcome) {
+            (Some(digest), bytes, ExecutionResultOutcomeV1::Succeeded) => {
+                validate_digest(digest)
+                    .map_err(|_| ExecutionIdentityError::InvalidReceiptField("result_digest"))?;
+                if bytes == 0 {
+                    return Err(ExecutionIdentityError::InvalidReceiptField("result_bytes"));
+                }
+            }
+            (None, 0, ExecutionResultOutcomeV1::Failed)
+            | (None, 0, ExecutionResultOutcomeV1::Cancelled)
+            | (None, 0, ExecutionResultOutcomeV1::TimedOut) => {}
+            _ => return Err(ExecutionIdentityError::InvalidReceiptField("outcome")),
+        }
+        Ok(())
+    }
+}
+
 /// Binds a semantic execution identity to the key used by an existing claim
 /// ledger. The ledger key is kept separate so old persisted receipts remain
 /// replay-compatible while new code can carry one typed identity through all
@@ -151,6 +208,25 @@ impl ExecutionClaimV1 {
     pub(crate) fn owner_id(&self) -> &str {
         &self.owner_id
     }
+
+    pub(crate) fn result_receipt(
+        &self,
+        evidence_digest: impl Into<String>,
+        outcome: ExecutionResultOutcomeV1,
+        result_digest: Option<String>,
+        result_bytes: u64,
+    ) -> Result<ExecutionResultReceiptV1, ExecutionIdentityError> {
+        let receipt = ExecutionResultReceiptV1 {
+            schema: EXECUTION_RESULT_RECEIPT_SCHEMA_V1.to_string(),
+            identity: self.identity.clone(),
+            evidence_digest: evidence_digest.into(),
+            outcome,
+            result_digest,
+            result_bytes,
+        };
+        receipt.validate()?;
+        Ok(receipt)
+    }
 }
 
 fn canonicalize(value: serde_json::Value) -> serde_json::Value {
@@ -167,6 +243,20 @@ fn canonicalize(value: serde_json::Value) -> serde_json::Value {
         }
         value => value,
     }
+}
+
+fn validate_digest(value: &str) -> Result<(), ExecutionIdentityError> {
+    let Some(hex) = value.strip_prefix("sha256:") else {
+        return Err(ExecutionIdentityError::InvalidDigest);
+    };
+    if hex.len() != 64
+        || !hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(ExecutionIdentityError::InvalidDigest);
+    }
+    Ok(())
 }
 
 fn validate_domain(domain: &str) -> Result<(), ExecutionIdentityError> {
@@ -247,5 +337,39 @@ mod tests {
         assert_eq!(claim.owner_id(), "owner-1");
         let debug = format!("{claim:?}");
         assert!(!debug.contains("do-not-persist"));
+    }
+
+    #[test]
+    fn result_receipt_is_digest_only_and_bounded() {
+        let identity = ExecutionIdentityV1::derive("a3s.test", &"request").unwrap();
+        let claim =
+            ExecutionClaimV1::new(identity.clone(), "record-1", "legacy-hash", "owner-1").unwrap();
+        let receipt = claim
+            .result_receipt(
+                "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ExecutionResultOutcomeV1::Succeeded,
+                Some(
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        .into(),
+                ),
+                12,
+            )
+            .unwrap();
+        receipt.validate().unwrap();
+        assert_eq!(receipt.identity, identity);
+        assert!(!format!("{receipt:?}").contains("request"));
+
+        let invalid = ExecutionResultReceiptV1 {
+            schema: EXECUTION_RESULT_RECEIPT_SCHEMA_V1.into(),
+            identity: receipt.identity,
+            evidence_digest: receipt.evidence_digest,
+            outcome: ExecutionResultOutcomeV1::Succeeded,
+            result_digest: None,
+            result_bytes: 0,
+        };
+        assert!(matches!(
+            invalid.validate(),
+            Err(ExecutionIdentityError::InvalidReceiptField("outcome"))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- persist canonical execution identity and bounded digest-only result receipts in evaluation dispatch ledgers
- fence stale claim, renewal, release, and completion attempts by identity while preserving legacy request-digest keys
- record evidence snapshot digest, terminal outcome, and optional result digest/byte count without plaintext output
- keep old ledger records replay-compatible and cover supervisor receipt persistence

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p a3s-code-core`
- `cargo test -p a3s-code-core evaluation --lib -- --nocapture` (49 passed)
