### PR TITLE
feat(core): fence dynamic workflow generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added mixed-generation qualification for dynamic workflows. New runs pin
+  the Code runtime build, continuation identities are reconstructed from the
+  durable Run/step definitions without a second journal, and changed source,
+  input, step definitions, malformed history, or unsupported runtime builds
+  fail closed before a step body starts. Terminal replay remains idempotent
+  across retries and process generations; legacy unpinned histories remain
+  readable during the migration window.
 - Added scheduler/plan convergence for dynamic workflows. Flow history now
   projects into the canonical `ExecutionPlan` (including resumed runs),
   dynamic steps use a cancellation-aware bounded concurrency gate, and

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   Standalone Flow adapters can additionally use the agent-wide priority
   scheduler with a digest-only step identity; session-bound calls retain one
   outer scheduler lease to avoid nested single-slot deadlocks.
+- **Generation-fenced workflow replay.** New dynamic workflow runs pin the
+  Code runtime build and expose a digest-only continuation identity derived
+  from durable immutable facts. Changed source/input, conflicting step
+  definitions, and unsupported runtime generations are rejected before step
+  execution, while legacy unpinned histories remain readable during
+  migration.
 
 Go consumers must update the module path to
 `github.com/A3S-Lab/Code/sdk/go/v8`. See [CHANGELOG.md](CHANGELOG.md) for the
@@ -1031,6 +1037,9 @@ step, handler, and bounded input. Durable completed-step recovery is bound to
 the exact run id, original query, and step id rather than acting as a cross-run
 query cache. A resumed run reconstructs its complete plan from durable
 history, so progress does not lose steps emitted before the current process.
+New runs also persist an exact runtime-build requirement; the continuation
+identity is recomputed from the persisted RunCreated/StepCreated facts on every
+resume, without storing source, input, or output plaintext in the identity.
 
 Delegated tasks, workflows, and Skill child runs retain the parent sandbox and
 intersect local permission policy with the parent checker. A child auto-approve

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -293,11 +293,36 @@ fan-out use its own child admission, which prevents a single-slot scheduler
 from deadlocking on a nested lease. Delegated tasks now pass their canonical
 step identity through that same global scheduler boundary.
 
-The next slice is mixed-generation restart/retry qualification: bind the
-projected plan identity and step identity to a persisted Flow continuation,
-then prove that a changed handler/input or a cancelled parent cannot duplicate
-an already committed side effect. Cloud/Use package ownership, fairness
-policy, and business-level retry decisions remain outside Code.
+The follow-up mixed-generation continuation qualification is recorded in
+section 3.3.3. Cloud/Use package ownership, fairness policy, and business-level
+retry decisions remain outside Code.
+
+### 3.3.3 Mixed-generation continuation qualification
+
+Dynamic workflow runs now pin a Code runtime build in the durable Flow
+`WorkflowSpec`. The default compatibility window accepts legacy unpinned runs
+while requiring the current build for new runs; hosts can provide an explicit
+`RuntimeBuildCompatibility` set when they retain an older worker. A continuation
+identity is reconstructed from the persisted Run/step definitions, source
+hash, initial-input digest, runtime build, and canonical plan identity. It
+excludes progress, retry events, sequence numbers, and outputs, so the same
+continuation identity survives a restart and a completed replay without a
+second journal.
+
+Before a resumed run reaches Flow execution, Code validates run ownership,
+sequence monotonicity, source/input equality, step identity consistency, and
+runtime-build syntax. Flow's own immutable start check and build compatibility
+gate then reject changed generations before any step body can run. The local
+qualification fixture proves a terminal retry replay does not repeat its
+side-effecting step and a worker on a different build cannot resume an active
+run. Legacy unpinned histories remain readable only inside the explicit
+migration window.
+
+The next slice is parent-cancellation and takeover qualification for a
+non-terminal continuation: carry the persisted continuation identity through a
+worker claim, fence a stale lease before admission, and prove a cancelled or
+reclaimed step cannot commit a duplicate side effect. Cloud/Use ownership,
+retention, and business retry policy remain outside Code.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/dynamic_workflow.rs
+++ b/core/src/dynamic_workflow.rs
@@ -4,7 +4,10 @@
 //! Flow runtime. Flow owns durable replay and step lifecycle; A3S Code's
 //! existing `program` tool remains the sandbox and tool-call boundary.
 
-use crate::execution_identity::{ExecutionIdentityV1, FLOW_STEP_IDENTITY_DOMAIN_V1};
+use crate::execution_identity::{
+    ExecutionIdentityV1, DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1,
+    DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1, FLOW_STEP_IDENTITY_DOMAIN_V1,
+};
 use crate::llm::{ModelGenerationAdmission, ModelGenerationConcurrency};
 use crate::task_scheduler::{TaskLease, TaskPriority as SchedulerTaskPriority, TaskScheduler};
 use crate::tools::{
@@ -17,16 +20,16 @@ use crate::{
 };
 use a3s_flow::{
     FanoutFlowEventObserver, FlowEngine, FlowEvent, FlowEventEnvelope, FlowEventObserver,
-    FlowEventStore, FlowRuntime, InMemoryEventStore, LocalFileEventStore, RuntimeCommand,
-    StepInvocation, StepStatus, WorkflowInvocation, WorkflowRunSnapshot, WorkflowRunStatus,
-    WorkflowSpec,
+    FlowEventStore, FlowRuntime, InMemoryEventStore, LocalFileEventStore,
+    RuntimeBuildCompatibility, RuntimeBuildId, RuntimeCommand, StepInvocation, StepStatus,
+    WorkflowInvocation, WorkflowRunSnapshot, WorkflowRunStatus, WorkflowSpec,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -45,6 +48,18 @@ const DEFAULT_MAX_CONCURRENT_STEPS: usize = 4;
 const MAX_MAX_CONCURRENT_STEPS: usize = 32;
 const MAX_FLOW_STEP_ID_BYTES: usize = 256;
 const MAX_FLOW_STEP_INPUT_BYTES: usize = 64 * 1024;
+const MAX_DYNAMIC_WORKFLOW_INPUT_BYTES: usize = 128 * 1024;
+
+/// Runtime build used to pin newly-created dynamic workflow runs.
+///
+/// Deployments that need a stronger revision identity can provide an explicit
+/// [`RuntimeBuildCompatibility`] through [`DynamicWorkflowTool::with_runtime_build_compatibility`].
+pub const DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID: &str =
+    concat!("a3s-code-core-", env!("CARGO_PKG_VERSION"));
+
+/// Legacy marker used only while deriving an identity for an unpinned history
+/// created before dynamic workflow runtime-build fencing was enabled.
+const LEGACY_UNPINNED_RUNTIME_BUILD_ID: &str = "<unpinned>";
 
 /// Project-relative directory used for durable dynamic workflow history.
 pub const DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH: &str = ".a3s/workflow";
@@ -580,6 +595,210 @@ pub fn dynamic_workflow_step_identity(
     )
 }
 
+fn dynamic_workflow_input_identity(
+    input: &Value,
+) -> Result<ExecutionIdentityV1, crate::execution_identity::ExecutionIdentityError> {
+    let encoded = serde_json::to_vec(input).map_err(|error| {
+        crate::execution_identity::ExecutionIdentityError::Serialization(error.to_string())
+    })?;
+    if encoded.len() > MAX_DYNAMIC_WORKFLOW_INPUT_BYTES {
+        return Err(
+            crate::execution_identity::ExecutionIdentityError::Serialization(format!(
+                "dynamic workflow input exceeds {} bytes",
+                MAX_DYNAMIC_WORKFLOW_INPUT_BYTES
+            )),
+        );
+    }
+    ExecutionIdentityV1::derive(DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1, input)
+}
+
+/// Reconstruct the immutable identity of a dynamic workflow continuation.
+///
+/// The Flow journal already persists the run definition and every step
+/// definition. This adapter binds those facts to the current runtime build,
+/// source, and initial input without introducing a second journal. Progress,
+/// retries, event sequence, and step outputs are intentionally excluded, so a
+/// restart observes the same continuation identity before and after replay.
+/// A malformed or mixed-generation history is rejected before a step body can
+/// be admitted.
+pub fn dynamic_workflow_continuation_identity(
+    run_id: &str,
+    source: &str,
+    input: &Value,
+    runtime_build_id: &str,
+    history: &[FlowEventEnvelope],
+) -> std::result::Result<ExecutionIdentityV1, crate::execution_identity::ExecutionIdentityError> {
+    if !safe_workflow_run_id(run_id) {
+        return Err(crate::execution_identity::ExecutionIdentityError::InvalidClaimField("run_id"));
+    }
+    if source.is_empty() {
+        return Err(crate::execution_identity::ExecutionIdentityError::InvalidClaimField("source"));
+    }
+    RuntimeBuildId::new(runtime_build_id.to_string()).map_err(|error| {
+        crate::execution_identity::ExecutionIdentityError::Serialization(format!(
+            "invalid dynamic workflow runtime build id: {error}"
+        ))
+    })?;
+    let input_identity = dynamic_workflow_input_identity(input)?;
+    let expected_source_hash = source_hash(source);
+    let expected_spec = WorkflowSpec::rust_embedded(
+        "a3s-code.dynamic-workflow",
+        expected_source_hash.as_str(),
+        "ptc",
+        "run",
+    );
+    let mut saw_run_created = false;
+    let mut persisted_runtime_build: Option<String> = None;
+    let mut step_identities = BTreeMap::<String, String>::new();
+    let mut terminal_seen = false;
+
+    for (index, envelope) in history.iter().enumerate() {
+        if envelope.run_id != run_id {
+            return Err(
+                crate::execution_identity::ExecutionIdentityError::InvalidClaimField("run_id"),
+            );
+        }
+        if envelope.sequence != index as u64 + 1 {
+            return Err(
+                crate::execution_identity::ExecutionIdentityError::InvalidClaimField("sequence"),
+            );
+        }
+        if terminal_seen {
+            return Err(
+                crate::execution_identity::ExecutionIdentityError::InvalidClaimField("terminal"),
+            );
+        }
+        if index == 0 && !matches!(&envelope.event, FlowEvent::RunCreated { .. }) {
+            return Err(
+                crate::execution_identity::ExecutionIdentityError::InvalidClaimField("run_created"),
+            );
+        }
+
+        match &envelope.event {
+            FlowEvent::RunCreated {
+                spec,
+                input: persisted_input,
+            } => {
+                if saw_run_created {
+                    return Err(
+                        crate::execution_identity::ExecutionIdentityError::InvalidClaimField(
+                            "run_created",
+                        ),
+                    );
+                }
+                saw_run_created = true;
+                if spec.name != expected_spec.name
+                    || spec.runtime != expected_spec.runtime
+                    || !spec.patch_markers.is_empty()
+                    || !spec.signal_names.is_empty()
+                {
+                    return Err(
+                        crate::execution_identity::ExecutionIdentityError::InvalidClaimField(
+                            "workflow_spec",
+                        ),
+                    );
+                }
+                if spec.version != expected_source_hash {
+                    return Err(
+                        crate::execution_identity::ExecutionIdentityError::InvalidClaimField(
+                            "source",
+                        ),
+                    );
+                }
+                let persisted_input_identity = dynamic_workflow_input_identity(persisted_input)?;
+                if persisted_input_identity != input_identity {
+                    return Err(
+                        crate::execution_identity::ExecutionIdentityError::InvalidClaimField(
+                            "input",
+                        ),
+                    );
+                }
+                if let Some(build_id) = &spec.runtime_build_id {
+                    RuntimeBuildId::new(build_id.as_str().to_string()).map_err(|error| {
+                        crate::execution_identity::ExecutionIdentityError::Serialization(format!(
+                            "invalid persisted dynamic workflow runtime build id: {error}"
+                        ))
+                    })?;
+                    persisted_runtime_build = Some(build_id.as_str().to_string());
+                } else {
+                    persisted_runtime_build = Some(LEGACY_UNPINNED_RUNTIME_BUILD_ID.to_string());
+                }
+            }
+            FlowEvent::StepCreated {
+                step_id,
+                step_name,
+                input,
+                retry,
+            } => {
+                let admission_identity =
+                    dynamic_workflow_step_identity(run_id, step_id, step_name, input)?;
+                // Retry behavior is part of Flow's immutable step definition,
+                // even though it is not needed for the scheduler admission
+                // lease. Bind it here so a conflicting duplicate cannot hide
+                // behind the digest-only admission identity.
+                let identity = ExecutionIdentityV1::derive(
+                    FLOW_STEP_IDENTITY_DOMAIN_V1,
+                    &json!({
+                        "admission": admission_identity.digest,
+                        "retry": retry,
+                    }),
+                )?;
+                if step_identities
+                    .insert(step_id.clone(), identity.digest)
+                    .is_some()
+                {
+                    return Err(
+                        crate::execution_identity::ExecutionIdentityError::InvalidClaimField(
+                            "step_definition",
+                        ),
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        terminal_seen = matches!(
+            &envelope.event,
+            FlowEvent::RunCompleted { .. }
+                | FlowEvent::RunFailed { .. }
+                | FlowEvent::RunCancelled { .. }
+                | FlowEvent::RunTimedOut { .. }
+                | FlowEvent::RunRetryExhausted { .. }
+                | FlowEvent::RunHostShutdown { .. }
+                | FlowEvent::RunContinuedAsNew { .. }
+        );
+    }
+
+    if !history.is_empty() && !saw_run_created {
+        return Err(
+            crate::execution_identity::ExecutionIdentityError::InvalidClaimField("run_created"),
+        );
+    }
+    let effective_runtime_build = persisted_runtime_build
+        .as_deref()
+        .unwrap_or(runtime_build_id);
+    if effective_runtime_build != LEGACY_UNPINNED_RUNTIME_BUILD_ID {
+        RuntimeBuildId::new(effective_runtime_build.to_string()).map_err(|error| {
+            crate::execution_identity::ExecutionIdentityError::Serialization(format!(
+                "invalid effective dynamic workflow runtime build id: {error}"
+            ))
+        })?;
+    }
+    let plan = dynamic_workflow_execution_plan(history);
+    let plan_identity = plan.definition_identity()?;
+    ExecutionIdentityV1::derive(
+        DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1,
+        &json!({
+            "run_id": run_id,
+            "source_hash": expected_source_hash,
+            "input_identity": input_identity.digest,
+            "runtime_build_id": effective_runtime_build,
+            "plan_identity": plan_identity.digest,
+            "step_identities": step_identities,
+        }),
+    )
+}
+
 /// Project the complete durable Flow history into Code's canonical plan model.
 ///
 /// Flow remains the execution authority; this is a read-only adapter used by
@@ -862,6 +1081,7 @@ pub struct DynamicWorkflowTool {
     graph_observer: Option<FlowGraphObserver>,
     task_scheduler: Option<Arc<TaskScheduler>>,
     admit_steps_globally: bool,
+    runtime_build_compatibility: Option<RuntimeBuildCompatibility>,
 }
 
 enum DynamicWorkflowRegistry {
@@ -885,6 +1105,7 @@ impl DynamicWorkflowTool {
             graph_observer: None,
             task_scheduler: None,
             admit_steps_globally: false,
+            runtime_build_compatibility: None,
         }
     }
 
@@ -894,6 +1115,7 @@ impl DynamicWorkflowTool {
             graph_observer: None,
             task_scheduler: None,
             admit_steps_globally: false,
+            runtime_build_compatibility: None,
         }
     }
 
@@ -914,6 +1136,19 @@ impl DynamicWorkflowTool {
     ) -> Self {
         self.task_scheduler = Some(scheduler);
         self.admit_steps_globally = admit_steps_globally;
+        self
+    }
+
+    /// Fence new and resumed runs to an explicit runtime-build compatibility
+    /// set. By default the tool pins new runs to
+    /// [`DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID`] and temporarily accepts legacy
+    /// unpinned histories; hosts that can replay older builds should add them
+    /// to this compatibility set explicitly.
+    pub fn with_runtime_build_compatibility(
+        mut self,
+        compatibility: RuntimeBuildCompatibility,
+    ) -> Self {
+        self.runtime_build_compatibility = Some(compatibility);
         self
     }
 }
@@ -1001,6 +1236,29 @@ impl Tool for DynamicWorkflowTool {
             .and_then(|value| serde_json::from_value(value).ok())
             .unwrap_or_default();
 
+        let runtime_build_id = match &self.runtime_build_compatibility {
+            Some(compatibility) => compatibility.current_build_id().clone(),
+            None => match RuntimeBuildId::new(DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID.to_string()) {
+                Ok(build_id) => build_id,
+                Err(error) => {
+                    return Ok(ToolOutput::error(format!(
+                        "invalid dynamic workflow runtime build identity: {error}"
+                    )))
+                }
+            },
+        };
+        let runtime_build_compatibility =
+            self.runtime_build_compatibility.clone().unwrap_or_else(|| {
+                RuntimeBuildCompatibility::new(runtime_build_id.clone()).accept_unpinned()
+            });
+        let source_hash = source_hash(source);
+        let base_spec = WorkflowSpec::rust_embedded(
+            "a3s-code.dynamic-workflow",
+            source_hash.as_str(),
+            "ptc",
+            "run",
+        );
+
         let mut runtime = DynamicWorkflowRuntime::new(registry, ctx.clone(), source)
             .with_allowed_tools(allowed_tools)
             .with_limits(limits);
@@ -1014,15 +1272,58 @@ impl Tool for DynamicWorkflowTool {
             Ok(store) => store,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
-        let initial_plan = if let Some(run_id) = requested_run_id {
-            let prior_history = match store.list(run_id).await {
+        let prior_history = if let Some(run_id) = requested_run_id {
+            match store.list(run_id).await {
                 Ok(history) => history,
                 Err(a3s_flow::FlowError::RunNotFound(_)) => Vec::new(),
                 Err(error) => return Ok(ToolOutput::error(error.to_string())),
-            };
-            dynamic_workflow_execution_plan(&prior_history)
+            }
         } else {
+            Vec::new()
+        };
+        // Preserve the immutable build pin already persisted in a resumed
+        // history. A new run is pinned to this worker's current build; a
+        // legacy run remains intentionally unpinned during migration. Keeping
+        // the exact persisted spec is required because Flow treats the whole
+        // workflow definition as the idempotent start contract.
+        let (spec, effective_runtime_build_id) = prior_history
+            .iter()
+            .find_map(|envelope| match &envelope.event {
+                FlowEvent::RunCreated { spec, .. } => Some(spec.clone()),
+                _ => None,
+            })
+            .map(|persisted_spec| {
+                let runtime_build_id = persisted_spec
+                    .runtime_build_id
+                    .as_ref()
+                    .map(ToString::to_string);
+                (persisted_spec, runtime_build_id)
+            })
+            .unwrap_or_else(|| {
+                let spec = base_spec.with_runtime_build(runtime_build_id.clone());
+                (spec, Some(runtime_build_id.to_string()))
+            });
+        if let Some(run_id) = requested_run_id {
+            if let Err(error) = dynamic_workflow_continuation_identity(
+                run_id,
+                source,
+                &input,
+                runtime_build_id.as_str(),
+                &prior_history,
+            ) {
+                return Ok(ToolOutput::error(format!(
+                    "dynamic workflow continuation identity rejected: {error}"
+                )));
+            }
+        } else if let Err(error) = dynamic_workflow_input_identity(&input) {
+            return Ok(ToolOutput::error(format!(
+                "dynamic workflow input identity rejected: {error}"
+            )));
+        }
+        let initial_plan = if prior_history.is_empty() {
             ExecutionPlan::new("dynamic workflow", Complexity::Medium)
+        } else {
+            dynamic_workflow_execution_plan(&prior_history)
         };
         let mut observers: Vec<Arc<dyn FlowEventObserver>> = Vec::new();
         if let Some(tx) = ctx.agent_event_tx.clone() {
@@ -1035,21 +1336,15 @@ impl Tool for DynamicWorkflowTool {
         if let Some(observer) = &self.graph_observer {
             observers.push(Arc::new(observer.clone()));
         }
-        let engine = if observers.is_empty() {
-            FlowEngine::new(store, runtime)
-        } else {
-            FlowEngine::builder(runtime)
-                .with_store(store)
-                .with_observer(Arc::new(FanoutFlowEventObserver::from_observers(observers)))
-                .build()
-        };
-        let source_hash = source_hash(source);
-        let spec = WorkflowSpec::rust_embedded(
-            "a3s-code.dynamic-workflow",
-            source_hash.as_str(),
-            "ptc",
-            "run",
-        );
+        let mut engine_builder = FlowEngine::builder(runtime)
+            .with_store(store)
+            .with_runtime_build_compatibility(runtime_build_compatibility);
+        if !observers.is_empty() {
+            engine_builder = engine_builder
+                .with_observer(Arc::new(FanoutFlowEventObserver::from_observers(observers)));
+        }
+        let engine = engine_builder.build();
+        let input_for_identity = input.clone();
 
         let run_id = match requested_run_id {
             Some(run_id) => match engine.start_with_id(run_id, spec, input).await {
@@ -1069,6 +1364,20 @@ impl Tool for DynamicWorkflowTool {
         let history = match engine.history(&run_id).await {
             Ok(history) => history,
             Err(err) => return Ok(ToolOutput::error(err.to_string())),
+        };
+        let continuation_identity = match dynamic_workflow_continuation_identity(
+            &run_id,
+            source,
+            &input_for_identity,
+            runtime_build_id.as_str(),
+            &history,
+        ) {
+            Ok(identity) => identity,
+            Err(error) => {
+                return Ok(ToolOutput::error(format!(
+                    "dynamic workflow continuation identity rejected after replay: {error}"
+                )))
+            }
         };
 
         let output = match &snapshot.output {
@@ -1093,10 +1402,12 @@ impl Tool for DynamicWorkflowTool {
                 "status": format!("{:?}", snapshot.status),
                 "last_sequence": snapshot.last_sequence,
                 "source_hash": source_hash,
+                "runtime_build_id": effective_runtime_build_id,
                 "snapshot": snapshot,
                 "history": history,
                 "plan": plan,
                 "plan_identity": plan_identity,
+                "continuation_identity": continuation_identity,
                 "admission": runtime_for_metadata.admission_stats(),
             }
         });

--- a/core/src/dynamic_workflow/tests.rs
+++ b/core/src/dynamic_workflow/tests.rs
@@ -883,6 +883,14 @@ return await ctx.read(inputs.input.path);
         crate::execution_identity::EXECUTION_PLAN_IDENTITY_DOMAIN_V1
     );
     assert_eq!(
+        metadata["dynamic_workflow"]["runtime_build_id"],
+        DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID
+    );
+    assert_eq!(
+        metadata["dynamic_workflow"]["continuation_identity"]["domain"],
+        DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1
+    );
+    assert_eq!(
         metadata["dynamic_workflow"]["admission"]["peakActiveSteps"],
         1
     );
@@ -1404,6 +1412,274 @@ async function run(ctx, inputs) {
     assert_eq!(
         metadata["dynamic_workflow"]["snapshot"]["steps"]["retry_once"]["attempt"],
         2
+    );
+
+    // Replaying a terminal run must use the durable completion and never
+    // execute the side-effecting step a third time.
+    let replay = executor
+        .execute(
+            DYNAMIC_WORKFLOW_TOOL,
+            &json!({
+                "source": source,
+                "run_id": "test-dynamic-workflow-inline-retry",
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.exit_code, 0, "{}", replay.output);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        replay.metadata.as_ref().expect("replay metadata")["dynamic_workflow"]
+            ["continuation_identity"]["domain"],
+        DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1
+    );
+
+    // A changed source is a new immutable generation, not a permission to
+    // rerun the old step under the same durable run id.
+    let changed_source = format!("{source}\n// changed generation");
+    let changed = executor
+        .execute(
+            DYNAMIC_WORKFLOW_TOOL,
+            &json!({
+                "source": changed_source,
+                "run_id": "test-dynamic-workflow-inline-retry",
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ne!(changed.exit_code, 0, "changed source must be rejected");
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn dynamic_workflow_continuation_identity_binds_persisted_facts_not_progress() {
+    let run_id = "continuation-identity";
+    let source =
+        "async function run(ctx, inputs) { return { type: 'complete', output: { ok: true } }; }";
+    let input = json!({"secret_path": "scientific-notes.txt"});
+    let runtime_build = RuntimeBuildId::new("code-generation-a").unwrap();
+    let envelope = |sequence, event| {
+        FlowEventEnvelope::new(run_id, sequence, uuid::Uuid::new_v4(), Utc::now(), event)
+    };
+    let spec = WorkflowSpec::rust_embedded(
+        "a3s-code.dynamic-workflow",
+        source_hash(source),
+        "ptc",
+        "run",
+    )
+    .with_runtime_build(runtime_build.clone());
+    let created = envelope(
+        1,
+        FlowEvent::RunCreated {
+            spec,
+            input: input.clone(),
+        },
+    );
+    let step = envelope(
+        2,
+        FlowEvent::StepCreated {
+            step_id: "read".to_string(),
+            step_name: "read".to_string(),
+            input: json!({"path": "scientific-notes.txt"}),
+            retry: Default::default(),
+        },
+    );
+    let before = vec![
+        created.clone(),
+        step.clone(),
+        envelope(
+            3,
+            FlowEvent::StepStarted {
+                step_id: "read".to_string(),
+                attempt: 1,
+            },
+        ),
+    ];
+    let after = vec![
+        created,
+        step.clone(),
+        envelope(
+            3,
+            FlowEvent::StepStarted {
+                step_id: "read".to_string(),
+                attempt: 1,
+            },
+        ),
+        envelope(
+            4,
+            FlowEvent::StepCompleted {
+                step_id: "read".to_string(),
+                output: json!({"content": "secret"}),
+            },
+        ),
+        envelope(
+            5,
+            FlowEvent::RunCompleted {
+                output: json!({"ok": true}),
+            },
+        ),
+    ];
+    let first = dynamic_workflow_continuation_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &before,
+    )
+    .unwrap();
+    let replay = dynamic_workflow_continuation_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &after,
+    )
+    .unwrap();
+    assert_eq!(first, replay);
+    assert!(!serde_json::to_string(&replay)
+        .unwrap()
+        .contains("scientific-notes.txt"));
+
+    let mut conflicting = after.clone();
+    conflicting.push(envelope(
+        6,
+        FlowEvent::StepCreated {
+            step_id: "read".to_string(),
+            step_name: "write".to_string(),
+            input: json!({"path": "scientific-notes.txt"}),
+            retry: Default::default(),
+        },
+    ));
+    assert!(dynamic_workflow_continuation_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &conflicting,
+    )
+    .is_err());
+
+    let mut conflicting_retry = before.clone();
+    conflicting_retry.push(envelope(
+        4,
+        FlowEvent::StepCreated {
+            step_id: "read".to_string(),
+            step_name: "read".to_string(),
+            input: json!({"path": "scientific-notes.txt"}),
+            retry: a3s_flow::RetryPolicy::fixed(2, Duration::from_millis(1)),
+        },
+    ));
+    assert!(dynamic_workflow_continuation_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &conflicting_retry,
+    )
+    .is_err());
+
+    let mut malformed_sequence = before.clone();
+    malformed_sequence[2].sequence = 4;
+    assert!(dynamic_workflow_continuation_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &malformed_sequence,
+    )
+    .is_err());
+}
+
+#[tokio::test]
+async fn dynamic_workflow_rejects_a_stale_runtime_generation_before_replay() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let source = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    return { type: "wait_until", wait_id: "operator", resume_at: "2099-01-01T00:00:00Z" };
+  }
+  return { error: "unexpected invocation" };
+}
+"#;
+    let v1 = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_runtime_build_compatibility(RuntimeBuildCompatibility::new(
+            RuntimeBuildId::new("code-generation-a").unwrap(),
+        ));
+    let args = json!({
+        "source": source,
+        "run_id": "stale-generation-run",
+    });
+    let first = v1
+        .execute(&args, &executor.registry().context())
+        .await
+        .unwrap();
+    assert!(!first.success);
+
+    let v2 = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_runtime_build_compatibility(RuntimeBuildCompatibility::new(
+            RuntimeBuildId::new("code-generation-b").unwrap(),
+        ));
+    let replay = v2
+        .execute(&args, &executor.registry().context())
+        .await
+        .unwrap();
+    assert!(!replay.success);
+    assert!(
+        replay.content.contains("conflicts with existing run")
+            || replay.content.contains("runtime build")
+    );
+}
+
+#[tokio::test]
+async fn dynamic_workflow_keeps_legacy_unpinned_terminal_runs_readable() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let source = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    return { type: "complete", output: { legacy: true } };
+  }
+  return { error: "unexpected invocation" };
+}
+"#;
+    let context = executor.registry().context();
+    let runtime = Arc::new(DynamicWorkflowRuntime::new(
+        Arc::clone(executor.registry()),
+        context.clone(),
+        source,
+    ));
+    let store = Arc::new(LocalFileEventStore::new(dynamic_workflow_store_path(
+        dir.path(),
+    )));
+    let legacy_engine = FlowEngine::new(store, runtime);
+    let spec = WorkflowSpec::rust_embedded(
+        "a3s-code.dynamic-workflow",
+        source_hash(source),
+        "ptc",
+        "run",
+    );
+    legacy_engine
+        .start_with_id("legacy-unpinned-run", spec, json!({}))
+        .await
+        .unwrap();
+
+    let replay = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .execute(
+            &json!({
+                "source": source,
+                "run_id": "legacy-unpinned-run",
+            }),
+            &context,
+        )
+        .await
+        .unwrap();
+    assert!(replay.success, "{}", replay.content);
+    let metadata = replay.metadata.expect("legacy replay metadata");
+    assert!(metadata["dynamic_workflow"]["runtime_build_id"].is_null());
+    assert_eq!(
+        metadata["dynamic_workflow"]["continuation_identity"]["domain"],
+        DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1
     );
 }
 

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -20,6 +20,13 @@ pub const FLOW_DECISION_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-decision.ident
 /// the former are identified by the Flow run/step/name and JSON input, while
 /// the latter are identified by an [`AgentStepSpec`](crate::orchestration::AgentStepSpec).
 pub const FLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-step.identity.v1";
+/// Identity domain for the immutable input portion of a dynamic workflow.
+pub const DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1: &str =
+    "a3s.code.dynamic-workflow.input.identity.v1";
+/// Identity domain for a dynamic workflow continuation reconstructed from its
+/// durable immutable facts.
+pub const DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1: &str =
+    "a3s.code.dynamic-workflow.continuation.identity.v1";
 /// Identity domain for the immutable definition of a projected execution plan.
 pub const EXECUTION_PLAN_IDENTITY_DOMAIN_V1: &str = "a3s.code.execution-plan.identity.v1";
 pub const WORKFLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.workflow-step.identity.v1";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -224,10 +224,11 @@ pub use durable_memory::{
     DURABLE_MEMORY_SEMANTIC_REFRESH_PROFILE_V1,
 };
 pub use dynamic_workflow::{
-    dynamic_workflow_execution_plan, dynamic_workflow_step_identity, dynamic_workflow_store_path,
+    dynamic_workflow_continuation_identity, dynamic_workflow_execution_plan,
+    dynamic_workflow_step_identity, dynamic_workflow_store_path,
     register_dynamic_workflow_with_scheduler, DynamicWorkflowAdmissionStats,
     DynamicWorkflowRuntime, DynamicWorkflowScriptLimits, DynamicWorkflowTool,
-    DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,
+    DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID, DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,
 };
 pub use embedding::{
     EmbeddingBatchRequest, EmbeddingBatchResponse, EmbeddingError, EmbeddingExecution,


### PR DESCRIPTION
## Summary
- pin new dynamic workflow runs to a runtime build while preserving legacy unpinned histories during migration
- derive digest-only continuation identities from durable RunCreated/StepCreated facts
- reject changed source/input, malformed history, duplicate/conflicting step definitions, and stale active generations before step bodies
- prove terminal replay idempotence and legacy compatibility

## Validation
- cargo +stable test -p a3s-code-core --lib -- --nocapture (3164 passed, 13 ignored)
- cargo +stable test -p a3s-code-core dynamic_workflow --lib -- --nocapture (32 passed)
- cargo +stable test -p a3s-code-core --tests --no-run
- cargo +stable check -p a3s-code-core --all-features
- RUSTDOCFLAGS="-D warnings" cargo +stable doc -p a3s-code-core --no-deps