### PR TITLE
feat(core): fence dynamic workflow cancellation takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added parent-cancellation and worker-takeover fencing for dynamic workflows.
+  Each run derives one stable digest-only claim identity, uses a shared local
+  file lease (or an injected host ledger), renews the lease while Flow replay
+  and inline retries are active, and rechecks ownership before workflow and
+  step admission. Expired owners cannot complete a reclaimed run; cooperative
+  parent cancellation settles and releases only after the execution future has
+  stopped, while an unsettled future keeps its lease fenced until expiry.
 - Added mixed-generation qualification for dynamic workflows. New runs pin
   the Code runtime build, continuation identities are reconstructed from the
   durable Run/step definitions without a second journal, and changed source,

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   from durable immutable facts. Changed source/input, conflicting step
   definitions, and unsupported runtime generations are rejected before step
   execution, while legacy unpinned histories remain readable during
-  migration.
+  migration. A stable claim identity now gates each worker with a local
+  file-backed (or host-injected) lease, heartbeats keep live owners fenced,
+  stale workers are rejected before workflow/step admission, and parent
+  cancellation settles or leaves the lease fenced rather than releasing an
+  in-flight worker.
 
 Go consumers must update the module path to
 `github.com/A3S-Lab/Code/sdk/go/v8`. See [CHANGELOG.md](CHANGELOG.md) for the
@@ -1039,7 +1043,12 @@ query cache. A resumed run reconstructs its complete plan from durable
 history, so progress does not lose steps emitted before the current process.
 New runs also persist an exact runtime-build requirement; the continuation
 identity is recomputed from the persisted RunCreated/StepCreated facts on every
-resume, without storing source, input, or output plaintext in the identity.
+resume, without storing source, input, or output plaintext in the identity. The
+worker claim identity intentionally excludes evolving plan progress, so
+takeover and retry use one stable digest. Local claim metadata lives under
+`.a3s/workflow/leases`; A3S Flow's event history remains the sole workflow
+authority, and the sidecar contains only bounded digests, owner leases, and
+attempt state.
 
 Delegated tasks, workflows, and Skill child runs retain the parent sandbox and
 intersect local permission policy with the parent checker. A child auto-approve

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -294,8 +294,8 @@ from deadlocking on a nested lease. Delegated tasks now pass their canonical
 step identity through that same global scheduler boundary.
 
 The follow-up mixed-generation continuation qualification is recorded in
-section 3.3.3. Cloud/Use package ownership, fairness policy, and business-level
-retry decisions remain outside Code.
+sections 3.3.3 and 3.3.4. Cloud/Use package ownership, fairness policy, and
+business-level retry decisions remain outside Code.
 
 ### 3.3.3 Mixed-generation continuation qualification
 
@@ -318,10 +318,31 @@ side-effecting step and a worker on a different build cannot resume an active
 run. Legacy unpinned histories remain readable only inside the explicit
 migration window.
 
-The next slice is parent-cancellation and takeover qualification for a
-non-terminal continuation: carry the persisted continuation identity through a
-worker claim, fence a stale lease before admission, and prove a cancelled or
-reclaimed step cannot commit a duplicate side effect. Cloud/Use ownership,
+### 3.3.4 Parent cancellation and worker takeover
+
+The non-terminal continuation boundary now carries a stable claim identity
+through worker admission. The identity is derived only from the run id, source
+hash, initial-input digest, and effective runtime build; evolving plan progress,
+retry counters, and outputs cannot create a second claim. Local workspaces use
+an atomic file-backed lease sidecar at `.a3s/workflow/leases`, remote hosts may
+inject any `FlowDecisionLedger`, and in-memory hosts retain one tool-scoped
+ledger. Neither path stores workflow source, input, output, or owner secrets.
+
+An admitted worker renews its lease during Flow replay and inline retry waits,
+and the runtime revalidates ownership immediately before each workflow or step
+body. A stale owner therefore cannot start new work or complete a claim after a
+takeover. Parent cancellation propagates to a child `ToolContext`; the worker
+waits a bounded settlement window, releases only after the execution future has
+stopped, and leaves an unsettled lease fenced until it expires. Completion uses
+the same identity/owner/lease checks as Flow decision dispatch. Qualification
+now covers cross-worker busy claims, expired-owner fencing, cancellation at a
+retry boundary, pre-admission lease loss, generated run ids, and digest-only
+sidecar records.
+
+The event-sourced Flow history remains the workflow authority. Exactly-once
+external effects still require the invoked Tool or host to provide its own
+idempotency/receipt contract; Code does not pretend that a lease can undo an
+effect that was committed outside the Flow journal. Cloud/Use ownership,
 retention, and business retry policy remain outside Code.
 
 ### 3.4 Scoped capability program

--- a/core/src/dynamic_workflow.rs
+++ b/core/src/dynamic_workflow.rs
@@ -5,8 +5,9 @@
 //! existing `program` tool remains the sandbox and tool-call boundary.
 
 use crate::execution_identity::{
-    ExecutionIdentityV1, DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1,
-    DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1, FLOW_STEP_IDENTITY_DOMAIN_V1,
+    ExecutionIdentityV1, DYNAMIC_WORKFLOW_CLAIM_IDENTITY_DOMAIN_V1,
+    DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1, DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1,
+    FLOW_STEP_IDENTITY_DOMAIN_V1,
 };
 use crate::llm::{ModelGenerationAdmission, ModelGenerationConcurrency};
 use crate::task_scheduler::{TaskLease, TaskPriority as SchedulerTaskPriority, TaskScheduler};
@@ -15,7 +16,10 @@ use crate::tools::{
 };
 use crate::{
     agent::AgentEvent,
-    flow_graph::FlowGraphObserver,
+    flow_graph::{
+        FileFlowDecisionLedger, FlowDecisionClaimOutcome, FlowDecisionLedger, FlowGraphObserver,
+        MemoryFlowDecisionLedger,
+    },
     planning::{Complexity, ExecutionPlan, Task, TaskStatus},
 };
 use a3s_flow::{
@@ -34,8 +38,9 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
 
 const DYNAMIC_WORKFLOW_TOOL: &str = "dynamic_workflow";
 const GENERATE_OBJECT_TOOL: &str = "generate_object";
@@ -49,6 +54,9 @@ const MAX_MAX_CONCURRENT_STEPS: usize = 32;
 const MAX_FLOW_STEP_ID_BYTES: usize = 256;
 const MAX_FLOW_STEP_INPUT_BYTES: usize = 64 * 1024;
 const MAX_DYNAMIC_WORKFLOW_INPUT_BYTES: usize = 128 * 1024;
+const DEFAULT_DYNAMIC_WORKFLOW_LEASE_MS: u64 = 30_000;
+const MAX_DYNAMIC_WORKFLOW_SETTLE: Duration = Duration::from_secs(5);
+const DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH: &str = "leases";
 
 /// Runtime build used to pin newly-created dynamic workflow runs.
 ///
@@ -283,6 +291,7 @@ pub struct DynamicWorkflowRuntime {
     /// should leave this unset to avoid nested single-slot deadlocks.
     task_scheduler: Option<Arc<TaskScheduler>>,
     admit_steps_globally: bool,
+    continuation_lease: Option<Arc<DynamicWorkflowLease>>,
 }
 
 impl DynamicWorkflowRuntime {
@@ -308,6 +317,7 @@ impl DynamicWorkflowRuntime {
             step_admission: DynamicStepAdmission::new(DEFAULT_MAX_CONCURRENT_STEPS),
             task_scheduler: None,
             admit_steps_globally: false,
+            continuation_lease: None,
         }
     }
 
@@ -348,12 +358,18 @@ impl DynamicWorkflowRuntime {
         self
     }
 
+    fn with_continuation_lease(mut self, lease: Arc<DynamicWorkflowLease>) -> Self {
+        self.continuation_lease = Some(lease);
+        self
+    }
+
     /// Return local Flow-step admission counters for diagnostics and hosts.
     pub fn admission_stats(&self) -> DynamicWorkflowAdmissionStats {
         self.step_admission.stats()
     }
 
     async fn admit_step(&self, invocation: &StepInvocation) -> a3s_flow::Result<DynamicStepLease> {
+        self.ensure_continuation_lease().await?;
         let identity = dynamic_workflow_step_identity(
             &invocation.run_id,
             &invocation.step_id,
@@ -396,6 +412,23 @@ impl DynamicWorkflowRuntime {
             lease = lease.with_task_lease(task_lease);
         }
         Ok(lease)
+    }
+
+    async fn ensure_continuation_lease(&self) -> a3s_flow::Result<()> {
+        let Some(lease) = self.continuation_lease.as_ref() else {
+            return Ok(());
+        };
+        if lease
+            .renew()
+            .await
+            .map_err(|error| a3s_flow::FlowError::Runtime(error.to_string()))?
+        {
+            Ok(())
+        } else {
+            Err(a3s_flow::FlowError::Runtime(
+                "dynamic workflow worker lease is no longer owned before admission".to_string(),
+            ))
+        }
     }
 
     async fn run_script(
@@ -514,6 +547,7 @@ impl FlowRuntime for DynamicWorkflowRuntime {
         &self,
         invocation: WorkflowInvocation,
     ) -> a3s_flow::Result<RuntimeCommand> {
+        self.ensure_continuation_lease().await?;
         let payload = invocation_payload("workflow", &invocation.run_id, &invocation.history)
             .with("input", invocation.input);
         let result = self.run_script(payload.into_value(), &self.context).await?;
@@ -610,6 +644,45 @@ fn dynamic_workflow_input_identity(
         );
     }
     ExecutionIdentityV1::derive(DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1, input)
+}
+
+/// Derive the stable, digest-only claim identity for one dynamic workflow.
+///
+/// Unlike the continuation identity, this identity intentionally excludes the
+/// evolving plan and step history. It therefore remains constant while a
+/// worker replays, retries, or takes over the same durable run. The complete
+/// continuation identity is still validated first, so malformed or
+/// mixed-generation history can never acquire a worker lease.
+pub fn dynamic_workflow_claim_identity(
+    run_id: &str,
+    source: &str,
+    input: &Value,
+    runtime_build_id: &str,
+    history: &[FlowEventEnvelope],
+) -> std::result::Result<ExecutionIdentityV1, crate::execution_identity::ExecutionIdentityError> {
+    dynamic_workflow_continuation_identity(run_id, source, input, runtime_build_id, history)?;
+    let input_identity = dynamic_workflow_input_identity(input)?;
+    let effective_runtime_build_id = history
+        .iter()
+        .find_map(|envelope| match &envelope.event {
+            FlowEvent::RunCreated { spec, .. } => Some(
+                spec.runtime_build_id
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| LEGACY_UNPINNED_RUNTIME_BUILD_ID.to_string()),
+            ),
+            _ => None,
+        })
+        .unwrap_or_else(|| runtime_build_id.to_string());
+    ExecutionIdentityV1::derive(
+        DYNAMIC_WORKFLOW_CLAIM_IDENTITY_DOMAIN_V1,
+        &json!({
+            "run_id": run_id,
+            "source_hash": source_hash(source),
+            "input_identity": input_identity.digest,
+            "runtime_build_id": effective_runtime_build_id,
+        }),
+    )
 }
 
 /// Reconstruct the immutable identity of a dynamic workflow continuation.
@@ -1075,6 +1148,131 @@ fn bounded_workflow_description(value: &str) -> String {
     format!("{}…", &value[..end])
 }
 
+#[derive(Clone)]
+struct DynamicWorkflowLease {
+    ledger: Arc<dyn FlowDecisionLedger>,
+    decision_id: String,
+    request_hash: String,
+    identity: ExecutionIdentityV1,
+    owner_id: String,
+    lease_ms: u64,
+    attempt: u32,
+}
+
+impl DynamicWorkflowLease {
+    async fn renew(&self) -> Result<bool> {
+        self.ledger
+            .renew_with_identity(
+                &self.decision_id,
+                &self.request_hash,
+                &self.identity,
+                &self.owner_id,
+                dynamic_workflow_now_ms(),
+                self.lease_ms,
+            )
+            .await
+    }
+
+    async fn complete(&self) -> Result<()> {
+        self.ledger
+            .complete_with_identity(
+                &self.decision_id,
+                &self.request_hash,
+                &self.identity,
+                &self.owner_id,
+                dynamic_workflow_now_ms(),
+            )
+            .await
+    }
+
+    async fn release(&self) -> Result<()> {
+        self.ledger
+            .release_with_identity(
+                &self.decision_id,
+                &self.request_hash,
+                &self.identity,
+                &self.owner_id,
+            )
+            .await
+    }
+}
+
+enum DynamicWorkflowLeaseClaim {
+    Owned(DynamicWorkflowLease),
+    AlreadyCompleted,
+}
+
+async fn claim_dynamic_workflow_lease(
+    ledger: Arc<dyn FlowDecisionLedger>,
+    identity: ExecutionIdentityV1,
+    lease_ms: u64,
+) -> Result<DynamicWorkflowLeaseClaim> {
+    identity
+        .validate()
+        .map_err(|error| anyhow::anyhow!(error))?;
+    let decision_id = format!("dynamic-workflow:{}", identity.digest);
+    let request_hash = identity.digest.clone();
+    let owner_id = format!("dynamic-workflow-worker-{}", uuid::Uuid::new_v4());
+    let outcome = ledger
+        .claim_with_identity(
+            &decision_id,
+            &request_hash,
+            &identity,
+            &owner_id,
+            dynamic_workflow_now_ms(),
+            lease_ms,
+        )
+        .await
+        .context("admit dynamic workflow worker lease")?;
+    match outcome {
+        FlowDecisionClaimOutcome::Claimed { attempt } => {
+            Ok(DynamicWorkflowLeaseClaim::Owned(DynamicWorkflowLease {
+                ledger,
+                decision_id,
+                request_hash,
+                identity,
+                owner_id,
+                lease_ms,
+                attempt,
+            }))
+        }
+        FlowDecisionClaimOutcome::Completed => Ok(DynamicWorkflowLeaseClaim::AlreadyCompleted),
+        FlowDecisionClaimOutcome::Busy {
+            lease_expires_at_ms,
+        } => anyhow::bail!("dynamic workflow worker lease is busy until {lease_expires_at_ms}"),
+        FlowDecisionClaimOutcome::Conflict => {
+            anyhow::bail!("dynamic workflow worker lease identity conflicts with its claim")
+        }
+    }
+}
+
+fn dynamic_workflow_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+fn is_terminal_workflow_event(event: &FlowEvent) -> bool {
+    matches!(
+        event,
+        FlowEvent::RunCompleted { .. }
+            | FlowEvent::RunFailed { .. }
+            | FlowEvent::RunCancelled { .. }
+            | FlowEvent::RunTimedOut { .. }
+            | FlowEvent::RunRetryExhausted { .. }
+            | FlowEvent::RunHostShutdown { .. }
+            | FlowEvent::RunContinuedAsNew { .. }
+    )
+}
+
+fn history_is_terminal(history: &[FlowEventEnvelope]) -> bool {
+    history
+        .last()
+        .is_some_and(|envelope| is_terminal_workflow_event(&envelope.event))
+}
+
 /// Model-visible tool that executes a dynamic workflow through A3S Flow.
 pub struct DynamicWorkflowTool {
     registry: DynamicWorkflowRegistry,
@@ -1082,6 +1280,9 @@ pub struct DynamicWorkflowTool {
     task_scheduler: Option<Arc<TaskScheduler>>,
     admit_steps_globally: bool,
     runtime_build_compatibility: Option<RuntimeBuildCompatibility>,
+    continuation_lease_ledger: Option<Arc<dyn FlowDecisionLedger>>,
+    continuation_lease_ms: u64,
+    memory_continuation_lease_ledger: Arc<MemoryFlowDecisionLedger>,
 }
 
 enum DynamicWorkflowRegistry {
@@ -1106,6 +1307,9 @@ impl DynamicWorkflowTool {
             task_scheduler: None,
             admit_steps_globally: false,
             runtime_build_compatibility: None,
+            continuation_lease_ledger: None,
+            continuation_lease_ms: DEFAULT_DYNAMIC_WORKFLOW_LEASE_MS,
+            memory_continuation_lease_ledger: Arc::new(MemoryFlowDecisionLedger::new()),
         }
     }
 
@@ -1116,6 +1320,9 @@ impl DynamicWorkflowTool {
             task_scheduler: None,
             admit_steps_globally: false,
             runtime_build_compatibility: None,
+            continuation_lease_ledger: None,
+            continuation_lease_ms: DEFAULT_DYNAMIC_WORKFLOW_LEASE_MS,
+            memory_continuation_lease_ledger: Arc::new(MemoryFlowDecisionLedger::new()),
         }
     }
 
@@ -1150,6 +1357,51 @@ impl DynamicWorkflowTool {
     ) -> Self {
         self.runtime_build_compatibility = Some(compatibility);
         self
+    }
+
+    /// Use a caller-owned durable lease ledger for worker admission.
+    ///
+    /// The ledger stores only claim metadata and digests; A3S Flow's event
+    /// store remains the workflow source of truth. Hosts that run multiple
+    /// workers should provide a shared ledger (for example a
+    /// [`FileFlowDecisionLedger`]) and choose a lease long enough for one
+    /// heartbeat interval. Without an explicit ledger, local workspaces use a
+    /// sidecar file ledger and remote/in-memory contexts use a tool-scoped
+    /// memory ledger.
+    pub fn with_continuation_lease_ledger(
+        mut self,
+        ledger: Arc<dyn FlowDecisionLedger>,
+        lease_ms: u64,
+    ) -> Self {
+        self.continuation_lease_ledger = Some(ledger);
+        self.continuation_lease_ms = lease_ms.max(1);
+        self
+    }
+
+    /// Change the default worker lease while retaining automatic ledger
+    /// selection.
+    pub fn with_continuation_lease_ms(mut self, lease_ms: u64) -> Self {
+        self.continuation_lease_ms = lease_ms.max(1);
+        self
+    }
+
+    async fn continuation_lease_ledger_for_context(
+        &self,
+        ctx: &ToolContext,
+    ) -> Result<Arc<dyn FlowDecisionLedger>> {
+        if let Some(ledger) = &self.continuation_lease_ledger {
+            return Ok(Arc::clone(ledger));
+        }
+        let Some(root) = ctx.workspace_services.local_root() else {
+            let ledger: Arc<dyn FlowDecisionLedger> = self.memory_continuation_lease_ledger.clone();
+            return Ok(ledger);
+        };
+        let workflow_root = dynamic_workflow_store_path(root);
+        validate_dynamic_workflow_directory(&root.join(".a3s"), ".a3s").await?;
+        validate_dynamic_workflow_directory(&workflow_root, ".a3s/workflow").await?;
+        let lease_root = workflow_root.join(DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH);
+        validate_dynamic_workflow_directory(&lease_root, ".a3s/workflow/leases").await?;
+        Ok(Arc::new(FileFlowDecisionLedger::new(lease_root)))
     }
 }
 
@@ -1259,27 +1511,28 @@ impl Tool for DynamicWorkflowTool {
             "run",
         );
 
-        let mut runtime = DynamicWorkflowRuntime::new(registry, ctx.clone(), source)
-            .with_allowed_tools(allowed_tools)
-            .with_limits(limits);
-        if let Some(scheduler) = &self.task_scheduler {
-            runtime = runtime.with_task_scheduler(Arc::clone(scheduler), self.admit_steps_globally);
+        if ctx.is_cancelled() {
+            return Ok(ToolOutput::error(
+                "dynamic_workflow was cancelled before admission",
+            ));
         }
-        let runtime = Arc::new(runtime);
-        let runtime_for_metadata = Arc::clone(&runtime);
         let requested_run_id = args.get("run_id").and_then(Value::as_str);
-        let store = match flow_store_for_context(ctx, requested_run_id).await {
+        if requested_run_id.is_some_and(|run_id| !safe_workflow_run_id(run_id)) {
+            return Ok(ToolOutput::error(
+                "dynamic_workflow run_id must contain only ASCII letters, numbers, '-' or '_'",
+            ));
+        }
+        let run_id = requested_run_id
+            .map(ToString::to_string)
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let store = match flow_store_for_context(ctx, Some(&run_id)).await {
             Ok(store) => store,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
-        let prior_history = if let Some(run_id) = requested_run_id {
-            match store.list(run_id).await {
-                Ok(history) => history,
-                Err(a3s_flow::FlowError::RunNotFound(_)) => Vec::new(),
-                Err(error) => return Ok(ToolOutput::error(error.to_string())),
-            }
-        } else {
-            Vec::new()
+        let prior_history = match store.list(&run_id).await {
+            Ok(history) => history,
+            Err(a3s_flow::FlowError::RunNotFound(_)) => Vec::new(),
+            Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
         // Preserve the immutable build pin already persisted in a resumed
         // history. A new run is pinned to this worker's current build; a
@@ -1303,23 +1556,59 @@ impl Tool for DynamicWorkflowTool {
                 let spec = base_spec.with_runtime_build(runtime_build_id.clone());
                 (spec, Some(runtime_build_id.to_string()))
             });
-        if let Some(run_id) = requested_run_id {
-            if let Err(error) = dynamic_workflow_continuation_identity(
-                run_id,
-                source,
-                &input,
-                runtime_build_id.as_str(),
-                &prior_history,
-            ) {
+        let claim_identity = match dynamic_workflow_claim_identity(
+            &run_id,
+            source,
+            &input,
+            runtime_build_id.as_str(),
+            &prior_history,
+        ) {
+            Ok(identity) => identity,
+            Err(error) => {
                 return Ok(ToolOutput::error(format!(
                     "dynamic workflow continuation identity rejected: {error}"
-                )));
+                )))
             }
-        } else if let Err(error) = dynamic_workflow_input_identity(&input) {
-            return Ok(ToolOutput::error(format!(
-                "dynamic workflow input identity rejected: {error}"
-            )));
+        };
+        let lease_ledger = match self.continuation_lease_ledger_for_context(ctx).await {
+            Ok(ledger) => ledger,
+            Err(error) => return Ok(ToolOutput::error(error.to_string())),
+        };
+        let lease_claim = match claim_dynamic_workflow_lease(
+            lease_ledger,
+            claim_identity,
+            self.continuation_lease_ms,
+        )
+        .await
+        {
+            Ok(claim) => claim,
+            Err(error) => return Ok(ToolOutput::error(error.to_string())),
+        };
+        let (lease, mut lease_state) = match lease_claim {
+            DynamicWorkflowLeaseClaim::Owned(lease) => (Some(lease), "claimed"),
+            DynamicWorkflowLeaseClaim::AlreadyCompleted => {
+                if !history_is_terminal(&prior_history) {
+                    return Ok(ToolOutput::error(
+                        "dynamic workflow worker claim is completed but its durable run is not terminal",
+                    ));
+                }
+                (None, "already_completed")
+            }
+        };
+        let parent_cancellation = ctx.cancellation_token();
+        let child_cancellation = parent_cancellation.child_token();
+        let workflow_context = ctx.clone().with_cancellation(child_cancellation.clone());
+        let mut runtime = DynamicWorkflowRuntime::new(registry, workflow_context.clone(), source)
+            .with_allowed_tools(allowed_tools)
+            .with_limits(limits);
+        if let Some(scheduler) = &self.task_scheduler {
+            runtime = runtime.with_task_scheduler(Arc::clone(scheduler), self.admit_steps_globally);
         }
+        if let Some(lease) = lease.as_ref() {
+            runtime = runtime.with_continuation_lease(Arc::new(lease.clone()));
+        }
+        let runtime = Arc::new(runtime);
+        let runtime_for_metadata = Arc::clone(&runtime);
         let initial_plan = if prior_history.is_empty() {
             ExecutionPlan::new("dynamic workflow", Complexity::Medium)
         } else {
@@ -1346,39 +1635,63 @@ impl Tool for DynamicWorkflowTool {
         let engine = engine_builder.build();
         let input_for_identity = input.clone();
 
-        let run_id = match requested_run_id {
-            Some(run_id) => match engine.start_with_id(run_id, spec, input).await {
+        let execution_result = if let Some(lease) = lease.as_ref() {
+            drive_dynamic_workflow_with_lease(
+                &engine,
+                &run_id,
+                spec,
+                input,
+                DynamicWorkflowDriveContext {
+                    source,
+                    input_for_identity: &input_for_identity,
+                    runtime_build_id: runtime_build_id.as_str(),
+                    workflow_context: &workflow_context,
+                    parent_cancellation,
+                    child_cancellation,
+                },
+                lease,
+            )
+            .await
+        } else {
+            let started_run_id = match engine.start_with_id(&run_id, spec, input).await {
                 Ok(run_id) => run_id,
-                Err(err) => return Ok(ToolOutput::error(err.to_string())),
-            },
-            None => match engine.start(spec, input).await {
-                Ok(run_id) => run_id,
-                Err(err) => return Ok(ToolOutput::error(err.to_string())),
-            },
-        };
-
-        let snapshot = match drive_inline_retries(&engine, &run_id, ctx).await {
-            Ok(snapshot) => snapshot,
-            Err(err) => return Ok(ToolOutput::error(err.to_string())),
-        };
-        let history = match engine.history(&run_id).await {
-            Ok(history) => history,
-            Err(err) => return Ok(ToolOutput::error(err.to_string())),
-        };
-        let continuation_identity = match dynamic_workflow_continuation_identity(
-            &run_id,
-            source,
-            &input_for_identity,
-            runtime_build_id.as_str(),
-            &history,
-        ) {
-            Ok(identity) => identity,
-            Err(error) => {
+                Err(error) => return Ok(ToolOutput::error(error.to_string())),
+            };
+            if started_run_id != run_id {
                 return Ok(ToolOutput::error(format!(
-                    "dynamic workflow continuation identity rejected after replay: {error}"
-                )))
+                    "dynamic workflow engine returned unexpected run id `{started_run_id}` for `{run_id}`"
+                )));
             }
+            let snapshot = match drive_inline_retries(&engine, &run_id, &workflow_context).await {
+                Ok(snapshot) => snapshot,
+                Err(error) => return Ok(ToolOutput::error(error.to_string())),
+            };
+            collect_dynamic_workflow_execution(
+                &engine,
+                &run_id,
+                snapshot,
+                source,
+                &input_for_identity,
+                runtime_build_id.as_str(),
+            )
+            .await
         };
+        let execution = match execution_result {
+            Ok(execution) => execution,
+            Err(err) => return Ok(ToolOutput::error(err.to_string())),
+        };
+        let DynamicWorkflowExecution {
+            snapshot,
+            history,
+            continuation_identity,
+        } = execution;
+        if lease.is_some() {
+            lease_state = if snapshot.status.is_terminal() {
+                "completed"
+            } else {
+                "released"
+            };
+        }
 
         let output = match &snapshot.output {
             Some(output) => {
@@ -1408,6 +1721,10 @@ impl Tool for DynamicWorkflowTool {
                 "plan": plan,
                 "plan_identity": plan_identity,
                 "continuation_identity": continuation_identity,
+                "worker_lease": {
+                    "state": lease_state,
+                    "attempt": lease.as_ref().map(|lease| lease.attempt),
+                },
                 "admission": runtime_for_metadata.admission_stats(),
             }
         });
@@ -1420,6 +1737,165 @@ impl Tool for DynamicWorkflowTool {
         };
 
         Ok(output.with_metadata(metadata))
+    }
+}
+
+struct DynamicWorkflowExecution {
+    snapshot: WorkflowRunSnapshot,
+    history: Vec<FlowEventEnvelope>,
+    continuation_identity: ExecutionIdentityV1,
+}
+
+struct DynamicWorkflowDriveContext<'a> {
+    source: &'a str,
+    input_for_identity: &'a Value,
+    runtime_build_id: &'a str,
+    workflow_context: &'a ToolContext,
+    parent_cancellation: CancellationToken,
+    child_cancellation: CancellationToken,
+}
+
+async fn collect_dynamic_workflow_execution(
+    engine: &FlowEngine,
+    run_id: &str,
+    snapshot: WorkflowRunSnapshot,
+    source: &str,
+    input: &Value,
+    runtime_build_id: &str,
+) -> Result<DynamicWorkflowExecution> {
+    let history = engine.history(run_id).await?;
+    let continuation_identity =
+        dynamic_workflow_continuation_identity(run_id, source, input, runtime_build_id, &history)
+            .map_err(|error| {
+            anyhow::anyhow!("dynamic workflow continuation identity rejected after replay: {error}")
+        })?;
+    Ok(DynamicWorkflowExecution {
+        snapshot,
+        history,
+        continuation_identity,
+    })
+}
+
+async fn settle_dynamic_workflow_lease(
+    lease: &DynamicWorkflowLease,
+    result: Result<DynamicWorkflowExecution>,
+) -> Result<DynamicWorkflowExecution> {
+    match result {
+        Ok(execution) if execution.snapshot.status.is_terminal() => {
+            lease
+                .complete()
+                .await
+                .context("complete dynamic workflow worker lease")?;
+            Ok(execution)
+        }
+        Ok(execution) => {
+            lease
+                .release()
+                .await
+                .context("release suspended dynamic workflow worker lease")?;
+            Ok(execution)
+        }
+        Err(error) => {
+            if let Err(release_error) = lease.release().await {
+                tracing::warn!(
+                    error = %release_error,
+                    "failed to release dynamic workflow worker lease after execution error"
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn drive_dynamic_workflow_with_lease(
+    engine: &FlowEngine,
+    run_id: &str,
+    spec: WorkflowSpec,
+    input: Value,
+    drive_context: DynamicWorkflowDriveContext<'_>,
+    lease: &DynamicWorkflowLease,
+) -> Result<DynamicWorkflowExecution> {
+    let DynamicWorkflowDriveContext {
+        source,
+        input_for_identity,
+        runtime_build_id,
+        workflow_context,
+        parent_cancellation,
+        child_cancellation,
+    } = drive_context;
+    let execution = async {
+        let started_run_id = engine.start_with_id(run_id, spec, input).await?;
+        if started_run_id != run_id {
+            anyhow::bail!(
+                "dynamic workflow engine returned unexpected run id `{started_run_id}` for `{run_id}`"
+            );
+        }
+        let snapshot = drive_inline_retries(engine, run_id, workflow_context).await?;
+        collect_dynamic_workflow_execution(
+            engine,
+            run_id,
+            snapshot,
+            source,
+            input_for_identity,
+            runtime_build_id,
+        )
+        .await
+    };
+    tokio::pin!(execution);
+
+    let heartbeat_period = Duration::from_millis((lease.lease_ms / 3).max(1));
+    let first_heartbeat = tokio::time::Instant::now() + heartbeat_period;
+    let mut heartbeat = tokio::time::interval_at(first_heartbeat, heartbeat_period);
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut execution => {
+                return settle_dynamic_workflow_lease(lease, result).await;
+            }
+            _ = parent_cancellation.cancelled() => {
+                child_cancellation.cancel();
+                match tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut execution).await {
+                    Ok(result) => {
+                        match settle_dynamic_workflow_lease(lease, result).await {
+                            Ok(execution) if execution.snapshot.status.is_terminal() => {
+                                return Ok(execution)
+                            }
+                            Ok(_) => anyhow::bail!("dynamic workflow cancelled by its parent"),
+                            Err(error) => return Err(error).context("settle dynamic workflow cancellation"),
+                        }
+                    }
+                    Err(_) => anyhow::bail!(
+                        "dynamic workflow cancellation did not settle within {} seconds; worker lease remains fenced until expiry",
+                        MAX_DYNAMIC_WORKFLOW_SETTLE.as_secs()
+                    ),
+                }
+            }
+            _ = heartbeat.tick() => {
+                match lease.renew().await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        child_cancellation.cancel();
+                        if tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut execution)
+                            .await
+                            .is_ok()
+                        {
+                            let _ = lease.release().await;
+                        }
+                        anyhow::bail!("dynamic workflow worker lease was lost before execution completed");
+                    }
+                    Err(error) => {
+                        child_cancellation.cancel();
+                        if tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut execution)
+                            .await
+                            .is_ok()
+                        {
+                            let _ = lease.release().await;
+                        }
+                        return Err(error).context("renew dynamic workflow worker lease");
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/core/src/dynamic_workflow/tests.rs
+++ b/core/src/dynamic_workflow/tests.rs
@@ -281,6 +281,53 @@ struct RetryOnceRuntimeTool {
     calls: Arc<AtomicUsize>,
 }
 
+#[derive(Default)]
+struct LeaseLosingWorkflowLedger;
+
+#[async_trait]
+impl FlowDecisionLedger for LeaseLosingWorkflowLedger {
+    async fn claim(
+        &self,
+        _decision_id: &str,
+        _request_hash: &str,
+        _owner_id: &str,
+        _now_ms: u64,
+        _lease_ms: u64,
+    ) -> anyhow::Result<FlowDecisionClaimOutcome> {
+        Ok(FlowDecisionClaimOutcome::Claimed { attempt: 1 })
+    }
+
+    async fn renew(
+        &self,
+        _decision_id: &str,
+        _request_hash: &str,
+        _owner_id: &str,
+        _now_ms: u64,
+        _lease_ms: u64,
+    ) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+
+    async fn complete(
+        &self,
+        _decision_id: &str,
+        _request_hash: &str,
+        _owner_id: &str,
+        _completed_at_ms: u64,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn release(
+        &self,
+        _decision_id: &str,
+        _request_hash: &str,
+        _owner_id: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Tool for RetryOnceRuntimeTool {
     fn name(&self) -> &str {
@@ -910,6 +957,188 @@ return await ctx.read(inputs.input.path);
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dynamic_workflow_worker_lease_serializes_same_run_and_replays_completion() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let started = Arc::new(AtomicUsize::new(0));
+    let release = Arc::new(Notify::new());
+    executor.register_dynamic_tool(Arc::new(BlockingTaskTool {
+        started: Arc::clone(&started),
+        release: Arc::clone(&release),
+    }));
+    let ledger: Arc<dyn FlowDecisionLedger> = Arc::new(MemoryFlowDecisionLedger::new());
+    let source = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    if (inputs.step_outputs.work) {
+      return { type: "complete", output: { ok: true } };
+    }
+    return {
+      type: "schedule_step",
+      step_id: "work",
+      step_name: "task",
+      input: {},
+      retry: { max_attempts: 1, delay_ms: 0 },
+    };
+  }
+  return await ctx.tool("task", inputs.input);
+}
+"#;
+    let args = json!({
+        "source": source,
+        "run_id": "serialized-worker-run",
+    });
+    let first_tool = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(Arc::clone(&ledger), 1_000);
+    let second_tool = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(Arc::clone(&ledger), 1_000);
+    let first_context = executor.registry().context();
+    let first_args = args.clone();
+    let first_task =
+        tokio::spawn(async move { first_tool.execute(&first_args, &first_context).await });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while started.load(Ordering::SeqCst) != 1 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("first worker should enter its side-effecting step");
+
+    let second = second_tool
+        .execute(
+            &json!({
+                "source": source,
+                "run_id": "serialized-worker-run",
+            }),
+            &executor.registry().context(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        !second.success,
+        "a live lease must reject a competing worker"
+    );
+    assert!(
+        second.content.contains("worker lease is busy"),
+        "{}",
+        second.content
+    );
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+
+    release.notify_waiters();
+    let first = tokio::time::timeout(Duration::from_secs(2), first_task)
+        .await
+        .expect("first worker should settle")
+        .expect("first worker task should join")
+        .unwrap();
+    assert!(first.success, "{}", first.content);
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        first.metadata.as_ref().expect("first metadata")["dynamic_workflow"]["worker_lease"]
+            ["state"],
+        "completed"
+    );
+
+    let replay = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(ledger, 1_000)
+        .execute(&args, &executor.registry().context())
+        .await
+        .unwrap();
+    assert!(replay.success, "{}", replay.content);
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        replay.metadata.as_ref().expect("replay metadata")["dynamic_workflow"]["worker_lease"]
+            ["state"],
+        "already_completed"
+    );
+}
+
+#[tokio::test]
+async fn dynamic_workflow_generates_safe_run_id_and_keeps_lease_sidecar_digest_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let source =
+        "async function run(ctx, inputs) { return { type: 'complete', output: { ok: true } }; }";
+    let result = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .execute(
+            &json!({ "source": source, "input": { "secret": "do-not-persist" } }),
+            &executor.registry().context(),
+        )
+        .await
+        .unwrap();
+    assert!(result.success, "{}", result.content);
+    let metadata = result.metadata.expect("generated-run metadata");
+    let run_id = metadata["dynamic_workflow"]["run_id"]
+        .as_str()
+        .expect("generated run id");
+    assert!(safe_workflow_run_id(run_id));
+    assert_eq!(
+        metadata["dynamic_workflow"]["worker_lease"]["state"],
+        "completed"
+    );
+    let lease_path = dynamic_workflow_store_path(dir.path())
+        .join(DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH)
+        .join("flow-decisions.json");
+    let lease_contents = tokio::fs::read_to_string(lease_path).await.unwrap();
+    assert!(!lease_contents.contains("do-not-persist"));
+    assert!(!lease_contents.contains(source));
+}
+
+#[tokio::test]
+async fn dynamic_workflow_rejects_unsafe_run_id_before_store_access() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let result = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .execute(
+            &json!({
+                "source": "async function run(ctx, inputs) { return { type: 'complete', output: {} }; }",
+                "run_id": "../outside",
+            }),
+            &executor.registry().context(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.success);
+    assert!(result.content.contains("run_id must contain only"));
+    assert!(!tokio::fs::try_exists(dir.path().join("outside.jsonl"))
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn dynamic_workflow_lost_lease_is_fenced_before_runtime_admission() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let tool = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(Arc::new(LeaseLosingWorkflowLedger), 1_000);
+    let result = tool
+        .execute(
+            &json!({
+                "source": "async function run(ctx, inputs) { return { type: 'complete', output: { should_not_run: true } }; }",
+                "run_id": "lost-lease-before-admission",
+            }),
+            &executor.registry().context(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.success);
+    assert!(
+        result.content.contains("lease is no longer owned"),
+        "{}",
+        result.content
+    );
+
+    let store = LocalFileEventStore::new(dynamic_workflow_store_path(dir.path()));
+    let history = store.list("lost-lease-before-admission").await.unwrap();
+    assert!(history
+        .iter()
+        .all(|envelope| !is_terminal_workflow_event(&envelope.event)));
+    assert!(history
+        .iter()
+        .all(|envelope| !matches!(&envelope.event, FlowEvent::StepCreated { .. })));
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn dynamic_workflow_refuses_symlinked_project_store() {
@@ -1451,6 +1680,88 @@ async function run(ctx, inputs) {
     assert_eq!(calls.load(Ordering::SeqCst), 2);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dynamic_workflow_parent_cancellation_releases_claim_for_retrying_worker() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let calls = Arc::new(AtomicUsize::new(0));
+    executor.register_dynamic_tool(Arc::new(RetryOnceRuntimeTool {
+        calls: Arc::clone(&calls),
+    }));
+    let ledger: Arc<dyn FlowDecisionLedger> = Arc::new(MemoryFlowDecisionLedger::new());
+    let source = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    const result = inputs.step_outputs.retry_once;
+    if (result) return { type: "complete", output: { recovered: result.output } };
+    return {
+      type: "schedule_step",
+      step_id: "retry_once",
+      step_name: "retry_once",
+      input: {},
+      retry: { max_attempts: 2, delay_ms: 200 },
+    };
+  }
+  const result = await ctx.tool("runtime", {});
+  if (result.exitCode !== 0) throw new Error(result.output || "runtime failed");
+  return result;
+}
+"#;
+    let cancellation = CancellationToken::new();
+    let first_context = executor
+        .registry()
+        .context()
+        .with_cancellation(cancellation.clone());
+    let first_tool = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(Arc::clone(&ledger), 1_000);
+    let first_args = json!({
+        "source": source,
+        "run_id": "cancel-and-retry-run",
+    });
+    let first_task =
+        tokio::spawn(async move { first_tool.execute(&first_args, &first_context).await });
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while calls.load(Ordering::SeqCst) != 1 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("first attempt should be recorded before cancellation");
+    cancellation.cancel();
+    let first = tokio::time::timeout(Duration::from_secs(2), first_task)
+        .await
+        .expect("cancelled worker should settle")
+        .expect("cancelled worker task should join")
+        .unwrap();
+    assert!(
+        !first.success,
+        "parent cancellation must not report success"
+    );
+
+    // The retry boundary remains in Flow history, but the old worker no longer
+    // owns the claim. A fresh worker can take it over without replaying the
+    // already-recorded first attempt as a second side effect.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let second = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(ledger, 1_000)
+        .execute(
+            &json!({
+                "source": source,
+                "run_id": "cancel-and-retry-run",
+            }),
+            &executor.registry().context(),
+        )
+        .await
+        .unwrap();
+    assert!(second.success, "{}", second.content);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        second.metadata.as_ref().expect("retry metadata")["dynamic_workflow"]["worker_lease"]
+            ["state"],
+        "completed"
+    );
+}
+
 #[test]
 fn dynamic_workflow_continuation_identity_binds_persisted_facts_not_progress() {
     let run_id = "continuation-identity";
@@ -1588,6 +1899,57 @@ fn dynamic_workflow_continuation_identity_binds_persisted_facts_not_progress() {
         &malformed_sequence,
     )
     .is_err());
+}
+
+#[test]
+fn dynamic_workflow_claim_identity_is_stable_across_history_progress() {
+    let run_id = "claim-identity";
+    let source =
+        "async function run(ctx, inputs) { return { type: 'complete', output: { ok: true } }; }";
+    let input = json!({ "query": "identity-bound" });
+    let runtime_build = RuntimeBuildId::new("code-generation-a").unwrap();
+    let empty =
+        dynamic_workflow_claim_identity(run_id, source, &input, runtime_build.as_str(), &[])
+            .unwrap();
+    let spec = WorkflowSpec::rust_embedded(
+        "a3s-code.dynamic-workflow",
+        source_hash(source),
+        "ptc",
+        "run",
+    )
+    .with_runtime_build(runtime_build.clone());
+    let progressed = vec![
+        FlowEventEnvelope::new(
+            run_id,
+            1,
+            uuid::Uuid::new_v4(),
+            Utc::now(),
+            FlowEvent::RunCreated {
+                spec,
+                input: input.clone(),
+            },
+        ),
+        FlowEventEnvelope::new(
+            run_id,
+            2,
+            uuid::Uuid::new_v4(),
+            Utc::now(),
+            FlowEvent::RunStarted,
+        ),
+    ];
+    let resumed = dynamic_workflow_claim_identity(
+        run_id,
+        source,
+        &input,
+        runtime_build.as_str(),
+        &progressed,
+    )
+    .unwrap();
+    assert_eq!(empty, resumed);
+    assert_eq!(empty.domain, DYNAMIC_WORKFLOW_CLAIM_IDENTITY_DOMAIN_V1);
+    assert!(!serde_json::to_string(&empty)
+        .unwrap()
+        .contains("identity-bound"));
 }
 
 #[tokio::test]

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -27,6 +27,10 @@ pub const DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1: &str =
 /// durable immutable facts.
 pub const DYNAMIC_WORKFLOW_CONTINUATION_IDENTITY_DOMAIN_V1: &str =
     "a3s.code.dynamic-workflow.continuation.identity.v1";
+/// Identity domain for the stable root claim that fences one dynamic
+/// workflow continuation while workers replay its evolving step history.
+pub const DYNAMIC_WORKFLOW_CLAIM_IDENTITY_DOMAIN_V1: &str =
+    "a3s.code.dynamic-workflow.claim.identity.v1";
 /// Identity domain for the immutable definition of a projected execution plan.
 pub const EXECUTION_PLAN_IDENTITY_DOMAIN_V1: &str = "a3s.code.execution-plan.identity.v1";
 pub const WORKFLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.workflow-step.identity.v1";

--- a/core/src/flow_graph/decision_ledger.rs
+++ b/core/src/flow_graph/decision_ledger.rs
@@ -85,6 +85,25 @@ pub trait FlowDecisionLedger: Send + Sync {
         completed_at_ms: u64,
     ) -> Result<()>;
 
+    /// Complete a pending claim only when its canonical execution identity
+    /// still matches the record that was admitted.  The default keeps custom
+    /// host ledgers source-compatible; built-in ledgers persist and fence the
+    /// identity together with the owner and lease checks.
+    async fn complete_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        completed_at_ms: u64,
+    ) -> Result<()> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        self.complete(decision_id, request_hash, owner_id, completed_at_ms)
+            .await
+    }
+
     /// Complete with a bounded digest-only result receipt. The default keeps
     /// third-party ledgers source-compatible but cannot persist the receipt.
     async fn complete_with_receipt(
@@ -238,6 +257,29 @@ impl FlowDecisionLedger for MemoryFlowDecisionLedger {
             decision_id,
             request_hash,
             None,
+            owner_id,
+            None,
+            completed_at_ms,
+        )
+    }
+
+    async fn complete_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        completed_at_ms: u64,
+    ) -> Result<()> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        let mut records = self.records.lock().await;
+        complete_record(
+            &mut records,
+            decision_id,
+            request_hash,
+            Some(identity),
             owner_id,
             None,
             completed_at_ms,
@@ -467,6 +509,31 @@ impl FlowDecisionLedger for FileFlowDecisionLedger {
                 decision_id,
                 request_hash,
                 None,
+                owner_id,
+                None,
+                completed_at_ms,
+            )
+        })
+        .await
+    }
+
+    async fn complete_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+        owner_id: &str,
+        completed_at_ms: u64,
+    ) -> Result<()> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        self.mutate(|records| {
+            complete_record(
+                records,
+                decision_id,
+                request_hash,
+                Some(identity),
                 owner_id,
                 None,
                 completed_at_ms,
@@ -992,6 +1059,10 @@ mod tests {
             )
             .await
             .is_err());
+        assert!(ledger
+            .complete_with_identity("decision", "hash", &first, "other", 120)
+            .await
+            .is_err());
         assert_eq!(
             ledger
                 .claim_with_identity("decision", "hash", &second, "second-owner", 121, 20)
@@ -1011,6 +1082,10 @@ mod tests {
             .await
             .is_err());
         let second_receipt = receipt(second.clone());
+        ledger
+            .complete_with_identity("decision", "hash", &second, "second-owner", 123)
+            .await
+            .unwrap();
         ledger
             .complete_with_receipt(
                 "decision",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -224,8 +224,8 @@ pub use durable_memory::{
     DURABLE_MEMORY_SEMANTIC_REFRESH_PROFILE_V1,
 };
 pub use dynamic_workflow::{
-    dynamic_workflow_continuation_identity, dynamic_workflow_execution_plan,
-    dynamic_workflow_step_identity, dynamic_workflow_store_path,
+    dynamic_workflow_claim_identity, dynamic_workflow_continuation_identity,
+    dynamic_workflow_execution_plan, dynamic_workflow_step_identity, dynamic_workflow_store_path,
     register_dynamic_workflow_with_scheduler, DynamicWorkflowAdmissionStats,
     DynamicWorkflowRuntime, DynamicWorkflowScriptLimits, DynamicWorkflowTool,
     DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID, DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,


### PR DESCRIPTION
## Summary
- derive one stable digest-only claim identity for each dynamic workflow continuation
- add host-injected, local file-backed, and tool-scoped in-memory worker leases with heartbeat and stale-owner fencing
- propagate parent cancellation through a child ToolContext and settle/release only after execution stops
- qualify takeover, cancellation, unsafe run IDs, lease loss, and digest-only metadata with focused tests

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable clippy -p a3s-code-core --lib --tests -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo +stable doc -p a3s-code-core --no-deps
- cargo +stable test -p a3s-code-core dynamic_workflow --lib -- --nocapture (38 passed)
- cargo +stable test -p a3s-code-core --lib (3171 passed, 13 ignored)

Flow event history remains the workflow authority; exactly-once external effects still require host/tool idempotency.