### PR TITLE
feat(core): converge scheduler and dynamic workflow plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added scheduler/plan convergence for dynamic workflows. Flow history now
+  projects into the canonical `ExecutionPlan` (including resumed runs),
+  dynamic steps use a cancellation-aware bounded concurrency gate, and
+  standalone adapters can carry a digest-only step identity through the
+  agent-wide scheduler. Session-bound workflows keep the enclosing lease and
+  avoid nested single-slot deadlocks; admission counters are exposed without
+  retaining step input or output.
 - Added identity-bound workflow result convergence. Resumable workflow
   checkpoints and Flow decision ledgers now persist bounded, digest-only
   terminal receipts, fence stale workers across claim/renew/complete/release,

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   decision claims carry bounded, digest-only result receipts tied to canonical
   execution identities; stale or unreadable state fails closed, while legacy
   records remain loadable.
+- **Convergent workflow admission.** Dynamic Flow steps project into the same
+  `ExecutionPlan` used by Code planning, rebuild that plan from complete
+  history on resume, and use a cancellable per-workflow concurrency gate.
+  Standalone Flow adapters can additionally use the agent-wide priority
+  scheduler with a digest-only step identity; session-bound calls retain one
+  outer scheduler lease to avoid nested single-slot deadlocks.
 
 Go consumers must update the module path to
 `github.com/A3S-Lab/Code/sdk/go/v8`. See [CHANGELOG.md](CHANGELOG.md) for the
@@ -1018,8 +1024,13 @@ credentials, refresh, and live session-scoped add/remove operations.
 
 Dynamic workflows can bound independently session-forked structured generation
 with `maxConcurrentGenerations` (1-4); providers without session forking remain
-single-flight. Durable completed-step recovery is bound to the exact run id,
-original query, and step id rather than acting as a cross-run query cache.
+single-flight. Flow step bodies also accept `maxConcurrentSteps` (1-32,
+default 4); waiting is cancellation-aware and starts the sandbox timeout only
+after admission. Every step has a digest-only identity derived from its run,
+step, handler, and bounded input. Durable completed-step recovery is bound to
+the exact run id, original query, and step id rather than acting as a cross-run
+query cache. A resumed run reconstructs its complete plan from durable
+history, so progress does not lose steps emitted before the current process.
 
 Delegated tasks, workflows, and Skill child runs retain the parent sandbox and
 intersect local permission policy with the parent checker. A child auto-approve

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,7 @@ runtime mode. The cross-repository implementation plan is tracked in the
 | `CAR-04` | In progress | Canonical `SessionCheckpointExportV1` payloads bind `SessionSnapshotV1`, optional between-tool-round logical resume evidence, and exact component/aggregate identities; a host-injected `SessionCheckpointExportSink` captures both components from one acknowledged live Run boundary after preceding events and capability-owned effects settle; every new logical checkpoint binds the source Run's exact Code catalog, authority ceiling, and optional Use cursor; recovery pins that complete historical generation before target-Run admission, and the Code Harness restores both components plus an optional exact host capability batch as one visible admission without split store prewrites; common Harness adoption and real provider/Box certification remain | Cloud `A1.6` owns checkpoint identity, immutable-object authorization, external revision fencing, retention, approval, and fork lineage |
 | `CAR-05` | Planned | Pass restart, exact replay, cancellation, hostile Tool output, bounded-content, Secret-redaction, checkpoint, and cleanup conformance through one Cloud-managed Box workload | No direct Code-to-node control path |
 | `WORKFLOW-RESULT1` | Delivered | Resumable workflow checkpoints and Flow decision claims share canonical execution identities and bounded digest-only result receipts; stale or unreadable state fails closed while legacy records remain loadable | Core checkpoint, Flow ledger, restart, takeover, and identity-fencing tests pass; host policy and business retention remain outside Code |
+| `WORKFLOW-SCHED1` | Delivered | Dynamic Flow history projects into the canonical `ExecutionPlan`; step admission shares cancellation and bounded per-workflow quotas, while standalone scheduler leases carry digest-only step identities and delegated tasks use the same identity boundary | Plan identity is stable across status changes; resumed projections retain prior steps; local and global admission tests cover priority, cancellation, serialization, and the max-active=1 nested-deadlock boundary |
 
 Observation precedes mutation: `CAR-02` must provide useful read-only context
 diagnostics before `CAR-03` can reduce any Tool result. The first transform
@@ -271,6 +272,32 @@ the same identity-aware claim, renewal, completion, and release boundary and
 stores a digest-only receipt for an accepted decision. The result receipt is a
 mechanism for replay and fencing; source evidence, review policy, retention, and
 publication decisions remain host responsibilities.
+
+### 3.3.2 Scheduler and plan convergence
+
+Dynamic Flow is now an adapter over the same `ExecutionPlan` used by Code
+planning rather than a second progress model. A complete Flow history can be
+projected into that plan on every inspection and when a resumed observer is
+attached; duplicate lifecycle delivery preserves insertion order and cannot
+regress a terminal status. The plan's definition identity excludes mutable
+status, so retries and restarts retain one stable execution intent while the
+visible progress changes.
+
+Each Flow step crosses a cancellation-aware, bounded local admission gate. Its
+identity is domain-separated from delegated Agent steps and contains only the
+run/step/handler tuple plus the bounded input derivation; scheduler traces and
+leases never retain input or output plaintext. A standalone Flow adapter may
+layer the agent-wide priority/FIFO scheduler on direct script-backed steps.
+Normal Session calls keep the enclosing scheduler lease and let host `task`
+fan-out use its own child admission, which prevents a single-slot scheduler
+from deadlocking on a nested lease. Delegated tasks now pass their canonical
+step identity through that same global scheduler boundary.
+
+The next slice is mixed-generation restart/retry qualification: bind the
+projected plan identity and step identity to a persisted Flow continuation,
+then prove that a changed handler/input or a cancelled parent cannot duplicate
+an already committed side effect. Cloud/Use package ownership, fairness
+policy, and business-level retry decisions remain outside Code.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/dynamic_workflow.rs
+++ b/core/src/dynamic_workflow.rs
@@ -4,7 +4,9 @@
 //! Flow runtime. Flow owns durable replay and step lifecycle; A3S Code's
 //! existing `program` tool remains the sandbox and tool-call boundary.
 
+use crate::execution_identity::{ExecutionIdentityV1, FLOW_STEP_IDENTITY_DOMAIN_V1};
 use crate::llm::{ModelGenerationAdmission, ModelGenerationConcurrency};
+use crate::task_scheduler::{TaskLease, TaskPriority as SchedulerTaskPriority, TaskScheduler};
 use crate::tools::{
     registry_tool_invoker, Tool, ToolContext, ToolInvoker, ToolOutput, ToolRegistry, ToolResult,
 };
@@ -27,9 +29,10 @@ use serde_json::{json, Map, Value};
 use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, OwnedSemaphorePermit, Semaphore};
 
 const DYNAMIC_WORKFLOW_TOOL: &str = "dynamic_workflow";
 const GENERATE_OBJECT_TOOL: &str = "generate_object";
@@ -38,6 +41,10 @@ const TASK_TOOL: &str = "task";
 const PARALLEL_TASK_TOOL: &str = "parallel_task";
 const MAX_INLINE_RETRY_RESUMES: usize = 8;
 const MAX_INLINE_RETRY_DELAY: Duration = Duration::from_secs(5);
+const DEFAULT_MAX_CONCURRENT_STEPS: usize = 4;
+const MAX_MAX_CONCURRENT_STEPS: usize = 32;
+const MAX_FLOW_STEP_ID_BYTES: usize = 256;
+const MAX_FLOW_STEP_INPUT_BYTES: usize = 64 * 1024;
 
 /// Project-relative directory used for durable dynamic workflow history.
 pub const DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH: &str = ".a3s/workflow";
@@ -118,6 +125,132 @@ pub struct DynamicWorkflowScriptLimits {
     /// This orchestration limit is not forwarded to the PTC program sandbox.
     #[serde(default, skip_serializing)]
     pub max_concurrent_generations: Option<usize>,
+    /// Maximum Flow step bodies that may execute concurrently for one run.
+    /// This is an orchestration boundary and is never forwarded to QuickJS.
+    #[serde(default, skip_serializing)]
+    pub max_concurrent_steps: Option<usize>,
+}
+
+/// Point-in-time admission counters for one dynamic workflow runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicWorkflowAdmissionStats {
+    /// Effective per-run step concurrency limit.
+    pub max_concurrent_steps: usize,
+    /// Number of step bodies admitted since this runtime was created.
+    pub admitted_steps: usize,
+    /// Number of step bodies currently holding a local permit.
+    pub active_steps: usize,
+    /// Highest observed active step count.
+    pub peak_active_steps: usize,
+}
+
+#[derive(Clone)]
+struct DynamicStepAdmission {
+    semaphore: Arc<Semaphore>,
+    max_concurrent_steps: usize,
+    admitted_steps: Arc<AtomicUsize>,
+    active_steps: Arc<AtomicUsize>,
+    peak_active_steps: Arc<AtomicUsize>,
+}
+
+impl DynamicStepAdmission {
+    fn new(max_concurrent_steps: usize) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(max_concurrent_steps)),
+            max_concurrent_steps,
+            admitted_steps: Arc::new(AtomicUsize::new(0)),
+            active_steps: Arc::new(AtomicUsize::new(0)),
+            peak_active_steps: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    async fn acquire(
+        &self,
+        identity: ExecutionIdentityV1,
+        cancellation: &tokio_util::sync::CancellationToken,
+    ) -> a3s_flow::Result<DynamicStepLease> {
+        let permit = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                return Err(a3s_flow::FlowError::Runtime(
+                    "dynamic workflow step admission cancelled".to_string(),
+                ));
+            }
+            permit = Arc::clone(&self.semaphore).acquire_owned() => {
+                permit.map_err(|_| a3s_flow::FlowError::Runtime(
+                    "dynamic workflow step admission is closed".to_string(),
+                ))?
+            }
+        };
+        if cancellation.is_cancelled() {
+            drop(permit);
+            return Err(a3s_flow::FlowError::Runtime(
+                "dynamic workflow step admission cancelled".to_string(),
+            ));
+        }
+
+        let active = self.active_steps.fetch_add(1, Ordering::AcqRel) + 1;
+        self.admitted_steps.fetch_add(1, Ordering::Relaxed);
+        let mut observed = self.peak_active_steps.load(Ordering::Acquire);
+        while active > observed {
+            match self.peak_active_steps.compare_exchange(
+                observed,
+                active,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(current) => observed = current,
+            }
+        }
+        tracing::trace!(
+            execution_identity = identity.key(),
+            active_steps = active,
+            max_concurrent_steps = self.max_concurrent_steps,
+            "dynamic workflow step admitted"
+        );
+        Ok(DynamicStepLease {
+            _permit: permit,
+            identity,
+            active_steps: Arc::clone(&self.active_steps),
+            task_lease: None,
+        })
+    }
+
+    fn stats(&self) -> DynamicWorkflowAdmissionStats {
+        DynamicWorkflowAdmissionStats {
+            max_concurrent_steps: self.max_concurrent_steps,
+            admitted_steps: self.admitted_steps.load(Ordering::Acquire),
+            active_steps: self.active_steps.load(Ordering::Acquire),
+            peak_active_steps: self.peak_active_steps.load(Ordering::Acquire),
+        }
+    }
+}
+
+struct DynamicStepLease {
+    _permit: OwnedSemaphorePermit,
+    identity: ExecutionIdentityV1,
+    active_steps: Arc<AtomicUsize>,
+    task_lease: Option<TaskLease>,
+}
+
+impl DynamicStepLease {
+    fn with_task_lease(mut self, task_lease: TaskLease) -> Self {
+        self.task_lease = Some(task_lease);
+        self
+    }
+}
+
+impl Drop for DynamicStepLease {
+    fn drop(&mut self) {
+        let active = self.active_steps.fetch_sub(1, Ordering::AcqRel) - 1;
+        tracing::trace!(
+            execution_identity = self.identity.key(),
+            active_steps = active,
+            "dynamic workflow step admission released"
+        );
+    }
 }
 
 /// Runs A3S Flow workflow and step invocations through a sandboxed PTC script.
@@ -129,6 +262,12 @@ pub struct DynamicWorkflowRuntime {
     allowed_tools: Vec<String>,
     limits: DynamicWorkflowScriptLimits,
     parallel_generation_admission: Option<ModelGenerationAdmission>,
+    step_admission: DynamicStepAdmission,
+    /// Optional global scheduler for runtimes created outside an AgentSession.
+    /// Session-bound callers already hold the enclosing scheduler lease and
+    /// should leave this unset to avoid nested single-slot deadlocks.
+    task_scheduler: Option<Arc<TaskScheduler>>,
+    admit_steps_globally: bool,
 }
 
 impl DynamicWorkflowRuntime {
@@ -151,6 +290,9 @@ impl DynamicWorkflowRuntime {
             allowed_tools,
             limits: DynamicWorkflowScriptLimits::default(),
             parallel_generation_admission: None,
+            step_admission: DynamicStepAdmission::new(DEFAULT_MAX_CONCURRENT_STEPS),
+            task_scheduler: None,
+            admit_steps_globally: false,
         }
     }
 
@@ -166,8 +308,79 @@ impl DynamicWorkflowRuntime {
             .map(|maximum| {
                 ModelGenerationAdmission::new(ModelGenerationConcurrency::bounded(maximum))
             });
+        let step_concurrency = limits
+            .max_concurrent_steps
+            .unwrap_or(DEFAULT_MAX_CONCURRENT_STEPS)
+            .clamp(1, MAX_MAX_CONCURRENT_STEPS);
+        self.step_admission = DynamicStepAdmission::new(step_concurrency);
         self.limits = limits;
         self
+    }
+
+    /// Attach the agent-wide scheduler when this runtime is used as a
+    /// standalone host adapter.
+    ///
+    /// `admit_steps_globally = false` is the correct setting for a runtime
+    /// invoked from an existing AgentSession operation: the parent operation
+    /// already owns the global lease and Flow steps use the local bounded gate.
+    pub fn with_task_scheduler(
+        mut self,
+        scheduler: Arc<TaskScheduler>,
+        admit_steps_globally: bool,
+    ) -> Self {
+        self.task_scheduler = Some(scheduler);
+        self.admit_steps_globally = admit_steps_globally;
+        self
+    }
+
+    /// Return local Flow-step admission counters for diagnostics and hosts.
+    pub fn admission_stats(&self) -> DynamicWorkflowAdmissionStats {
+        self.step_admission.stats()
+    }
+
+    async fn admit_step(&self, invocation: &StepInvocation) -> a3s_flow::Result<DynamicStepLease> {
+        let identity = dynamic_workflow_step_identity(
+            &invocation.run_id,
+            &invocation.step_id,
+            &invocation.step_name,
+            &invocation.input,
+        )
+        .map_err(|error| a3s_flow::FlowError::Runtime(error.to_string()))?;
+        let mut lease = self
+            .step_admission
+            .acquire(identity.clone(), &self.context.cancellation_token())
+            .await?;
+
+        // Host task fan-out has its own child-run scheduler boundary. Holding
+        // a second global lease here would deadlock a max_active=1 scheduler
+        // while the child waits for capacity, so only direct script-backed
+        // steps opt into the standalone global admission.
+        if self.admit_steps_globally
+            && !matches!(
+                invocation.step_name.as_str(),
+                TASK_TOOL | PARALLEL_TASK_TOOL
+            )
+        {
+            let Some(scheduler) = self.task_scheduler.as_ref() else {
+                return Err(a3s_flow::FlowError::Runtime(
+                    "global Flow-step admission requires a configured task scheduler".to_string(),
+                ));
+            };
+            let task_lease = scheduler
+                .acquire_with_identity(
+                    SchedulerTaskPriority::Foreground,
+                    format!(
+                        "flow:{}:{}:{}",
+                        invocation.run_id, invocation.step_id, invocation.step_name
+                    ),
+                    Some(identity),
+                    &self.context.cancellation_token(),
+                )
+                .await
+                .map_err(|error| a3s_flow::FlowError::Runtime(error.to_string()))?;
+            lease = lease.with_task_lease(task_lease);
+        }
+        Ok(lease)
     }
 
     async fn run_script(
@@ -293,6 +506,7 @@ impl FlowRuntime for DynamicWorkflowRuntime {
     }
 
     async fn run_step(&self, invocation: StepInvocation) -> a3s_flow::Result<Value> {
+        let _admission = self.admit_step(&invocation).await?;
         if matches!(
             invocation.step_name.as_str(),
             TASK_TOOL | PARALLEL_TASK_TOOL
@@ -318,13 +532,118 @@ impl FlowRuntime for DynamicWorkflowRuntime {
     }
 }
 
+/// Derive the stable identity for one dynamic Flow step admission.
+///
+/// The returned value is digest-only. The step input is included in the
+/// derivation so retries with different arguments cannot share a lease, but no
+/// input bytes are retained in the identity or emitted by the scheduler.
+pub fn dynamic_workflow_step_identity(
+    run_id: &str,
+    step_id: &str,
+    step_name: &str,
+    input: &Value,
+) -> Result<ExecutionIdentityV1, crate::execution_identity::ExecutionIdentityError> {
+    for (field, value) in [
+        ("run_id", run_id),
+        ("step_id", step_id),
+        ("step_name", step_name),
+    ] {
+        if value.is_empty()
+            || value.len() > MAX_FLOW_STEP_ID_BYTES
+            || value.contains('\0')
+            || value.lines().count() != 1
+        {
+            return Err(
+                crate::execution_identity::ExecutionIdentityError::InvalidClaimField(field),
+            );
+        }
+    }
+    let encoded_input = serde_json::to_vec(input).map_err(|error| {
+        crate::execution_identity::ExecutionIdentityError::Serialization(error.to_string())
+    })?;
+    if encoded_input.len() > MAX_FLOW_STEP_INPUT_BYTES {
+        return Err(
+            crate::execution_identity::ExecutionIdentityError::Serialization(format!(
+                "dynamic Flow step input exceeds {} bytes",
+                MAX_FLOW_STEP_INPUT_BYTES
+            )),
+        );
+    }
+    ExecutionIdentityV1::derive(
+        FLOW_STEP_IDENTITY_DOMAIN_V1,
+        &json!({
+            "run_id": run_id,
+            "step_id": step_id,
+            "step_name": step_name,
+            "input": input,
+        }),
+    )
+}
+
+/// Project the complete durable Flow history into Code's canonical plan model.
+///
+/// Flow remains the execution authority; this is a read-only adapter used by
+/// progress events and metadata. Replaying the full history (rather than only
+/// observing newly appended events) makes resumed runs expose the same plan as
+/// fresh runs.
+pub fn dynamic_workflow_execution_plan(history: &[FlowEventEnvelope]) -> ExecutionPlan {
+    let mut plan = ExecutionPlan::new("dynamic workflow", Complexity::Medium);
+    for envelope in history {
+        match &envelope.event {
+            FlowEvent::StepCreated {
+                step_id,
+                step_name,
+                input,
+                ..
+            } => {
+                let task = Task::new(
+                    step_id.clone(),
+                    workflow_step_description(step_id, step_name, Some(input)),
+                )
+                .with_tool(step_name.clone());
+                plan.upsert_step(task);
+            }
+            FlowEvent::StepStarted { step_id, .. } => {
+                plan.mark_status(step_id, TaskStatus::InProgress);
+            }
+            FlowEvent::StepRetrying { step_id, .. } => {
+                plan.mark_status(step_id, TaskStatus::InProgress);
+            }
+            FlowEvent::StepCompleted { step_id, .. } => {
+                plan.mark_status(step_id, TaskStatus::Completed);
+            }
+            FlowEvent::StepFailed { step_id, .. } => {
+                plan.mark_status(step_id, TaskStatus::Failed);
+            }
+            FlowEvent::RunFailed { .. }
+            | FlowEvent::RunTimedOut { .. }
+            | FlowEvent::RunRetryExhausted { .. } => {
+                for task in &mut plan.steps {
+                    if task.status.is_active() {
+                        task.status = TaskStatus::Failed;
+                    }
+                }
+            }
+            FlowEvent::RunCancelled { .. } | FlowEvent::RunHostShutdown { .. } => {
+                for task in &mut plan.steps {
+                    if task.status.is_active() {
+                        task.status = TaskStatus::Cancelled;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    plan
+}
+
 struct WorkflowProgressState {
-    tasks: Vec<Task>,
+    plan: ExecutionPlan,
 }
 
 impl WorkflowProgressState {
-    fn new() -> Self {
-        Self { tasks: Vec::new() }
+    fn new(plan: ExecutionPlan) -> Self {
+        Self { plan }
     }
 
     fn upsert_step(
@@ -335,29 +654,22 @@ impl WorkflowProgressState {
         status: TaskStatus,
     ) {
         let content = workflow_step_description(step_id, step_name, input);
-        if let Some(task) = self.tasks.iter_mut().find(|task| task.id == step_id) {
-            task.content = content;
-            task.status = status;
-            task.tool = Some(step_name.to_string());
-        } else {
-            self.tasks
-                .push(Task::new(step_id.to_string(), content).with_tool(step_name));
-            if let Some(task) = self.tasks.last_mut() {
-                task.status = status;
-            }
-        }
+        self.plan.upsert_step(
+            Task::new(step_id.to_string(), content)
+                .with_tool(step_name)
+                .with_status(status),
+        );
     }
 
     fn mark_status(&mut self, step_id: &str, status: TaskStatus) {
-        if let Some(task) = self.tasks.iter_mut().find(|task| task.id == step_id) {
-            task.status = status;
-        }
+        self.plan.mark_status(step_id, status);
     }
 
     fn step_position(&self, step_id: &str) -> (usize, usize) {
-        let total = self.tasks.len().max(1);
+        let total = self.plan.steps.len().max(1);
         let number = self
-            .tasks
+            .plan
+            .steps
             .iter()
             .position(|task| task.id == step_id)
             .map(|idx| idx + 1)
@@ -366,11 +678,20 @@ impl WorkflowProgressState {
     }
 
     fn step_description(&self, step_id: &str) -> String {
-        self.tasks
+        self.plan
+            .steps
             .iter()
             .find(|task| task.id == step_id)
             .map(|task| task.content.clone())
             .unwrap_or_else(|| step_id.to_string())
+    }
+
+    fn tasks(&self) -> &[Task] {
+        &self.plan.steps
+    }
+
+    fn snapshot(&self) -> ExecutionPlan {
+        self.plan.clone()
     }
 }
 
@@ -381,11 +702,11 @@ struct AgentEventFlowObserver {
 }
 
 impl AgentEventFlowObserver {
-    fn new(tx: broadcast::Sender<AgentEvent>, session_id: String) -> Self {
+    fn new(tx: broadcast::Sender<AgentEvent>, session_id: String, plan: ExecutionPlan) -> Self {
         Self {
             tx,
             session_id,
-            state: Mutex::new(WorkflowProgressState::new()),
+            state: Mutex::new(WorkflowProgressState::new(plan)),
         }
     }
 
@@ -405,6 +726,14 @@ impl FlowEventObserver for AgentEventFlowObserver {
                 let _ = self.tx.send(AgentEvent::PlanningStart {
                     prompt: "dynamic_workflow".to_string(),
                 });
+                let state = self.state.lock().await;
+                if !state.plan.steps.is_empty() {
+                    let plan = state.snapshot();
+                    let _ = self.tx.send(AgentEvent::PlanningEnd {
+                        estimated_steps: plan.steps.len(),
+                        plan,
+                    });
+                }
             }
             FlowEvent::StepCreated {
                 step_id,
@@ -414,11 +743,8 @@ impl FlowEventObserver for AgentEventFlowObserver {
             } => {
                 let mut state = self.state.lock().await;
                 state.upsert_step(&step_id, &step_name, Some(&input), TaskStatus::Pending);
-                self.emit_task_update(&state.tasks);
-                let mut plan = ExecutionPlan::new("dynamic workflow", Complexity::Medium);
-                for task in state.tasks.iter().cloned() {
-                    plan.add_step(task);
-                }
+                self.emit_task_update(state.tasks());
+                let plan = state.snapshot();
                 let _ = self.tx.send(AgentEvent::PlanningEnd {
                     estimated_steps: plan.steps.len(),
                     plan,
@@ -427,7 +753,7 @@ impl FlowEventObserver for AgentEventFlowObserver {
             FlowEvent::StepStarted { step_id, .. } => {
                 let mut state = self.state.lock().await;
                 state.mark_status(&step_id, TaskStatus::InProgress);
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
                 let (step_number, total_steps) = state.step_position(&step_id);
                 let _ = self.tx.send(AgentEvent::StepStart {
                     description: state.step_description(&step_id),
@@ -439,7 +765,7 @@ impl FlowEventObserver for AgentEventFlowObserver {
             FlowEvent::StepCompleted { step_id, .. } => {
                 let mut state = self.state.lock().await;
                 state.mark_status(&step_id, TaskStatus::Completed);
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
                 let (step_number, total_steps) = state.step_position(&step_id);
                 let _ = self.tx.send(AgentEvent::StepEnd {
                     step_id,
@@ -451,12 +777,12 @@ impl FlowEventObserver for AgentEventFlowObserver {
             FlowEvent::StepRetrying { step_id, .. } => {
                 let mut state = self.state.lock().await;
                 state.mark_status(&step_id, TaskStatus::InProgress);
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
             }
             FlowEvent::StepFailed { step_id, .. } => {
                 let mut state = self.state.lock().await;
                 state.mark_status(&step_id, TaskStatus::Failed);
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
                 let (step_number, total_steps) = state.step_position(&step_id);
                 let _ = self.tx.send(AgentEvent::StepEnd {
                     step_id,
@@ -465,23 +791,25 @@ impl FlowEventObserver for AgentEventFlowObserver {
                     total_steps,
                 });
             }
-            FlowEvent::RunFailed { .. } => {
+            FlowEvent::RunFailed { .. }
+            | FlowEvent::RunTimedOut { .. }
+            | FlowEvent::RunRetryExhausted { .. } => {
                 let mut state = self.state.lock().await;
-                for task in &mut state.tasks {
+                for task in &mut state.plan.steps {
                     if task.status.is_active() {
                         task.status = TaskStatus::Failed;
                     }
                 }
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
             }
-            FlowEvent::RunCancelled { .. } => {
+            FlowEvent::RunCancelled { .. } | FlowEvent::RunHostShutdown { .. } => {
                 let mut state = self.state.lock().await;
-                for task in &mut state.tasks {
+                for task in &mut state.plan.steps {
                     if task.status.is_active() {
                         task.status = TaskStatus::Cancelled;
                     }
                 }
-                self.emit_task_update(&state.tasks);
+                self.emit_task_update(state.tasks());
             }
             _ => {}
         }
@@ -496,27 +824,44 @@ fn workflow_step_description(step_id: &str, step_name: &str, input: Option<&Valu
             .map(Vec::len)
             .unwrap_or(0);
         if count > 0 {
-            return format!("Fan out {count} parallel subagent task(s)");
+            return bounded_workflow_description(&format!(
+                "Fan out {count} parallel subagent task(s)"
+            ));
         }
     }
 
-    input
+    let description = input
         .and_then(|value| value.get("description").or_else(|| value.get("title")))
         .and_then(Value::as_str)
-        .map(ToString::to_string)
+        .map(str::to_string)
         .unwrap_or_else(|| {
             if step_name == step_id {
                 step_id.to_string()
             } else {
                 format!("{step_name}: {step_id}")
             }
-        })
+        });
+    bounded_workflow_description(&description)
+}
+
+fn bounded_workflow_description(value: &str) -> String {
+    const MAX_DESCRIPTION_BYTES: usize = 512;
+    if value.len() <= MAX_DESCRIPTION_BYTES {
+        return value.to_string();
+    }
+    let mut end = MAX_DESCRIPTION_BYTES.saturating_sub("…".len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &value[..end])
 }
 
 /// Model-visible tool that executes a dynamic workflow through A3S Flow.
 pub struct DynamicWorkflowTool {
     registry: DynamicWorkflowRegistry,
     graph_observer: Option<FlowGraphObserver>,
+    task_scheduler: Option<Arc<TaskScheduler>>,
+    admit_steps_globally: bool,
 }
 
 enum DynamicWorkflowRegistry {
@@ -538,6 +883,8 @@ impl DynamicWorkflowTool {
         Self {
             registry: DynamicWorkflowRegistry::Standalone(registry),
             graph_observer: None,
+            task_scheduler: None,
+            admit_steps_globally: false,
         }
     }
 
@@ -545,6 +892,8 @@ impl DynamicWorkflowTool {
         Self {
             registry: DynamicWorkflowRegistry::RegistryBound(Arc::downgrade(&registry)),
             graph_observer: None,
+            task_scheduler: None,
+            admit_steps_globally: false,
         }
     }
 
@@ -552,6 +901,19 @@ impl DynamicWorkflowTool {
     /// A3S Flow remains the workflow execution source of truth.
     pub fn with_graph_observer(mut self, observer: FlowGraphObserver) -> Self {
         self.graph_observer = Some(observer);
+        self
+    }
+
+    /// Configure optional global admission for direct script-backed Flow
+    /// steps. Session-bound registrations should leave this disabled because
+    /// the enclosing session operation already owns the global lease.
+    pub fn with_task_scheduler(
+        mut self,
+        scheduler: Arc<TaskScheduler>,
+        admit_steps_globally: bool,
+    ) -> Self {
+        self.task_scheduler = Some(scheduler);
+        self.admit_steps_globally = admit_steps_globally;
         self
     }
 }
@@ -600,6 +962,12 @@ impl Tool for DynamicWorkflowTool {
                             "minimum": 1,
                             "maximum": 4,
                             "description": "Optional bounded fan-out for independently session-bound generate_object steps. Providers without session forking remain single-flight."
+                        },
+                        "maxConcurrentSteps": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 32,
+                            "description": "Optional per-workflow limit for concurrently executing Flow step bodies."
                         }
                     }
                 }
@@ -633,21 +1001,35 @@ impl Tool for DynamicWorkflowTool {
             .and_then(|value| serde_json::from_value(value).ok())
             .unwrap_or_default();
 
-        let runtime = Arc::new(
-            DynamicWorkflowRuntime::new(registry, ctx.clone(), source)
-                .with_allowed_tools(allowed_tools)
-                .with_limits(limits),
-        );
+        let mut runtime = DynamicWorkflowRuntime::new(registry, ctx.clone(), source)
+            .with_allowed_tools(allowed_tools)
+            .with_limits(limits);
+        if let Some(scheduler) = &self.task_scheduler {
+            runtime = runtime.with_task_scheduler(Arc::clone(scheduler), self.admit_steps_globally);
+        }
+        let runtime = Arc::new(runtime);
+        let runtime_for_metadata = Arc::clone(&runtime);
         let requested_run_id = args.get("run_id").and_then(Value::as_str);
         let store = match flow_store_for_context(ctx, requested_run_id).await {
             Ok(store) => store,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
+        };
+        let initial_plan = if let Some(run_id) = requested_run_id {
+            let prior_history = match store.list(run_id).await {
+                Ok(history) => history,
+                Err(a3s_flow::FlowError::RunNotFound(_)) => Vec::new(),
+                Err(error) => return Ok(ToolOutput::error(error.to_string())),
+            };
+            dynamic_workflow_execution_plan(&prior_history)
+        } else {
+            ExecutionPlan::new("dynamic workflow", Complexity::Medium)
         };
         let mut observers: Vec<Arc<dyn FlowEventObserver>> = Vec::new();
         if let Some(tx) = ctx.agent_event_tx.clone() {
             observers.push(Arc::new(AgentEventFlowObserver::new(
                 tx,
                 ctx.session_id.clone().unwrap_or_default(),
+                initial_plan,
             )));
         }
         if let Some(observer) = &self.graph_observer {
@@ -700,6 +1082,11 @@ impl Tool for DynamicWorkflowTool {
         };
 
         let status = snapshot.status;
+        let plan = dynamic_workflow_execution_plan(&history);
+        let plan_identity = match plan.definition_identity() {
+            Ok(identity) => identity,
+            Err(error) => return Ok(ToolOutput::error(error.to_string())),
+        };
         let metadata = json!({
             "dynamic_workflow": {
                 "run_id": run_id,
@@ -708,6 +1095,9 @@ impl Tool for DynamicWorkflowTool {
                 "source_hash": source_hash,
                 "snapshot": snapshot,
                 "history": history,
+                "plan": plan,
+                "plan_identity": plan_identity,
+                "admission": runtime_for_metadata.admission_stats(),
             }
         });
         let output = match status {
@@ -774,6 +1164,23 @@ pub fn register_dynamic_workflow(registry: &Arc<ToolRegistry>) {
     registry.register(Arc::new(DynamicWorkflowTool::new_registry_bound(
         Arc::clone(registry),
     )));
+}
+
+/// Register a dynamic workflow tool with an explicit scheduler policy.
+///
+/// This is intended for hosts that construct a Flow runtime outside the
+/// normal AgentSession operation boundary. AgentSession registrations should
+/// use [`register_dynamic_workflow`] so the enclosing run lease remains the
+/// single global admission boundary.
+pub fn register_dynamic_workflow_with_scheduler(
+    registry: &Arc<ToolRegistry>,
+    scheduler: Arc<TaskScheduler>,
+    admit_steps_globally: bool,
+) {
+    registry.register(Arc::new(
+        DynamicWorkflowTool::new_registry_bound(Arc::clone(registry))
+            .with_task_scheduler(scheduler, admit_steps_globally),
+    ));
 }
 
 async fn flow_store_for_context(

--- a/core/src/dynamic_workflow/tests.rs
+++ b/core/src/dynamic_workflow/tests.rs
@@ -4,7 +4,7 @@ use crate::llm::{
 };
 use crate::tools::{register_generate_object, ToolExecutor, ToolOutput};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 use tokio_util::sync::CancellationToken;
 
 #[test]
@@ -177,6 +177,58 @@ impl Tool for FakeTaskTool {
     }
 }
 
+struct BlockingTaskTool {
+    started: Arc<AtomicUsize>,
+    release: Arc<Notify>,
+}
+
+struct BlockingProbeTool {
+    started: Arc<AtomicUsize>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl Tool for BlockingProbeTool {
+    fn name(&self) -> &str {
+        "flow_probe"
+    }
+
+    fn description(&self) -> &str {
+        "Blocking probe for global Flow-step admission tests."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({ "type": "object" })
+    }
+
+    async fn execute(&self, _args: &Value, _ctx: &ToolContext) -> Result<ToolOutput> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.release.notified().await;
+        Ok(ToolOutput::success("released"))
+    }
+}
+
+#[async_trait]
+impl Tool for BlockingTaskTool {
+    fn name(&self) -> &str {
+        TASK_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Blocking task tool for dynamic workflow admission tests."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({ "type": "object" })
+    }
+
+    async fn execute(&self, _args: &Value, _ctx: &ToolContext) -> Result<ToolOutput> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.release.notified().await;
+        Ok(ToolOutput::success("released"))
+    }
+}
+
 struct FakeRuntimeTool;
 
 #[async_trait]
@@ -304,6 +356,7 @@ async function run(ctx, inputs) {
             max_tool_calls: Some(1),
             max_output_bytes: None,
             max_concurrent_generations: None,
+            max_concurrent_steps: None,
         });
     let run = tokio::spawn(async move {
         runtime
@@ -396,6 +449,7 @@ async function run(ctx, inputs) {
                 max_tool_calls: Some(1),
                 max_output_bytes: None,
                 max_concurrent_generations: Some(2),
+                max_concurrent_steps: None,
             }),
     );
     let invocation = |step_id: &str| {
@@ -418,6 +472,252 @@ async function run(ctx, inputs) {
     assert_eq!(sessions.len(), 2);
     assert!(sessions.iter().any(|session| session.ends_with(":first")));
     assert!(sessions.iter().any(|session| session.ends_with(":second")));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_workflow_step_admission_is_bounded_and_cancellable() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let started = Arc::new(AtomicUsize::new(0));
+    let release = Arc::new(Notify::new());
+    executor.register_dynamic_tool(Arc::new(BlockingTaskTool {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    }));
+    let cancellation = CancellationToken::new();
+    let context = executor
+        .registry()
+        .context()
+        .with_cancellation(cancellation.clone());
+    let runtime = Arc::new(
+        DynamicWorkflowRuntime::new(
+            Arc::clone(executor.registry()),
+            context,
+            "unused for host task steps",
+        )
+        .with_limits(DynamicWorkflowScriptLimits {
+            timeout_ms: None,
+            max_tool_calls: None,
+            max_output_bytes: None,
+            max_concurrent_generations: None,
+            max_concurrent_steps: Some(1),
+        }),
+    );
+
+    let first_runtime = Arc::clone(&runtime);
+    let first = tokio::spawn(async move {
+        first_runtime
+            .run_step(StepInvocation::new(
+                "admission-run",
+                "first",
+                TASK_TOOL,
+                json!({}),
+                Vec::new(),
+            ))
+            .await
+    });
+    for _ in 0..1_000 {
+        if started.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    if started.load(Ordering::SeqCst) != 1 {
+        let result = first.await.unwrap();
+        panic!("first step did not enter blocking tool: {result:?}");
+    }
+
+    let second_runtime = Arc::clone(&runtime);
+    let second = tokio::spawn(async move {
+        second_runtime
+            .run_step(StepInvocation::new(
+                "admission-run",
+                "second",
+                TASK_TOOL,
+                json!({}),
+                Vec::new(),
+            ))
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+    let stats = runtime.admission_stats();
+    assert_eq!(stats.active_steps, 1);
+    assert_eq!(stats.admitted_steps, 1);
+    assert_eq!(stats.peak_active_steps, 1);
+
+    cancellation.cancel();
+    let second_result = tokio::time::timeout(Duration::from_secs(1), second)
+        .await
+        .expect("queued step should observe cancellation")
+        .expect("queued step task should join")
+        .expect_err("queued step must not execute after cancellation");
+    assert!(second_result.to_string().contains("admission cancelled"));
+
+    release.notify_waiters();
+    first.await.unwrap().unwrap();
+    let stats = runtime.admission_stats();
+    assert_eq!(stats.active_steps, 0);
+    assert_eq!(stats.admitted_steps, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_workflow_can_layer_global_scheduler_admission_without_step_deadlock() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let started = Arc::new(AtomicUsize::new(0));
+    let release = Arc::new(Notify::new());
+    executor.register_dynamic_tool(Arc::new(BlockingProbeTool {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    }));
+    let scheduler = Arc::new(
+        crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+            max_active: 1,
+            aging_interval_ms: 60_000,
+        })
+        .unwrap(),
+    );
+    let runtime = Arc::new(
+        DynamicWorkflowRuntime::new(
+            Arc::clone(executor.registry()),
+            executor.registry().context(),
+            r#"async function run(ctx, inputs) {
+                if (inputs.kind !== "step") throw new Error("unexpected invocation");
+                return await ctx.tool("flow_probe", {});
+            }"#,
+        )
+        .with_allowed_tools(["flow_probe".to_string()])
+        .with_task_scheduler(Arc::clone(&scheduler), true),
+    );
+
+    let first_runtime = Arc::clone(&runtime);
+    let first = tokio::spawn(async move {
+        first_runtime
+            .run_step(StepInvocation::new(
+                "global-admission-run",
+                "first",
+                "flow_probe",
+                json!({}),
+                Vec::new(),
+            ))
+            .await
+    });
+    for _ in 0..1_000 {
+        if started.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+
+    let second_runtime = Arc::clone(&runtime);
+    let second = tokio::spawn(async move {
+        second_runtime
+            .run_step(StepInvocation::new(
+                "global-admission-run",
+                "second",
+                "flow_probe",
+                json!({}),
+                Vec::new(),
+            ))
+            .await
+    });
+    for _ in 0..1_000 {
+        if scheduler.stats().await.unwrap().pending == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert_eq!(scheduler.stats().await.unwrap().pending, 1);
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+
+    release.notify_one();
+    first.await.unwrap().unwrap();
+    for _ in 0..1_000 {
+        if started.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert_eq!(started.load(Ordering::SeqCst), 2);
+    release.notify_one();
+    second.await.unwrap().unwrap();
+    assert_eq!(runtime.admission_stats().peak_active_steps, 2);
+    assert_eq!(scheduler.stats().await.unwrap().active, 0);
+    scheduler.shutdown().await;
+}
+
+#[test]
+fn dynamic_flow_step_identity_is_digest_only_and_input_bound() {
+    let first =
+        dynamic_workflow_step_identity("run-1", "step-1", "read", &json!({ "path": "README.md" }))
+            .unwrap();
+    let same =
+        dynamic_workflow_step_identity("run-1", "step-1", "read", &json!({ "path": "README.md" }))
+            .unwrap();
+    let changed =
+        dynamic_workflow_step_identity("run-1", "step-1", "read", &json!({ "path": "src/lib.rs" }))
+            .unwrap();
+    assert_eq!(first, same);
+    assert_ne!(first, changed);
+    assert!(!serde_json::to_string(&first).unwrap().contains("README.md"));
+}
+
+#[test]
+fn dynamic_flow_history_projection_reconstructs_resumed_plan() {
+    let run_id = "projection-run";
+    let envelope = |sequence, event| {
+        FlowEventEnvelope::new(run_id, sequence, uuid::Uuid::new_v4(), Utc::now(), event)
+    };
+    let history = vec![
+        envelope(
+            1,
+            FlowEvent::RunCreated {
+                spec: WorkflowSpec::rust_embedded("test", "v1", "ptc", "run"),
+                input: json!({}),
+            },
+        ),
+        envelope(
+            2,
+            FlowEvent::StepCreated {
+                step_id: "first".to_string(),
+                step_name: "read".to_string(),
+                input: json!({"description": "Read source"}),
+                retry: Default::default(),
+            },
+        ),
+        envelope(
+            3,
+            FlowEvent::StepCompleted {
+                step_id: "first".to_string(),
+                output: json!({"ok": true}),
+            },
+        ),
+        envelope(
+            4,
+            FlowEvent::StepCreated {
+                step_id: "second".to_string(),
+                step_name: "write".to_string(),
+                input: json!({"title": "Write result"}),
+                retry: Default::default(),
+            },
+        ),
+        envelope(
+            5,
+            FlowEvent::StepStarted {
+                step_id: "second".to_string(),
+                attempt: 1,
+            },
+        ),
+    ];
+    let plan = dynamic_workflow_execution_plan(&history);
+    assert_eq!(plan.steps.len(), 2);
+    assert_eq!(plan.steps[0].status, TaskStatus::Completed);
+    assert_eq!(plan.steps[1].status, TaskStatus::InProgress);
+    assert_eq!(plan.steps[0].content, "Read source");
+    assert_eq!(plan.steps[1].content, "Write result");
+    assert_eq!(plan.required_tools, vec!["read", "write"]);
 }
 
 #[tokio::test]
@@ -569,6 +869,22 @@ return await ctx.read(inputs.input.path);
     assert_eq!(
         metadata["dynamic_workflow"]["snapshot"]["steps"]["read_fixture"]["status"],
         "completed"
+    );
+    assert_eq!(
+        metadata["dynamic_workflow"]["plan"]["steps"][0]["id"],
+        "read_fixture"
+    );
+    assert_eq!(
+        metadata["dynamic_workflow"]["plan"]["steps"][0]["status"],
+        "completed"
+    );
+    assert_eq!(
+        metadata["dynamic_workflow"]["plan_identity"]["domain"],
+        crate::execution_identity::EXECUTION_PLAN_IDENTITY_DOMAIN_V1
+    );
+    assert_eq!(
+        metadata["dynamic_workflow"]["admission"]["peakActiveSteps"],
+        1
     );
     assert!(
         tokio::fs::try_exists(

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -14,6 +14,14 @@ pub const EXECUTION_IDENTITY_SCHEMA_V1: &str = "a3s.code.execution-identity.v1";
 pub const MODEL_CALL_IDENTITY_DOMAIN_V1: &str = "a3s.code.model-call.identity.v1";
 pub const TOOL_INVOCATION_IDENTITY_DOMAIN_V1: &str = "a3s.code.tool-invocation.identity.v1";
 pub const FLOW_DECISION_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-decision.identity.v1";
+/// Identity domain for a dynamically admitted A3S Flow step.
+///
+/// Dynamic Flow steps are intentionally separate from delegated Agent steps:
+/// the former are identified by the Flow run/step/name and JSON input, while
+/// the latter are identified by an [`AgentStepSpec`](crate::orchestration::AgentStepSpec).
+pub const FLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-step.identity.v1";
+/// Identity domain for the immutable definition of a projected execution plan.
+pub const EXECUTION_PLAN_IDENTITY_DOMAIN_V1: &str = "a3s.code.execution-plan.identity.v1";
 pub const WORKFLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.workflow-step.identity.v1";
 pub const WORKFLOW_STEP_EVIDENCE_DOMAIN_V1: &str = "a3s.code.workflow-step.evidence.v1";
 pub const WORKFLOW_STEP_RESULT_DOMAIN_V1: &str = "a3s.code.workflow-step.result.v1";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -224,8 +224,10 @@ pub use durable_memory::{
     DURABLE_MEMORY_SEMANTIC_REFRESH_PROFILE_V1,
 };
 pub use dynamic_workflow::{
-    dynamic_workflow_store_path, DynamicWorkflowRuntime, DynamicWorkflowScriptLimits,
-    DynamicWorkflowTool, DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,
+    dynamic_workflow_execution_plan, dynamic_workflow_step_identity, dynamic_workflow_store_path,
+    register_dynamic_workflow_with_scheduler, DynamicWorkflowAdmissionStats,
+    DynamicWorkflowRuntime, DynamicWorkflowScriptLimits, DynamicWorkflowTool,
+    DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,
 };
 pub use embedding::{
     EmbeddingBatchRequest, EmbeddingBatchResponse, EmbeddingError, EmbeddingExecution,
@@ -354,8 +356,8 @@ pub use subagent_task_tracker::{
     InMemorySubagentTaskTracker, SubagentProgressEntry, SubagentStatus, SubagentTaskSnapshot,
 };
 pub use task_scheduler::{
-    TaskPriority, TaskPriorityCounts, TaskScheduler, TaskSchedulerConfig, TaskSchedulerError,
-    TaskSchedulerStats,
+    TaskLease, TaskPriority, TaskPriorityCounts, TaskScheduler, TaskSchedulerConfig,
+    TaskSchedulerError, TaskSchedulerStats,
 };
 pub use tools::{
     ImmutableContentAdapter, ImmutableContentAdapterBindingV1, ImmutableContentAdapterSession,

--- a/core/src/planning/mod.rs
+++ b/core/src/planning/mod.rs
@@ -237,11 +237,79 @@ impl ExecutionPlan {
         self.estimated_steps = self.steps.len();
     }
 
+    /// Insert or update one step while preserving the plan's insertion order.
+    ///
+    /// Flow replay can deliver the same durable step definition more than
+    /// once (for example when an observer is attached during a resumed run).
+    /// Keeping this operation on the canonical plan prevents each adapter from
+    /// implementing a subtly different deduplication and status policy.
+    pub fn upsert_step(&mut self, step: Task) {
+        let tool = step.tool.clone();
+        if let Some(existing) = self.steps.iter_mut().find(|item| item.id == step.id) {
+            // A terminal event is authoritative for the step. A duplicate
+            // StepCreated/Started notification must not regress a completed,
+            // failed, or cancelled task back to an active state.
+            existing.status = merge_status(existing.status, step.status);
+            existing.content = step.content;
+            existing.priority = step.priority;
+            existing.tool = step.tool.clone();
+            existing.dependencies = step.dependencies;
+            existing.success_criteria = step.success_criteria;
+        } else {
+            self.steps.push(step);
+        }
+        self.estimated_steps = self.steps.len();
+        if let Some(tool) = tool {
+            self.add_required_tool(tool);
+        }
+    }
+
     pub fn add_required_tool(&mut self, tool: impl Into<String>) {
         let tool_str = tool.into();
         if !self.required_tools.contains(&tool_str) {
             self.required_tools.push(tool_str);
         }
+    }
+
+    /// Derive an identity for the immutable plan definition.
+    ///
+    /// Mutable status is deliberately excluded: restarting or retrying a Flow
+    /// must keep the same plan identity while its progress changes. The
+    /// identity contains only already-materialized task definitions and
+    /// exposes no task output or other runtime evidence. Dynamic Flow adapters
+    /// bound user-facing descriptions before they enter this projection.
+    pub fn definition_identity(
+        &self,
+    ) -> Result<
+        crate::execution_identity::ExecutionIdentityV1,
+        crate::execution_identity::ExecutionIdentityError,
+    > {
+        let steps = self
+            .steps
+            .iter()
+            .map(|step| {
+                serde_json::json!({
+                    "id": step.id,
+                    "content": step.content,
+                    "priority": step.priority,
+                    "tool": step.tool,
+                    "dependencies": step.dependencies,
+                    "success_criteria": step.success_criteria,
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut required_tools = self.required_tools.clone();
+        required_tools.sort();
+        required_tools.dedup();
+        crate::execution_identity::ExecutionIdentityV1::derive(
+            crate::execution_identity::EXECUTION_PLAN_IDENTITY_DOMAIN_V1,
+            &serde_json::json!({
+                "goal": self.goal,
+                "complexity": self.complexity,
+                "required_tools": required_tools,
+                "steps": steps,
+            }),
+        )
     }
 
     /// Get steps that are ready to execute (dependencies met)
@@ -264,7 +332,7 @@ impl ExecutionPlan {
     /// Update the status of a step by ID
     pub fn mark_status(&mut self, step_id: &str, status: TaskStatus) {
         if let Some(step) = self.steps.iter_mut().find(|s| s.id == step_id) {
-            step.status = status;
+            step.status = merge_status(step.status, status);
         }
     }
 
@@ -296,6 +364,18 @@ impl ExecutionPlan {
             .count();
         completed as f32 / self.steps.len() as f32
     }
+}
+
+/// Merge a replay notification without allowing duplicate delivery to regress
+/// an already observed lifecycle transition.
+fn merge_status(current: TaskStatus, incoming: TaskStatus) -> TaskStatus {
+    if !current.is_active() {
+        return current;
+    }
+    if current == TaskStatus::InProgress && incoming == TaskStatus::Pending {
+        return current;
+    }
+    incoming
 }
 
 // ============================================================================
@@ -644,6 +724,35 @@ mod tests {
         let ready = plan.get_ready_steps();
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].id, "s3");
+    }
+
+    #[test]
+    fn upsert_preserves_order_and_does_not_regress_status() {
+        let mut plan = ExecutionPlan::new("Test", Complexity::Simple);
+        plan.upsert_step(
+            Task::new("step", "First")
+                .with_tool("read")
+                .with_status(TaskStatus::InProgress),
+        );
+        plan.upsert_step(
+            Task::new("step", "Updated")
+                .with_tool("read")
+                .with_status(TaskStatus::Pending),
+        );
+        assert_eq!(plan.steps.len(), 1);
+        assert_eq!(plan.steps[0].content, "Updated");
+        assert_eq!(plan.steps[0].status, TaskStatus::InProgress);
+        assert_eq!(plan.required_tools, vec!["read"]);
+    }
+
+    #[test]
+    fn definition_identity_ignores_progress_status() {
+        let mut plan = ExecutionPlan::new("Test", Complexity::Simple);
+        plan.add_step(Task::new("step", "First").with_tool("read"));
+        let before = plan.definition_identity().unwrap();
+        plan.mark_status("step", TaskStatus::Completed);
+        let after = plan.definition_identity().unwrap();
+        assert_eq!(before, after);
     }
 
     // ========================================================================

--- a/core/src/task_scheduler.rs
+++ b/core/src/task_scheduler.rs
@@ -4,6 +4,7 @@
 //! shared capacity boundary across every session created by one [`Agent`](crate::Agent),
 //! using `a3s-lane`'s stable priority queue for exact priority/FIFO ordering.
 
+use crate::execution_identity::ExecutionIdentityV1;
 use a3s_lane::{Priority, PriorityQueue};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -189,11 +190,34 @@ impl TaskScheduler {
         label: impl Into<String>,
         cancellation: &CancellationToken,
     ) -> Result<TaskLease, TaskSchedulerError> {
+        self.acquire_with_identity(priority, label, None, cancellation)
+            .await
+    }
+
+    /// Wait until this task owns one global execution slot and carry its
+    /// semantic execution identity through the admission boundary.
+    ///
+    /// The identity is optional for backwards compatibility with callers that
+    /// only need capacity. When present it is validated before anything is
+    /// queued, and the resulting lease retains it for tracing and downstream
+    /// adapters.
+    pub async fn acquire_with_identity(
+        &self,
+        priority: TaskPriority,
+        label: impl Into<String>,
+        identity: Option<ExecutionIdentityV1>,
+        cancellation: &CancellationToken,
+    ) -> Result<TaskLease, TaskSchedulerError> {
         if self.closed.load(Ordering::Acquire) {
             return Err(TaskSchedulerError::Closed);
         }
         if cancellation.is_cancelled() {
             return Err(TaskSchedulerError::Cancelled);
+        }
+        if let Some(identity) = &identity {
+            identity.validate().map_err(|error| {
+                TaskSchedulerError::InvalidConfig(format!("execution identity is invalid: {error}"))
+            })?;
         }
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
@@ -203,6 +227,7 @@ impl TaskScheduler {
                 id,
                 priority,
                 label: label.into(),
+                identity: identity.clone(),
                 enqueued_at: Instant::now(),
                 ready: ready_tx,
             }))
@@ -220,6 +245,7 @@ impl TaskScheduler {
                     id,
                     tx: self.tx.clone(),
                     released: false,
+                    identity,
                 })
             }
         }
@@ -251,12 +277,18 @@ pub struct TaskLease {
     id: u64,
     tx: mpsc::UnboundedSender<SchedulerMessage>,
     released: bool,
+    identity: Option<ExecutionIdentityV1>,
 }
 
 impl TaskLease {
     /// Stable admission identifier, useful for tracing.
     pub fn id(&self) -> u64 {
         self.id
+    }
+
+    /// Semantic identity carried by this admission, when one was supplied.
+    pub fn identity(&self) -> Option<&ExecutionIdentityV1> {
+        self.identity.as_ref()
     }
 }
 
@@ -273,6 +305,7 @@ struct QueuedAdmission {
     id: u64,
     priority: TaskPriority,
     label: String,
+    identity: Option<ExecutionIdentityV1>,
     enqueued_at: Instant,
     ready: oneshot::Sender<Result<(), TaskSchedulerError>>,
 }
@@ -391,12 +424,19 @@ impl SchedulerState {
             let id = item.id;
             let priority = item.priority;
             let label = item.label;
+            let identity = item.identity;
             self.active.insert(id, priority);
             if item.ready.send(Ok(())).is_err() {
                 self.active.remove(&id);
                 continue;
             }
-            tracing::trace!(admission_id = id, ?priority, %label, "task admitted");
+            tracing::trace!(
+                admission_id = id,
+                ?priority,
+                %label,
+                execution_identity = identity.as_ref().map(ExecutionIdentityV1::key).unwrap_or(""),
+                "task admitted"
+            );
         }
     }
 
@@ -721,6 +761,33 @@ mod tests {
         assert_eq!(stats.pending_by_priority.maintenance, 1);
         drop(blocker);
         drop(waiting.await.unwrap().unwrap());
+        scheduler.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn identity_is_carried_by_global_admission_lease() {
+        let scheduler = scheduler(1, 60_000);
+        let identity = ExecutionIdentityV1::derive(
+            crate::execution_identity::FLOW_STEP_IDENTITY_DOMAIN_V1,
+            &serde_json::json!({
+                "run_id": "run-1",
+                "step_id": "step-1",
+                "step_name": "read",
+                "input": {"path": "README.md"},
+            }),
+        )
+        .unwrap();
+        let lease = scheduler
+            .acquire_with_identity(
+                TaskPriority::Foreground,
+                "flow:run-1:step-1:read",
+                Some(identity.clone()),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(lease.identity(), Some(&identity));
+        drop(lease);
         scheduler.shutdown().await;
     }
 }

--- a/core/src/tools/mod.rs
+++ b/core/src/tools/mod.rs
@@ -25,7 +25,9 @@ pub mod skill;
 pub mod task;
 mod types;
 
-pub use crate::dynamic_workflow::register_dynamic_workflow;
+pub use crate::dynamic_workflow::{
+    register_dynamic_workflow, register_dynamic_workflow_with_scheduler,
+};
 pub use agent_dir_script_tool::AgentDirScriptTool;
 pub use artifacts::{ArtifactStore, ArtifactStoreLimits, ToolArtifact};
 pub use builtin::{

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -549,11 +549,40 @@ impl TaskExecutor {
                     .await;
             }
         }
+        let execution_identity =
+            if (params.background || self.schedule_foreground) && self.task_scheduler.is_some() {
+                let mut identity_spec = AgentStepSpec::new(
+                    task_id.clone(),
+                    params.agent.clone(),
+                    params.description.clone(),
+                    params.prompt.clone(),
+                );
+                if let Some(max_steps) = params.max_steps {
+                    identity_spec = identity_spec.with_max_steps(max_steps);
+                }
+                if let Some(output_schema) = params.output_schema.clone() {
+                    identity_spec = identity_spec.with_output_schema(output_schema);
+                }
+                if let Some(parent_session_id) = parent_session_id {
+                    identity_spec = identity_spec.with_parent_session_id(parent_session_id);
+                }
+                Some(
+                    crate::orchestration::workflow_step_execution_identity(
+                        parent_session_id.unwrap_or("host"),
+                        &identity_spec,
+                    )
+                    .map_err(|error| {
+                        anyhow::anyhow!("derive delegated task execution identity: {error}")
+                    })?,
+                )
+            } else {
+                None
+            };
         let _task_lease = if params.background || self.schedule_foreground {
             match &self.task_scheduler {
                 Some(scheduler) => Some(
                     scheduler
-                        .acquire(
+                        .acquire_with_identity(
                             if params.background {
                                 crate::task_scheduler::TaskPriority::Background
                             } else {
@@ -564,6 +593,7 @@ impl TaskExecutor {
                                 parent_session_id.unwrap_or("host"),
                                 task_id
                             ),
+                            execution_identity.clone(),
                             &cancel_token,
                         )
                         .await


### PR DESCRIPTION
## Summary
- project durable Flow history and resumed runs into the canonical ExecutionPlan
- add cancellation-aware bounded Flow-step admission and digest-only execution identities
- carry identities through standalone scheduler leases and delegated task admission without nested max-active=1 deadlocks
- add regression tests and document the delivered roadmap slice

## Validation
- cargo +stable test -p a3s-code-core --lib (3162 passed, 0 failed, 13 ignored)
- cargo +stable test -p a3s-code-core --tests --no-run
- cargo +stable check -p a3s-code-core --all-features
- cargo +stable test -p a3s-code-core --doc
- focused dynamic workflow, scheduler, planning, task, and QuickJS integration tests