### PR TITLE
feat(core): add durable workflow control boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the host-facing `DynamicWorkflowControl` adapter. A bound handle can
+  inspect a bounded redacted snapshot, read trusted history, resume a run, or
+  request/force durable cancellation while using the same identity-bound
+  worker lease as the model-visible tool. Local dynamic-workflow journals now
+  use a cross-process lock around the existing Flow JSONL store; Flow remains
+  the sole event authority and optimistic sequence conflicts stay retryable.
+  Hosts with a remote or database-backed adapter can inject the same typed
+  `FlowEventStore` into both model-visible execution and control operations.
+  Cross-process qualification covers a killed worker, lease expiry/takeover,
+  busy inspection, durable cancellation settlement, and injected event-store
+  conflicts across independent processes.
 - Added parent-cancellation and worker-takeover fencing for dynamic workflows.
   Each run derives one stable digest-only claim identity, uses a shared local
   file lease (or an injected host ledger), renews the lease while Flow replay

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   file-backed (or host-injected) lease, heartbeats keep live owners fenced,
   stale workers are rejected before workflow/step admission, and parent
   cancellation settles or leaves the lease fenced rather than releasing an
-  in-flight worker.
+  in-flight worker. Hosts can bind one `DynamicWorkflowControl` handle to
+  inspect a bounded digest-only snapshot, read trusted history, drive a run,
+  or request/force durable cancellation; local journals use a cross-process
+  lock while Flow remains the sole event authority.
 
 Go consumers must update the module path to
 `github.com/A3S-Lab/Code/sdk/go/v8`. See [CHANGELOG.md](CHANGELOG.md) for the
@@ -1048,7 +1051,20 @@ worker claim identity intentionally excludes evolving plan progress, so
 takeover and retry use one stable digest. Local claim metadata lives under
 `.a3s/workflow/leases`; A3S Flow's event history remains the sole workflow
 authority, and the sidecar contains only bounded digests, owner leases, and
-attempt state.
+attempt state. A host can obtain a control handle with
+`DynamicWorkflowTool::control(run_id, source, input, ctx)`. Its `inspect()`
+projection omits source, input, step arguments, outputs, and owner tokens;
+`history()` is an explicitly trusted full-history escape hatch. Mutating
+control operations acquire the same worker lease as the model-visible tool,
+then coordinate Flow's durable cancellation/terminal transition and settle
+the lease. Local workspace history is wrapped by a small cross-process file
+lock so independent workers cannot corrupt a JSONL append; optimistic Flow
+sequence conflicts still remain the retry authority. Remote/database-backed
+hosts can supply a typed `Arc<dyn FlowEventStore>` through
+`with_flow_event_store` (or register the weak-registry helper
+`register_dynamic_workflow_with_event_store`); Code then uses that same store
+for the model-visible Tool and its control handle without creating an in-memory
+shadow journal.
 
 Delegated tasks, workflows, and Skill child runs retain the parent sandbox and
 intersect local permission policy with the parent checker. A child auto-approve

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,7 @@ runtime mode. The cross-repository implementation plan is tracked in the
 | `CAR-05` | Planned | Pass restart, exact replay, cancellation, hostile Tool output, bounded-content, Secret-redaction, checkpoint, and cleanup conformance through one Cloud-managed Box workload | No direct Code-to-node control path |
 | `WORKFLOW-RESULT1` | Delivered | Resumable workflow checkpoints and Flow decision claims share canonical execution identities and bounded digest-only result receipts; stale or unreadable state fails closed while legacy records remain loadable | Core checkpoint, Flow ledger, restart, takeover, and identity-fencing tests pass; host policy and business retention remain outside Code |
 | `WORKFLOW-SCHED1` | Delivered | Dynamic Flow history projects into the canonical `ExecutionPlan`; step admission shares cancellation and bounded per-workflow quotas, while standalone scheduler leases carry digest-only step identities and delegated tasks use the same identity boundary | Plan identity is stable across status changes; resumed projections retain prior steps; local and global admission tests cover priority, cancellation, serialization, and the max-active=1 nested-deadlock boundary |
+| `WORKFLOW-CONTROL1` | Delivered | A host-facing dynamic-workflow control handle coordinates bounded inspection, trusted history, Flow durable cancellation/terminal transitions, identity-bound worker leases, and cross-process local event-store locking | Independent-process qualification covers busy ownership, killed-worker lease expiry/takeover, cancellation settlement, digest-only projections, and optimistic event-conflict retry; Flow remains the only workflow authority |
 
 Observation precedes mutation: `CAR-02` must provide useful read-only context
 diagnostics before `CAR-03` can reduce any Tool result. The first transform
@@ -344,6 +345,33 @@ external effects still require the invoked Tool or host to provide its own
 idempotency/receipt contract; Code does not pretend that a lease can undo an
 effect that was committed outside the Flow journal. Cloud/Use ownership,
 retention, and business retry policy remain outside Code.
+
+### 3.3.5 Host control and cross-process recovery
+
+`DynamicWorkflowTool::control` is the single host-facing boundary for dynamic
+workflow inspection and mutation. It binds the caller's exact source, input,
+runtime policy, registry, and workspace store before any operation runs. The
+bounded `DynamicWorkflowControlSnapshot` exposes status, sequence, step
+counts, cancellation presence, continuation/plan identities, runtime build,
+and a redacted worker-lease state; it never exposes source, input, step
+arguments, outputs, or owner tokens. `history()` is separate and explicitly
+trusted because it returns those durable values.
+
+`drive`, `request_cancellation`, and `force_cancel` first claim the same
+identity-bound lease used by the model-visible Tool. A live worker is reported
+as busy instead of being interrupted through a second control plane. Once a
+claim is owned, Flow appends or replays the authoritative cancellation and
+terminal events, while a bounded heartbeat/settlement loop renews and then
+completes or releases the claim. An unsettled future remains fenced until
+lease expiry. Local JSONL history is wrapped by
+`CrossProcessFlowEventStore`, which serializes appends and reads across
+processes without projecting a second state machine. The qualification test
+spawns independent workers, kills an owner, waits for takeover, settles a
+cleanup-aware cancellation, and forces optimistic event conflicts so Flow's
+existing bounded retries are exercised. Remote or database-backed hosts can
+inject one typed `FlowEventStore` through `with_flow_event_store`; the same
+store is then shared by model-visible execution and the control handle, so a
+non-local host does not silently fall back to a fresh in-memory journal.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/dynamic_workflow.rs
+++ b/core/src/dynamic_workflow.rs
@@ -17,14 +17,14 @@ use crate::tools::{
 use crate::{
     agent::AgentEvent,
     flow_graph::{
-        FileFlowDecisionLedger, FlowDecisionClaimOutcome, FlowDecisionLedger, FlowGraphObserver,
-        MemoryFlowDecisionLedger,
+        FileFlowDecisionLedger, FlowDecisionClaimOutcome, FlowDecisionClaimState,
+        FlowDecisionLedger, FlowGraphObserver, MemoryFlowDecisionLedger,
     },
     planning::{Complexity, ExecutionPlan, Task, TaskStatus},
 };
 use a3s_flow::{
-    FanoutFlowEventObserver, FlowEngine, FlowEvent, FlowEventEnvelope, FlowEventObserver,
-    FlowEventStore, FlowRuntime, InMemoryEventStore, LocalFileEventStore,
+    CancellationRequest, FanoutFlowEventObserver, FlowEngine, FlowEvent, FlowEventEnvelope,
+    FlowEventObserver, FlowEventStore, FlowRuntime, InMemoryEventStore, LocalFileEventStore,
     RuntimeBuildCompatibility, RuntimeBuildId, RuntimeCommand, StepInvocation, StepStatus,
     WorkflowInvocation, WorkflowRunSnapshot, WorkflowRunStatus, WorkflowSpec,
 };
@@ -34,6 +34,8 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::OpenOptions;
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -56,6 +58,7 @@ const MAX_FLOW_STEP_INPUT_BYTES: usize = 64 * 1024;
 const MAX_DYNAMIC_WORKFLOW_INPUT_BYTES: usize = 128 * 1024;
 const DEFAULT_DYNAMIC_WORKFLOW_LEASE_MS: u64 = 30_000;
 const MAX_DYNAMIC_WORKFLOW_SETTLE: Duration = Duration::from_secs(5);
+const MAX_DYNAMIC_WORKFLOW_CONTROL_REASON_BYTES: usize = 4 * 1024;
 const DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH: &str = "leases";
 
 /// Runtime build used to pin newly-created dynamic workflow runs.
@@ -71,6 +74,110 @@ const LEGACY_UNPINNED_RUNTIME_BUILD_ID: &str = "<unpinned>";
 
 /// Project-relative directory used for durable dynamic workflow history.
 pub const DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH: &str = ".a3s/workflow";
+
+/// Cross-process serialized adapter for a local Flow event journal.
+///
+/// `a3s-flow::LocalFileEventStore` deliberately serializes writers only
+/// inside one process. Dynamic workflows can be resumed or controlled by a
+/// replacement process, so Code adds one small lock-file boundary around the
+/// same append-only journal. The adapter does not project or cache workflow
+/// state: Flow remains the sole event authority and its optimistic sequence
+/// checks still decide whether an append is accepted.
+#[derive(Debug, Clone)]
+pub struct CrossProcessFlowEventStore {
+    root: PathBuf,
+    inner: LocalFileEventStore,
+    process_lock: Arc<Mutex<()>>,
+}
+
+impl CrossProcessFlowEventStore {
+    /// Create a cross-process event store rooted at `root`.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        Self {
+            inner: LocalFileEventStore::new(root.clone()),
+            root,
+            process_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Return the directory containing the journal files.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    async fn acquire_file_lock(&self) -> a3s_flow::Result<std::fs::File> {
+        tokio::fs::create_dir_all(&self.root).await?;
+        let lock_path = self.root.join(".flow-events.lock");
+        match tokio::fs::symlink_metadata(&lock_path).await {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(a3s_flow::FlowError::Store(format!(
+                    "refusing to use symlinked event-store lock {}",
+                    lock_path.display()
+                )))
+            }
+            Ok(metadata) if !metadata.is_file() => {
+                return Err(a3s_flow::FlowError::Store(format!(
+                    "event-store lock {} exists but is not a file",
+                    lock_path.display()
+                )))
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(a3s_flow::FlowError::Io(error)),
+        }
+        tokio::task::spawn_blocking(move || {
+            use fs2::FileExt;
+            let file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(a3s_flow::FlowError::Io)?;
+            file.lock_exclusive().map_err(a3s_flow::FlowError::Io)?;
+            Ok(file)
+        })
+        .await
+        .map_err(|error| {
+            a3s_flow::FlowError::Store(format!("event-store lock task failed: {error}"))
+        })?
+    }
+}
+
+#[async_trait]
+impl FlowEventStore for CrossProcessFlowEventStore {
+    async fn append(&self, run_id: &str, event: FlowEvent) -> a3s_flow::Result<FlowEventEnvelope> {
+        let _process_guard = self.process_lock.lock().await;
+        let _file_guard = self.acquire_file_lock().await?;
+        self.inner.append(run_id, event).await
+    }
+
+    async fn append_if_sequence(
+        &self,
+        run_id: &str,
+        expected_sequence: u64,
+        event: FlowEvent,
+    ) -> a3s_flow::Result<FlowEventEnvelope> {
+        let _process_guard = self.process_lock.lock().await;
+        let _file_guard = self.acquire_file_lock().await?;
+        self.inner
+            .append_if_sequence(run_id, expected_sequence, event)
+            .await
+    }
+
+    async fn list(&self, run_id: &str) -> a3s_flow::Result<Vec<FlowEventEnvelope>> {
+        let _process_guard = self.process_lock.lock().await;
+        let _file_guard = self.acquire_file_lock().await?;
+        self.inner.list(run_id).await
+    }
+
+    async fn list_run_ids(&self) -> a3s_flow::Result<Vec<String>> {
+        let _process_guard = self.process_lock.lock().await;
+        let _file_guard = self.acquire_file_lock().await?;
+        self.inner.list_run_ids().await
+    }
+}
 
 /// Resolve the durable dynamic workflow history directory for a local workspace.
 pub fn dynamic_workflow_store_path(workspace_root: impl AsRef<Path>) -> PathBuf {
@@ -166,6 +273,67 @@ pub struct DynamicWorkflowAdmissionStats {
     pub active_steps: usize,
     /// Highest observed active step count.
     pub peak_active_steps: usize,
+}
+
+/// Bounded, host-facing projection of one dynamic workflow continuation.
+///
+/// The projection deliberately omits source, input, step arguments, outputs,
+/// and worker owner tokens. Flow history remains available through the
+/// explicit inspection APIs when a trusted host needs the full record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicWorkflowControlSnapshot {
+    /// Stable durable run identifier.
+    pub run_id: String,
+    /// Current materialized Flow status.
+    pub status: WorkflowRunStatus,
+    /// Last durable event sequence observed for the run.
+    pub last_sequence: u64,
+    /// Number of durable step definitions in the run.
+    pub step_count: usize,
+    /// Number of steps with a committed output.
+    pub completed_steps: usize,
+    /// Number of steps that remain actionable or in flight.
+    pub open_steps: usize,
+    /// Whether Flow has recorded a cleanup-aware cancellation request.
+    pub cancellation_requested: bool,
+    /// Digest-only identity reconstructed from immutable continuation facts.
+    pub continuation_identity: ExecutionIdentityV1,
+    /// Digest-only identity of the projected immutable step plan.
+    pub plan_identity: ExecutionIdentityV1,
+    /// Runtime build pinned by the durable run, or `None` for a legacy
+    /// unpinned history.
+    pub runtime_build_id: Option<String>,
+    /// Redacted worker-lease state observed by the control operation.
+    pub worker_lease: FlowDecisionClaimState,
+}
+
+/// A host-owned control handle for one dynamic workflow run.
+///
+/// The handle keeps the exact source, input, registry, and runtime policy
+/// needed to replay the selected run. Mutating operations first acquire the
+/// same worker lease used by [`DynamicWorkflowTool`], then ask A3S Flow to
+/// append/drive its authoritative events. A live worker therefore remains the
+/// sole executor; a controller retries after the redacted lease state reports
+/// that the claim is busy.
+#[must_use = "a dynamic workflow control handle should be used or explicitly dropped"]
+#[derive(Clone)]
+pub struct DynamicWorkflowControl {
+    registry: Arc<ToolRegistry>,
+    context: ToolContext,
+    flow_event_store: Option<Arc<dyn FlowEventStore>>,
+    run_id: String,
+    source: Arc<str>,
+    input: Value,
+    allowed_tools: Vec<String>,
+    limits: DynamicWorkflowScriptLimits,
+    graph_observer: Option<FlowGraphObserver>,
+    task_scheduler: Option<Arc<TaskScheduler>>,
+    admit_steps_globally: bool,
+    runtime_build_compatibility: Option<RuntimeBuildCompatibility>,
+    continuation_lease_ledger: Option<Arc<dyn FlowDecisionLedger>>,
+    continuation_lease_ms: u64,
+    memory_continuation_lease_ledger: Arc<MemoryFlowDecisionLedger>,
 }
 
 #[derive(Clone)]
@@ -1202,6 +1370,13 @@ enum DynamicWorkflowLeaseClaim {
     AlreadyCompleted,
 }
 
+fn dynamic_workflow_lease_key(identity: &ExecutionIdentityV1) -> (String, String) {
+    (
+        format!("dynamic-workflow:{}", identity.digest),
+        identity.digest.clone(),
+    )
+}
+
 async fn claim_dynamic_workflow_lease(
     ledger: Arc<dyn FlowDecisionLedger>,
     identity: ExecutionIdentityV1,
@@ -1210,8 +1385,7 @@ async fn claim_dynamic_workflow_lease(
     identity
         .validate()
         .map_err(|error| anyhow::anyhow!(error))?;
-    let decision_id = format!("dynamic-workflow:{}", identity.digest);
-    let request_hash = identity.digest.clone();
+    let (decision_id, request_hash) = dynamic_workflow_lease_key(&identity);
     let owner_id = format!("dynamic-workflow-worker-{}", uuid::Uuid::new_v4());
     let outcome = ledger
         .claim_with_identity(
@@ -1276,6 +1450,7 @@ fn history_is_terminal(history: &[FlowEventEnvelope]) -> bool {
 /// Model-visible tool that executes a dynamic workflow through A3S Flow.
 pub struct DynamicWorkflowTool {
     registry: DynamicWorkflowRegistry,
+    flow_event_store: Option<Arc<dyn FlowEventStore>>,
     graph_observer: Option<FlowGraphObserver>,
     task_scheduler: Option<Arc<TaskScheduler>>,
     admit_steps_globally: bool,
@@ -1303,6 +1478,7 @@ impl DynamicWorkflowTool {
     pub fn new(registry: Arc<ToolRegistry>) -> Self {
         Self {
             registry: DynamicWorkflowRegistry::Standalone(registry),
+            flow_event_store: None,
             graph_observer: None,
             task_scheduler: None,
             admit_steps_globally: false,
@@ -1316,6 +1492,7 @@ impl DynamicWorkflowTool {
     fn new_registry_bound(registry: Arc<ToolRegistry>) -> Self {
         Self {
             registry: DynamicWorkflowRegistry::RegistryBound(Arc::downgrade(&registry)),
+            flow_event_store: None,
             graph_observer: None,
             task_scheduler: None,
             admit_steps_globally: false,
@@ -1330,6 +1507,18 @@ impl DynamicWorkflowTool {
     /// A3S Flow remains the workflow execution source of truth.
     pub fn with_graph_observer(mut self, observer: FlowGraphObserver) -> Self {
         self.graph_observer = Some(observer);
+        self
+    }
+
+    /// Use a host-owned Flow event store for workflow history and control.
+    ///
+    /// This is the extension point for remote or database-backed hosts. The
+    /// store must provide its own durable append/sequence contract; Code does
+    /// not mirror its events into a second journal or cache. When omitted,
+    /// local workspaces use [`CrossProcessFlowEventStore`] and non-local
+    /// contexts use a process-local in-memory store for compatibility.
+    pub fn with_flow_event_store(mut self, store: Arc<dyn FlowEventStore>) -> Self {
+        self.flow_event_store = Some(store);
         self
     }
 
@@ -1385,24 +1574,148 @@ impl DynamicWorkflowTool {
         self
     }
 
+    /// Bind a host control handle to one durable run and its replay inputs.
+    ///
+    /// The handle is intentionally separate from the model-visible tool call:
+    /// a host must provide the exact source and initial input before it can
+    /// inspect, drive, or cancel a run. No operation is performed until a
+    /// method on the returned handle is awaited.
+    pub fn control(
+        &self,
+        run_id: impl Into<String>,
+        source: impl Into<String>,
+        input: Value,
+        ctx: &ToolContext,
+    ) -> Result<DynamicWorkflowControl> {
+        let registry = self
+            .registry
+            .resolve()
+            .ok_or_else(|| anyhow::anyhow!("tool registry is closed"))?;
+        let run_id = run_id.into();
+        if !safe_workflow_run_id(&run_id) {
+            anyhow::bail!(
+                "dynamic workflow run_id must contain only ASCII letters, numbers, '-' or '_'"
+            );
+        }
+        let source = source.into();
+        if source.is_empty() {
+            anyhow::bail!("dynamic workflow source must not be empty");
+        }
+        dynamic_workflow_input_identity(&input)
+            .map_err(|error| anyhow::anyhow!("invalid dynamic workflow input: {error}"))?;
+        let allowed_tools = default_allowed_tools(&registry);
+        Ok(DynamicWorkflowControl {
+            registry,
+            context: ctx.clone(),
+            flow_event_store: self.flow_event_store.clone(),
+            run_id,
+            source: Arc::from(source),
+            input,
+            allowed_tools,
+            limits: DynamicWorkflowScriptLimits::default(),
+            graph_observer: self.graph_observer.clone(),
+            task_scheduler: self.task_scheduler.clone(),
+            admit_steps_globally: self.admit_steps_globally,
+            runtime_build_compatibility: self.runtime_build_compatibility.clone(),
+            continuation_lease_ledger: self.continuation_lease_ledger.clone(),
+            continuation_lease_ms: self.continuation_lease_ms,
+            memory_continuation_lease_ledger: Arc::clone(&self.memory_continuation_lease_ledger),
+        })
+    }
+
     async fn continuation_lease_ledger_for_context(
         &self,
         ctx: &ToolContext,
     ) -> Result<Arc<dyn FlowDecisionLedger>> {
-        if let Some(ledger) = &self.continuation_lease_ledger {
-            return Ok(Arc::clone(ledger));
-        }
-        let Some(root) = ctx.workspace_services.local_root() else {
-            let ledger: Arc<dyn FlowDecisionLedger> = self.memory_continuation_lease_ledger.clone();
-            return Ok(ledger);
-        };
-        let workflow_root = dynamic_workflow_store_path(root);
-        validate_dynamic_workflow_directory(&root.join(".a3s"), ".a3s").await?;
-        validate_dynamic_workflow_directory(&workflow_root, ".a3s/workflow").await?;
-        let lease_root = workflow_root.join(DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH);
-        validate_dynamic_workflow_directory(&lease_root, ".a3s/workflow/leases").await?;
-        Ok(Arc::new(FileFlowDecisionLedger::new(lease_root)))
+        dynamic_workflow_lease_ledger_for_context(
+            self.continuation_lease_ledger.as_ref(),
+            &self.memory_continuation_lease_ledger,
+            ctx,
+        )
+        .await
     }
+}
+
+impl DynamicWorkflowControl {
+    /// Return the immutable run id bound to this control handle.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// Replace the set of tools available to replayed script steps.
+    pub fn with_allowed_tools(mut self, allowed_tools: impl IntoIterator<Item = String>) -> Self {
+        self.allowed_tools = sanitize_allowed_tools(allowed_tools);
+        self
+    }
+
+    /// Replace the bounded script and orchestration limits used during replay.
+    pub fn with_limits(mut self, limits: DynamicWorkflowScriptLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Project control-driven Flow events into a graph observer.
+    pub fn with_graph_observer(mut self, observer: FlowGraphObserver) -> Self {
+        self.graph_observer = Some(observer);
+        self
+    }
+
+    /// Configure optional global admission for direct script-backed steps.
+    pub fn with_task_scheduler(
+        mut self,
+        scheduler: Arc<TaskScheduler>,
+        admit_steps_globally: bool,
+    ) -> Self {
+        self.task_scheduler = Some(scheduler);
+        self.admit_steps_globally = admit_steps_globally;
+        self
+    }
+
+    /// Set the runtime-build compatibility policy used by control replay.
+    pub fn with_runtime_build_compatibility(
+        mut self,
+        compatibility: RuntimeBuildCompatibility,
+    ) -> Self {
+        self.runtime_build_compatibility = Some(compatibility);
+        self
+    }
+
+    /// Use a caller-owned worker lease ledger for control operations.
+    pub fn with_continuation_lease_ledger(
+        mut self,
+        ledger: Arc<dyn FlowDecisionLedger>,
+        lease_ms: u64,
+    ) -> Self {
+        self.continuation_lease_ledger = Some(ledger);
+        self.continuation_lease_ms = lease_ms.max(1);
+        self
+    }
+
+    /// Change the worker lease while retaining automatic ledger selection.
+    pub fn with_continuation_lease_ms(mut self, lease_ms: u64) -> Self {
+        self.continuation_lease_ms = lease_ms.max(1);
+        self
+    }
+}
+
+async fn dynamic_workflow_lease_ledger_for_context(
+    explicit: Option<&Arc<dyn FlowDecisionLedger>>,
+    memory: &Arc<MemoryFlowDecisionLedger>,
+    ctx: &ToolContext,
+) -> Result<Arc<dyn FlowDecisionLedger>> {
+    if let Some(ledger) = explicit {
+        return Ok(Arc::clone(ledger));
+    }
+    let Some(root) = ctx.workspace_services.local_root() else {
+        let ledger: Arc<dyn FlowDecisionLedger> = memory.clone();
+        return Ok(ledger);
+    };
+    let workflow_root = dynamic_workflow_store_path(root);
+    validate_dynamic_workflow_directory(&root.join(".a3s"), ".a3s").await?;
+    validate_dynamic_workflow_directory(&workflow_root, ".a3s/workflow").await?;
+    let lease_root = workflow_root.join(DYNAMIC_WORKFLOW_LEASE_RELATIVE_PATH);
+    validate_dynamic_workflow_directory(&lease_root, ".a3s/workflow/leases").await?;
+    Ok(Arc::new(FileFlowDecisionLedger::new(lease_root)))
 }
 
 #[async_trait]
@@ -1488,21 +1801,16 @@ impl Tool for DynamicWorkflowTool {
             .and_then(|value| serde_json::from_value(value).ok())
             .unwrap_or_default();
 
-        let runtime_build_id = match &self.runtime_build_compatibility {
-            Some(compatibility) => compatibility.current_build_id().clone(),
-            None => match RuntimeBuildId::new(DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID.to_string()) {
-                Ok(build_id) => build_id,
+        let (runtime_build_id, runtime_build_compatibility) =
+            match dynamic_workflow_runtime_configuration(self.runtime_build_compatibility.as_ref())
+            {
+                Ok(configuration) => configuration,
                 Err(error) => {
                     return Ok(ToolOutput::error(format!(
                         "invalid dynamic workflow runtime build identity: {error}"
                     )))
                 }
-            },
-        };
-        let runtime_build_compatibility =
-            self.runtime_build_compatibility.clone().unwrap_or_else(|| {
-                RuntimeBuildCompatibility::new(runtime_build_id.clone()).accept_unpinned()
-            });
+            };
         let source_hash = source_hash(source);
         let base_spec = WorkflowSpec::rust_embedded(
             "a3s-code.dynamic-workflow",
@@ -1525,7 +1833,11 @@ impl Tool for DynamicWorkflowTool {
         let run_id = requested_run_id
             .map(ToString::to_string)
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let store = match flow_store_for_context(ctx, Some(&run_id)).await {
+        let store = match self.flow_event_store.clone() {
+            Some(store) => Ok(store),
+            None => flow_store_for_context(ctx, Some(&run_id)).await,
+        };
+        let store = match store {
             Ok(store) => store,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
@@ -1740,6 +2052,433 @@ impl Tool for DynamicWorkflowTool {
     }
 }
 
+struct DynamicWorkflowControlPreparation {
+    store: Arc<dyn FlowEventStore>,
+    prior_history: Vec<FlowEventEnvelope>,
+    spec: WorkflowSpec,
+    effective_runtime_build_id: Option<String>,
+    runtime_build_id: RuntimeBuildId,
+    runtime_build_compatibility: RuntimeBuildCompatibility,
+    claim_identity: ExecutionIdentityV1,
+    lease_ledger: Arc<dyn FlowDecisionLedger>,
+}
+
+fn dynamic_workflow_runtime_configuration(
+    configured: Option<&RuntimeBuildCompatibility>,
+) -> Result<(RuntimeBuildId, RuntimeBuildCompatibility)> {
+    let runtime_build_id =
+        match configured {
+            Some(compatibility) => compatibility.current_build_id().clone(),
+            None => RuntimeBuildId::new(DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID.to_string()).map_err(
+                |error| anyhow::anyhow!("invalid dynamic workflow runtime build identity: {error}"),
+            )?,
+        };
+    let compatibility = configured.cloned().unwrap_or_else(|| {
+        RuntimeBuildCompatibility::new(runtime_build_id.clone()).accept_unpinned()
+    });
+    Ok((runtime_build_id, compatibility))
+}
+
+impl DynamicWorkflowControl {
+    async fn prepare(&self, allow_missing: bool) -> Result<DynamicWorkflowControlPreparation> {
+        let (runtime_build_id, runtime_build_compatibility) =
+            dynamic_workflow_runtime_configuration(self.runtime_build_compatibility.as_ref())?;
+        let source_hash = source_hash(self.source.as_ref());
+        let base_spec = WorkflowSpec::rust_embedded(
+            "a3s-code.dynamic-workflow",
+            source_hash.as_str(),
+            "ptc",
+            "run",
+        );
+        let store = match self.flow_event_store.clone() {
+            Some(store) => store,
+            None => flow_store_for_context(&self.context, Some(&self.run_id)).await?,
+        };
+        let prior_history = match store.list(&self.run_id).await {
+            Ok(history) => history,
+            Err(a3s_flow::FlowError::RunNotFound(_)) if allow_missing => Vec::new(),
+            Err(error) => return Err(error.into()),
+        };
+        if !allow_missing && prior_history.is_empty() {
+            return Err(a3s_flow::FlowError::RunNotFound(self.run_id.clone()).into());
+        }
+        let (spec, effective_runtime_build_id) = prior_history
+            .iter()
+            .find_map(|envelope| match &envelope.event {
+                FlowEvent::RunCreated { spec, .. } => Some(spec.clone()),
+                _ => None,
+            })
+            .map(|persisted_spec| {
+                let runtime_build_id = persisted_spec
+                    .runtime_build_id
+                    .as_ref()
+                    .map(ToString::to_string);
+                (persisted_spec, runtime_build_id)
+            })
+            .unwrap_or_else(|| {
+                let spec = base_spec.with_runtime_build(runtime_build_id.clone());
+                (spec, Some(runtime_build_id.to_string()))
+            });
+        let claim_identity = dynamic_workflow_claim_identity(
+            &self.run_id,
+            self.source.as_ref(),
+            &self.input,
+            runtime_build_id.as_str(),
+            &prior_history,
+        )
+        .map_err(|error| {
+            anyhow::anyhow!("dynamic workflow continuation identity rejected: {error}")
+        })?;
+        let lease_ledger = dynamic_workflow_lease_ledger_for_context(
+            self.continuation_lease_ledger.as_ref(),
+            &self.memory_continuation_lease_ledger,
+            &self.context,
+        )
+        .await?;
+        Ok(DynamicWorkflowControlPreparation {
+            store,
+            prior_history,
+            spec,
+            effective_runtime_build_id,
+            runtime_build_id,
+            runtime_build_compatibility,
+            claim_identity,
+            lease_ledger,
+        })
+    }
+
+    fn build_engine(
+        &self,
+        preparation: &DynamicWorkflowControlPreparation,
+        workflow_context: ToolContext,
+        lease: Option<&DynamicWorkflowLease>,
+    ) -> FlowEngine {
+        let mut runtime = DynamicWorkflowRuntime::new(
+            Arc::clone(&self.registry),
+            workflow_context,
+            self.source.as_ref(),
+        )
+        .with_allowed_tools(self.allowed_tools.clone())
+        .with_limits(self.limits.clone());
+        if let Some(scheduler) = &self.task_scheduler {
+            runtime = runtime.with_task_scheduler(Arc::clone(scheduler), self.admit_steps_globally);
+        }
+        if let Some(lease) = lease {
+            runtime = runtime.with_continuation_lease(Arc::new(lease.clone()));
+        }
+        let runtime = Arc::new(runtime);
+        let initial_plan = if preparation.prior_history.is_empty() {
+            ExecutionPlan::new("dynamic workflow", Complexity::Medium)
+        } else {
+            dynamic_workflow_execution_plan(&preparation.prior_history)
+        };
+        let mut observers: Vec<Arc<dyn FlowEventObserver>> = Vec::new();
+        if let Some(tx) = self.context.agent_event_tx.clone() {
+            observers.push(Arc::new(AgentEventFlowObserver::new(
+                tx,
+                self.context.session_id.clone().unwrap_or_default(),
+                initial_plan,
+            )));
+        }
+        if let Some(observer) = &self.graph_observer {
+            observers.push(Arc::new(observer.clone()));
+        }
+        let mut builder = FlowEngine::builder(runtime)
+            .with_store(Arc::clone(&preparation.store))
+            .with_runtime_build_compatibility(preparation.runtime_build_compatibility.clone());
+        if !observers.is_empty() {
+            builder =
+                builder.with_observer(Arc::new(FanoutFlowEventObserver::from_observers(observers)));
+        }
+        builder.build()
+    }
+
+    async fn read_state(
+        &self,
+        preparation: &DynamicWorkflowControlPreparation,
+        engine: &FlowEngine,
+    ) -> Result<(WorkflowRunSnapshot, Vec<FlowEventEnvelope>)> {
+        for _ in 0..3 {
+            // Flow exposes history and its projection as separate reads. Read
+            // the journal on both sides of the projection so a concurrent
+            // append cannot be mistaken for an atomic snapshot; retry a
+            // bounded number of times when the sequences disagree.
+            let before_history = engine.history(&self.run_id).await?;
+            let snapshot = engine.snapshot(&self.run_id).await?;
+            let history = engine.history(&self.run_id).await?;
+            let before_sequence = before_history
+                .last()
+                .map(|event| event.sequence)
+                .unwrap_or(0);
+            let last_sequence = history.last().map(|event| event.sequence).unwrap_or(0);
+            if before_sequence == last_sequence && snapshot.last_sequence == last_sequence {
+                return Ok((snapshot, history));
+            }
+        }
+        let expected = preparation
+            .prior_history
+            .last()
+            .map(|event| event.sequence)
+            .unwrap_or(0);
+        anyhow::bail!(
+            "dynamic workflow state changed repeatedly while inspecting run `{}` (initial sequence {expected})",
+            self.run_id
+        )
+    }
+
+    async fn summarize(
+        &self,
+        preparation: &DynamicWorkflowControlPreparation,
+        snapshot: WorkflowRunSnapshot,
+        history: Vec<FlowEventEnvelope>,
+    ) -> Result<DynamicWorkflowControlSnapshot> {
+        let continuation_identity = dynamic_workflow_continuation_identity(
+            &self.run_id,
+            self.source.as_ref(),
+            &self.input,
+            preparation.runtime_build_id.as_str(),
+            &history,
+        )
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "dynamic workflow continuation identity rejected during inspection: {error}"
+            )
+        })?;
+        let plan = dynamic_workflow_execution_plan(&history);
+        let plan_identity = plan.definition_identity()?;
+        let (decision_id, request_hash) = dynamic_workflow_lease_key(&preparation.claim_identity);
+        let worker_lease = preparation
+            .lease_ledger
+            .inspect_with_identity(&decision_id, &request_hash, &preparation.claim_identity)
+            .await?;
+        let completed_steps = snapshot
+            .steps
+            .values()
+            .filter(|step| step.status == StepStatus::Completed)
+            .count();
+        let open_steps = snapshot
+            .steps
+            .values()
+            .filter(|step| {
+                !matches!(
+                    step.status,
+                    StepStatus::Completed | StepStatus::Failed | StepStatus::Cancelled
+                )
+            })
+            .count();
+        Ok(DynamicWorkflowControlSnapshot {
+            run_id: self.run_id.clone(),
+            status: snapshot.status,
+            last_sequence: snapshot.last_sequence,
+            step_count: snapshot.steps.len(),
+            completed_steps,
+            open_steps,
+            cancellation_requested: snapshot.cancellation.is_some(),
+            continuation_identity,
+            plan_identity,
+            runtime_build_id: preparation.effective_runtime_build_id.clone(),
+            worker_lease,
+        })
+    }
+
+    async fn claim(
+        &self,
+        preparation: &DynamicWorkflowControlPreparation,
+    ) -> Result<DynamicWorkflowLeaseClaim> {
+        claim_dynamic_workflow_lease(
+            Arc::clone(&preparation.lease_ledger),
+            preparation.claim_identity.clone(),
+            self.continuation_lease_ms,
+        )
+        .await
+    }
+
+    /// Inspect the durable run and return a bounded, digest-only projection.
+    pub async fn inspect(&self) -> Result<DynamicWorkflowControlSnapshot> {
+        let preparation = self.prepare(false).await?;
+        let engine = self.build_engine(&preparation, self.context.clone(), None);
+        let (snapshot, history) = self.read_state(&preparation, &engine).await?;
+        self.summarize(&preparation, snapshot, history).await
+    }
+
+    /// Read the complete durable Flow history for trusted host diagnostics.
+    ///
+    /// Unlike [`Self::inspect`], this method intentionally returns persisted
+    /// input and step output values. Callers should apply their own redaction
+    /// policy before exposing the result outside a trusted control plane.
+    pub async fn history(&self) -> Result<Vec<FlowEventEnvelope>> {
+        let preparation = self.prepare(false).await?;
+        let history = preparation.store.list(&self.run_id).await?;
+        dynamic_workflow_continuation_identity(
+            &self.run_id,
+            self.source.as_ref(),
+            &self.input,
+            preparation.runtime_build_id.as_str(),
+            &history,
+        )
+        .map_err(|error| anyhow::anyhow!("dynamic workflow history rejected: {error}"))?;
+        Ok(history)
+    }
+
+    /// Request cleanup-aware durable cancellation and settle the worker lease.
+    ///
+    /// A live worker keeps ownership and causes this method to return a busy
+    /// error; the caller can retry after the lease expires or the worker
+    /// releases it. This preserves one executor for side-effecting steps.
+    pub async fn request_cancellation(
+        &self,
+        reason: Option<String>,
+    ) -> Result<DynamicWorkflowControlSnapshot> {
+        validate_dynamic_workflow_control_reason(reason.as_deref())?;
+        if self.context.is_cancelled() {
+            anyhow::bail!("dynamic workflow control was cancelled before admission");
+        }
+        let preparation = self.prepare(false).await?;
+        let claim = self.claim(&preparation).await?;
+        let lease = match claim {
+            DynamicWorkflowLeaseClaim::Owned(lease) => lease,
+            DynamicWorkflowLeaseClaim::AlreadyCompleted => {
+                let engine = self.build_engine(&preparation, self.context.clone(), None);
+                let (snapshot, history) = self.read_state(&preparation, &engine).await?;
+                if !snapshot.status.is_terminal() {
+                    anyhow::bail!(
+                        "dynamic workflow worker claim is completed but its durable run is not terminal"
+                    );
+                }
+                return self.summarize(&preparation, snapshot, history).await;
+            }
+        };
+        let parent_cancellation = self.context.cancellation_token();
+        let child_cancellation = parent_cancellation.child_token();
+        let workflow_context = self
+            .context
+            .clone()
+            .with_cancellation(child_cancellation.clone());
+        let engine = self.build_engine(&preparation, workflow_context.clone(), Some(&lease));
+        let future = engine.request_cancellation(&self.run_id, CancellationRequest::new(reason));
+        let execution = drive_dynamic_workflow_control_future(
+            &engine,
+            &self.run_id,
+            DynamicWorkflowDriveContext {
+                source: self.source.as_ref(),
+                input_for_identity: &self.input,
+                runtime_build_id: preparation.runtime_build_id.as_str(),
+                workflow_context: &workflow_context,
+                parent_cancellation,
+                child_cancellation,
+            },
+            &lease,
+            future,
+        )
+        .await?;
+        self.summarize(&preparation, execution.snapshot, execution.history)
+            .await
+    }
+
+    /// Immediately terminate the run through Flow's durable cancellation
+    /// transition while still fencing the worker claim.
+    pub async fn force_cancel(
+        &self,
+        reason: Option<String>,
+    ) -> Result<DynamicWorkflowControlSnapshot> {
+        validate_dynamic_workflow_control_reason(reason.as_deref())?;
+        if self.context.is_cancelled() {
+            anyhow::bail!("dynamic workflow control was cancelled before admission");
+        }
+        let preparation = self.prepare(false).await?;
+        let claim = self.claim(&preparation).await?;
+        let lease = match claim {
+            DynamicWorkflowLeaseClaim::Owned(lease) => lease,
+            DynamicWorkflowLeaseClaim::AlreadyCompleted => {
+                let engine = self.build_engine(&preparation, self.context.clone(), None);
+                let (snapshot, history) = self.read_state(&preparation, &engine).await?;
+                if !snapshot.status.is_terminal() {
+                    anyhow::bail!(
+                        "dynamic workflow worker claim is completed but its durable run is not terminal"
+                    );
+                }
+                return self.summarize(&preparation, snapshot, history).await;
+            }
+        };
+        let parent_cancellation = self.context.cancellation_token();
+        let child_cancellation = parent_cancellation.child_token();
+        let workflow_context = self
+            .context
+            .clone()
+            .with_cancellation(child_cancellation.clone());
+        let engine = self.build_engine(&preparation, workflow_context.clone(), Some(&lease));
+        let future = async {
+            engine.force_cancel(&self.run_id, reason).await?;
+            engine.snapshot(&self.run_id).await
+        };
+        let execution = drive_dynamic_workflow_control_future(
+            &engine,
+            &self.run_id,
+            DynamicWorkflowDriveContext {
+                source: self.source.as_ref(),
+                input_for_identity: &self.input,
+                runtime_build_id: preparation.runtime_build_id.as_str(),
+                workflow_context: &workflow_context,
+                parent_cancellation,
+                child_cancellation,
+            },
+            &lease,
+            future,
+        )
+        .await?;
+        self.summarize(&preparation, execution.snapshot, execution.history)
+            .await
+    }
+
+    /// Resume or start the bound run under the same worker fencing contract as
+    /// the model-visible dynamic workflow tool.
+    pub async fn drive(&self) -> Result<DynamicWorkflowControlSnapshot> {
+        if self.context.is_cancelled() {
+            anyhow::bail!("dynamic workflow control was cancelled before admission");
+        }
+        let preparation = self.prepare(true).await?;
+        let claim = self.claim(&preparation).await?;
+        let lease = match claim {
+            DynamicWorkflowLeaseClaim::Owned(lease) => lease,
+            DynamicWorkflowLeaseClaim::AlreadyCompleted => {
+                let engine = self.build_engine(&preparation, self.context.clone(), None);
+                let (snapshot, history) = self.read_state(&preparation, &engine).await?;
+                if !snapshot.status.is_terminal() {
+                    anyhow::bail!(
+                        "dynamic workflow worker claim is completed but its durable run is not terminal"
+                    );
+                }
+                return self.summarize(&preparation, snapshot, history).await;
+            }
+        };
+        let parent_cancellation = self.context.cancellation_token();
+        let child_cancellation = parent_cancellation.child_token();
+        let workflow_context = self
+            .context
+            .clone()
+            .with_cancellation(child_cancellation.clone());
+        let engine = self.build_engine(&preparation, workflow_context.clone(), Some(&lease));
+        let execution = drive_dynamic_workflow_with_lease(
+            &engine,
+            &self.run_id,
+            preparation.spec.clone(),
+            self.input.clone(),
+            DynamicWorkflowDriveContext {
+                source: self.source.as_ref(),
+                input_for_identity: &self.input,
+                runtime_build_id: preparation.runtime_build_id.as_str(),
+                workflow_context: &workflow_context,
+                parent_cancellation,
+                child_cancellation,
+            },
+            &lease,
+        )
+        .await?;
+        self.summarize(&preparation, execution.snapshot, execution.history)
+            .await
+    }
+}
+
 struct DynamicWorkflowExecution {
     snapshot: WorkflowRunSnapshot,
     history: Vec<FlowEventEnvelope>,
@@ -1774,6 +2513,134 @@ async fn collect_dynamic_workflow_execution(
         history,
         continuation_identity,
     })
+}
+
+fn validate_dynamic_workflow_control_reason(reason: Option<&str>) -> Result<()> {
+    let Some(reason) = reason else {
+        return Ok(());
+    };
+    if reason.len() > MAX_DYNAMIC_WORKFLOW_CONTROL_REASON_BYTES {
+        anyhow::bail!(
+            "dynamic workflow cancellation reason exceeds {} bytes",
+            MAX_DYNAMIC_WORKFLOW_CONTROL_REASON_BYTES
+        );
+    }
+    if reason.contains('\0') {
+        anyhow::bail!("dynamic workflow cancellation reason contains a NUL byte");
+    }
+    Ok(())
+}
+
+async fn drive_dynamic_workflow_control_future<F>(
+    engine: &FlowEngine,
+    run_id: &str,
+    drive_context: DynamicWorkflowDriveContext<'_>,
+    lease: &DynamicWorkflowLease,
+    future: F,
+) -> Result<DynamicWorkflowExecution>
+where
+    F: Future<Output = a3s_flow::Result<WorkflowRunSnapshot>>,
+{
+    let DynamicWorkflowDriveContext {
+        source,
+        input_for_identity,
+        runtime_build_id,
+        workflow_context: _workflow_context,
+        parent_cancellation,
+        child_cancellation,
+    } = drive_context;
+    tokio::pin!(future);
+
+    async fn collect_result(
+        engine: &FlowEngine,
+        run_id: &str,
+        result: a3s_flow::Result<WorkflowRunSnapshot>,
+        source: &str,
+        input: &Value,
+        runtime_build_id: &str,
+    ) -> Result<DynamicWorkflowExecution> {
+        let snapshot = result?;
+        collect_dynamic_workflow_execution(
+            engine,
+            run_id,
+            snapshot,
+            source,
+            input,
+            runtime_build_id,
+        )
+        .await
+    }
+
+    let heartbeat_period = Duration::from_millis((lease.lease_ms / 3).max(1));
+    let first_heartbeat = tokio::time::Instant::now() + heartbeat_period;
+    let mut heartbeat = tokio::time::interval_at(first_heartbeat, heartbeat_period);
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut future => {
+                let result = collect_result(
+                    engine,
+                    run_id,
+                    result,
+                    source,
+                    input_for_identity,
+                    runtime_build_id,
+                ).await;
+                return settle_dynamic_workflow_lease(lease, result).await;
+            }
+            _ = parent_cancellation.cancelled() => {
+                child_cancellation.cancel();
+                match tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut future).await {
+                    Ok(result) => {
+                        let result = collect_result(
+                            engine,
+                            run_id,
+                            result,
+                            source,
+                            input_for_identity,
+                            runtime_build_id,
+                        ).await;
+                        match settle_dynamic_workflow_lease(lease, result).await {
+                            Ok(execution) if execution.snapshot.status.is_terminal() => {
+                                return Ok(execution)
+                            }
+                            Ok(_) => anyhow::bail!("dynamic workflow control cancelled by its parent"),
+                            Err(error) => return Err(error).context("settle dynamic workflow control cancellation"),
+                        }
+                    }
+                    Err(_) => anyhow::bail!(
+                        "dynamic workflow control cancellation did not settle within {} seconds; worker lease remains fenced until expiry",
+                        MAX_DYNAMIC_WORKFLOW_SETTLE.as_secs()
+                    ),
+                }
+            }
+            _ = heartbeat.tick() => {
+                match lease.renew().await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        child_cancellation.cancel();
+                        if tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut future)
+                            .await
+                            .is_ok()
+                        {
+                            let _ = lease.release().await;
+                        }
+                        anyhow::bail!("dynamic workflow control worker lease was lost before completion");
+                    }
+                    Err(error) => {
+                        child_cancellation.cancel();
+                        if tokio::time::timeout(MAX_DYNAMIC_WORKFLOW_SETTLE, &mut future)
+                            .await
+                            .is_ok()
+                        {
+                            let _ = lease.release().await;
+                        }
+                        return Err(error).context("renew dynamic workflow control worker lease");
+                    }
+                }
+            }
+        }
+    }
 }
 
 async fn settle_dynamic_workflow_lease(
@@ -1953,6 +2820,21 @@ pub fn register_dynamic_workflow(registry: &Arc<ToolRegistry>) {
     )));
 }
 
+/// Register a dynamic workflow Tool against a host-owned Flow event store.
+///
+/// The registry-bound Tool keeps only a weak registry reference, so adding a
+/// durable store does not create a registry/tool ownership cycle. Use this for
+/// database-backed or remote adapters that must be shared by model-visible
+/// execution and [`DynamicWorkflowTool::control`].
+pub fn register_dynamic_workflow_with_event_store(
+    registry: &Arc<ToolRegistry>,
+    store: Arc<dyn FlowEventStore>,
+) {
+    registry.register(Arc::new(
+        DynamicWorkflowTool::new_registry_bound(Arc::clone(registry)).with_flow_event_store(store),
+    ));
+}
+
 /// Register a dynamic workflow tool with an explicit scheduler policy.
 ///
 /// This is intended for hosts that construct a Flow runtime outside the
@@ -1982,7 +2864,7 @@ async fn flow_store_for_context(
             if let Some(run_id) = requested_run_id.filter(|run_id| safe_workflow_run_id(run_id)) {
                 validate_dynamic_workflow_log(&store.join(format!("{run_id}.jsonl"))).await?;
             }
-            Ok(Arc::new(LocalFileEventStore::new(store)))
+            Ok(Arc::new(CrossProcessFlowEventStore::new(store)))
         }
         None => Ok(Arc::new(InMemoryEventStore::new())),
     }

--- a/core/src/dynamic_workflow/tests.rs
+++ b/core/src/dynamic_workflow/tests.rs
@@ -20,6 +20,19 @@ fn registered_dynamic_workflow_does_not_retain_its_registry() {
     assert!(lifetime.upgrade().is_none());
 }
 
+#[test]
+fn event_store_registration_does_not_retain_its_registry() {
+    let registry = Arc::new(ToolRegistry::new(std::path::PathBuf::from(
+        "dynamic-workflow-store-cycle-test",
+    )));
+    let lifetime = Arc::downgrade(&registry);
+    register_dynamic_workflow_with_event_store(&registry, Arc::new(InMemoryEventStore::new()));
+
+    drop(registry);
+
+    assert!(lifetime.upgrade().is_none());
+}
+
 struct DelayedObjectClient {
     delay: Duration,
 }
@@ -2091,6 +2104,148 @@ return {
             ["status"],
         "waiting"
     );
+}
+
+#[tokio::test]
+async fn dynamic_workflow_control_projects_and_settles_durable_cancellation() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let ledger: Arc<dyn FlowDecisionLedger> = Arc::new(MemoryFlowDecisionLedger::new());
+    let source = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    const cancellationRequested = inputs.history.some((entry) =>
+      entry.event && entry.event.type === "run_cancellation_requested"
+    );
+    if (cancellationRequested) return { type: "cancel" };
+    return {
+      type: "wait_until",
+      wait_id: "operator",
+      resume_at: "2099-01-01T00:00:00Z",
+    };
+  }
+  return { type: "fail", error: "unexpected invocation" };
+}
+"#;
+    let input = json!({ "secret": "must-not-enter-projection" });
+    let control = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_continuation_lease_ledger(Arc::clone(&ledger), 1_000)
+        .control(
+            "control-cancellation-run",
+            source,
+            input.clone(),
+            &executor.registry().context(),
+        )
+        .unwrap();
+
+    let suspended = control.drive().await.unwrap();
+    assert_eq!(suspended.status, WorkflowRunStatus::Suspended);
+    assert!(!suspended.cancellation_requested);
+    assert!(matches!(
+        suspended.worker_lease,
+        FlowDecisionClaimState::Pending { .. }
+    ));
+    assert!(!suspended.worker_lease.is_live_at(dynamic_workflow_now_ms()));
+    let encoded = serde_json::to_string(&suspended).unwrap();
+    assert!(!encoded.contains("must-not-enter-projection"));
+    assert!(!encoded.contains(source));
+
+    let cancelled = control
+        .request_cancellation(Some("operator stop".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status, WorkflowRunStatus::Cancelled);
+    assert!(cancelled.cancellation_requested);
+    assert!(matches!(
+        cancelled.worker_lease,
+        FlowDecisionClaimState::Completed { .. }
+    ));
+
+    let inspected = control.inspect().await.unwrap();
+    assert_eq!(inspected, cancelled);
+    let history = control.history().await.unwrap();
+    assert!(history
+        .iter()
+        .any(|event| matches!(event.event, FlowEvent::RunCancellationRequested { .. })));
+    assert!(history
+        .iter()
+        .any(|event| matches!(event.event, FlowEvent::RunCancelled { .. })));
+    let _ = input;
+}
+
+#[tokio::test]
+async fn dynamic_workflow_control_reuses_a_host_owned_event_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let executor = ToolExecutor::new(dir.path().to_string_lossy().to_string());
+    let store: Arc<dyn FlowEventStore> = Arc::new(InMemoryEventStore::new());
+    let source =
+        "async function run(ctx, inputs) { return { type: 'complete', output: { hosted: true } }; }";
+    let tool = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+        .with_flow_event_store(Arc::clone(&store));
+    let args = json!({
+        "source": source,
+        "run_id": "host-owned-store-run",
+    });
+    let result = tool
+        .execute(&args, &executor.registry().context())
+        .await
+        .unwrap();
+    assert!(result.success, "{}", result.content);
+    let control = tool
+        .control(
+            "host-owned-store-run",
+            source,
+            json!({}),
+            &executor.registry().context(),
+        )
+        .unwrap();
+    let snapshot = control.inspect().await.unwrap();
+    assert_eq!(snapshot.status, WorkflowRunStatus::Completed);
+    assert_eq!(snapshot.last_sequence, 3);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cross_process_flow_store_serializes_independent_writers() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = Arc::new(CrossProcessFlowEventStore::new(directory.path()));
+    let second = Arc::new(CrossProcessFlowEventStore::new(directory.path()));
+    let spec = WorkflowSpec::rust_embedded(
+        "a3s-code.dynamic-workflow",
+        source_hash("cross-process-store"),
+        "ptc",
+        "run",
+    )
+    .with_runtime_build(
+        RuntimeBuildId::new(DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID.to_string()).unwrap(),
+    );
+    first
+        .append(
+            "cross-process-store",
+            FlowEvent::RunCreated {
+                spec,
+                input: json!({}),
+            },
+        )
+        .await
+        .unwrap();
+
+    let (left, right) = tokio::join!(
+        first.append_if_sequence("cross-process-store", 1, FlowEvent::RunStarted,),
+        second.append_if_sequence("cross-process-store", 1, FlowEvent::RunStarted,),
+    );
+    assert_eq!(left.is_ok() as u8 + right.is_ok() as u8, 1);
+    let conflict = if left.is_err() { left } else { right };
+    assert!(matches!(
+        conflict,
+        Err(a3s_flow::FlowError::EventConflict {
+            expected_sequence: 1,
+            actual_sequence: 2,
+            ..
+        })
+    ));
+    let history = second.list("cross-process-store").await.unwrap();
+    assert_eq!(history.len(), 2);
+    assert!(matches!(history[1].event, FlowEvent::RunStarted));
 }
 
 #[test]

--- a/core/src/flow_graph/decision_ledger.rs
+++ b/core/src/flow_graph/decision_ledger.rs
@@ -18,6 +18,41 @@ pub enum FlowDecisionClaimOutcome {
     Conflict,
 }
 
+/// Redacted point-in-time state of one decision claim.
+///
+/// The owner identifier is intentionally omitted: it is an internal fencing
+/// token, not an operator-facing diagnostic. A pending record may already be
+/// expired; callers compare `lease_expires_at_ms` with their own clock before
+/// attempting takeover.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowDecisionClaimState {
+    /// No claim record exists for the requested decision.
+    Missing,
+    /// A claim is pending (possibly expired and therefore reclaimable).
+    Pending {
+        lease_expires_at_ms: u64,
+        attempts: u32,
+    },
+    /// The claim has been completed and cannot be reclaimed.
+    Completed { completed_at_ms: Option<u64> },
+    /// The configured host ledger does not expose inspection.
+    Unavailable,
+}
+
+impl FlowDecisionClaimState {
+    /// Return whether a pending claim is still live at `now_ms`.
+    pub fn is_live_at(&self, now_ms: u64) -> bool {
+        matches!(
+            self,
+            Self::Pending {
+                lease_expires_at_ms,
+                ..
+            } if *lease_expires_at_ms > now_ms
+        )
+    }
+}
+
 #[async_trait]
 pub trait FlowDecisionLedger: Send + Sync {
     async fn claim(
@@ -57,6 +92,32 @@ pub trait FlowDecisionLedger: Send + Sync {
             .map_err(|error| anyhow::anyhow!(error))?;
         self.claim(decision_id, request_hash, owner_id, now_ms, lease_ms)
             .await
+    }
+
+    /// Inspect a claim without revealing its owner token.
+    ///
+    /// Custom host ledgers remain source-compatible and report
+    /// [`FlowDecisionClaimState::Unavailable`] until they opt into the
+    /// inspection contract.
+    async fn inspect(
+        &self,
+        _decision_id: &str,
+        _request_hash: &str,
+    ) -> Result<FlowDecisionClaimState> {
+        Ok(FlowDecisionClaimState::Unavailable)
+    }
+
+    /// Inspect a claim while validating its canonical execution identity.
+    async fn inspect_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+    ) -> Result<FlowDecisionClaimState> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        self.inspect(decision_id, request_hash).await
     }
 
     /// Renew only when both the legacy request key and canonical identity
@@ -242,6 +303,28 @@ impl FlowDecisionLedger for MemoryFlowDecisionLedger {
             now_ms,
             lease_ms,
         ))
+    }
+
+    async fn inspect(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+    ) -> Result<FlowDecisionClaimState> {
+        let records = self.records.lock().await;
+        inspect_record(&records, decision_id, request_hash, None)
+    }
+
+    async fn inspect_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+    ) -> Result<FlowDecisionClaimState> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        let records = self.records.lock().await;
+        inspect_record(&records, decision_id, request_hash, Some(identity))
     }
 
     async fn complete(
@@ -494,6 +577,28 @@ impl FlowDecisionLedger for FileFlowDecisionLedger {
             ))
         })
         .await
+    }
+
+    async fn inspect(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+    ) -> Result<FlowDecisionClaimState> {
+        let records = read_records(&self.data_path()).await?;
+        inspect_record(&records, decision_id, request_hash, None)
+    }
+
+    async fn inspect_with_identity(
+        &self,
+        decision_id: &str,
+        request_hash: &str,
+        identity: &ExecutionIdentityV1,
+    ) -> Result<FlowDecisionClaimState> {
+        identity
+            .validate()
+            .map_err(|error| anyhow::anyhow!(error))?;
+        let records = read_records(&self.data_path()).await?;
+        inspect_record(&records, decision_id, request_hash, Some(identity))
     }
 
     async fn complete(
@@ -823,6 +928,32 @@ fn identity_conflicts(
     )
 }
 
+fn inspect_record(
+    records: &BTreeMap<String, ClaimRecord>,
+    decision_id: &str,
+    request_hash: &str,
+    execution_identity: Option<&ExecutionIdentityV1>,
+) -> Result<FlowDecisionClaimState> {
+    let Some(record) = records.get(decision_id) else {
+        return Ok(FlowDecisionClaimState::Missing);
+    };
+    if record.request_hash != request_hash {
+        anyhow::bail!("decision `{decision_id}` request hash conflicts with its claim");
+    }
+    if identity_conflicts(record, execution_identity) {
+        anyhow::bail!("decision `{decision_id}` execution identity conflicts with its claim");
+    }
+    Ok(match record.status {
+        ClaimStatus::Pending => FlowDecisionClaimState::Pending {
+            lease_expires_at_ms: record.lease_expires_at_ms,
+            attempts: record.attempts,
+        },
+        ClaimStatus::Completed => FlowDecisionClaimState::Completed {
+            completed_at_ms: record.completed_at_ms,
+        },
+    })
+}
+
 fn validate_receipt(
     identity: &ExecutionIdentityV1,
     receipt: &ExecutionResultReceiptV1,
@@ -957,11 +1088,32 @@ mod tests {
         let other = identity("other");
         assert_eq!(
             ledger
+                .inspect_with_identity("decision", "hash", &first)
+                .await
+                .unwrap(),
+            FlowDecisionClaimState::Missing
+        );
+        assert_eq!(
+            ledger
                 .claim_with_identity("decision", "hash", &first, "owner", 100, 50)
                 .await
                 .unwrap(),
             FlowDecisionClaimOutcome::Claimed { attempt: 1 }
         );
+        assert_eq!(
+            ledger
+                .inspect_with_identity("decision", "hash", &first)
+                .await
+                .unwrap(),
+            FlowDecisionClaimState::Pending {
+                lease_expires_at_ms: 150,
+                attempts: 1,
+            }
+        );
+        assert!(ledger
+            .inspect_with_identity("decision", "hash", &other)
+            .await
+            .is_err());
         assert!(!ledger
             .renew_with_identity("decision", "hash", &other, "owner", 110, 50)
             .await
@@ -994,6 +1146,15 @@ mod tests {
         assert_eq!(
             ledger.completed_receipt("decision").await.unwrap(),
             Some(result_receipt)
+        );
+        assert_eq!(
+            ledger
+                .inspect_with_identity("decision", "hash", &first)
+                .await
+                .unwrap(),
+            FlowDecisionClaimState::Completed {
+                completed_at_ms: Some(121),
+            }
         );
         assert!(!ledger
             .renew_with_identity("decision", "hash", &first, "owner", 130, 50)
@@ -1033,6 +1194,15 @@ mod tests {
                 .await
                 .unwrap(),
             FlowDecisionClaimOutcome::Completed
+        );
+        assert_eq!(
+            reopened
+                .inspect_with_identity("decision", "hash", &execution_identity)
+                .await
+                .unwrap(),
+            FlowDecisionClaimState::Completed {
+                completed_at_ms: Some(120),
+            }
         );
     }
 

--- a/core/src/flow_graph/mod.rs
+++ b/core/src/flow_graph/mod.rs
@@ -23,7 +23,8 @@ pub use decision::{
     FlowDecisionHealthStatus, FlowDecisionRequest, FlowDecisionSink, FlowDecisionStep,
 };
 pub use decision_ledger::{
-    FileFlowDecisionLedger, FlowDecisionClaimOutcome, FlowDecisionLedger, MemoryFlowDecisionLedger,
+    FileFlowDecisionLedger, FlowDecisionClaimOutcome, FlowDecisionClaimState, FlowDecisionLedger,
+    MemoryFlowDecisionLedger,
 };
 
 pub const FLOW_GRAPH_SOURCE: &str = "a3s-flow";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -226,7 +226,9 @@ pub use durable_memory::{
 pub use dynamic_workflow::{
     dynamic_workflow_claim_identity, dynamic_workflow_continuation_identity,
     dynamic_workflow_execution_plan, dynamic_workflow_step_identity, dynamic_workflow_store_path,
-    register_dynamic_workflow_with_scheduler, DynamicWorkflowAdmissionStats,
+    register_dynamic_workflow, register_dynamic_workflow_with_event_store,
+    register_dynamic_workflow_with_scheduler, CrossProcessFlowEventStore,
+    DynamicWorkflowAdmissionStats, DynamicWorkflowControl, DynamicWorkflowControlSnapshot,
     DynamicWorkflowRuntime, DynamicWorkflowScriptLimits, DynamicWorkflowTool,
     DYNAMIC_WORKFLOW_RUNTIME_BUILD_ID, DYNAMIC_WORKFLOW_STORE_RELATIVE_PATH,
 };
@@ -275,11 +277,11 @@ pub use event_protocol::{
 };
 pub use flow_graph::{
     run_object_id as flow_run_object_id, step_object_id as flow_step_object_id,
-    FileFlowDecisionLedger, FlowDecision, FlowDecisionClaimOutcome, FlowDecisionDispatchError,
-    FlowDecisionDispatcher, FlowDecisionHealthSnapshot, FlowDecisionHealthStatus,
-    FlowDecisionLedger, FlowDecisionRequest, FlowDecisionSink, FlowDecisionStep,
-    FlowGraphHealthSnapshot, FlowGraphHealthStatus, FlowGraphObserver, MemoryFlowDecisionLedger,
-    FLOW_GRAPH_SOURCE,
+    FileFlowDecisionLedger, FlowDecision, FlowDecisionClaimOutcome, FlowDecisionClaimState,
+    FlowDecisionDispatchError, FlowDecisionDispatcher, FlowDecisionHealthSnapshot,
+    FlowDecisionHealthStatus, FlowDecisionLedger, FlowDecisionRequest, FlowDecisionSink,
+    FlowDecisionStep, FlowGraphHealthSnapshot, FlowGraphHealthStatus, FlowGraphObserver,
+    MemoryFlowDecisionLedger, FLOW_GRAPH_SOURCE,
 };
 pub use harness_evidence::{
     HarnessEvidenceError, ModelInputKindV1, ModelInputSnapshotV1, ModelPresentationApplicationV1,

--- a/core/src/tools/mod.rs
+++ b/core/src/tools/mod.rs
@@ -26,7 +26,8 @@ pub mod task;
 mod types;
 
 pub use crate::dynamic_workflow::{
-    register_dynamic_workflow, register_dynamic_workflow_with_scheduler,
+    register_dynamic_workflow, register_dynamic_workflow_with_event_store,
+    register_dynamic_workflow_with_scheduler,
 };
 pub use agent_dir_script_tool::AgentDirScriptTool;
 pub use artifacts::{ArtifactStore, ArtifactStoreLimits, ToolArtifact};

--- a/core/tests/dynamic_workflow_control_recovery.rs
+++ b/core/tests/dynamic_workflow_control_recovery.rs
@@ -1,0 +1,383 @@
+//! Cross-process qualification for the dynamic-workflow control boundary.
+//!
+//! The helper test is intentionally launched through the test binary itself.
+//! This keeps the fixture provider-free while still exercising independent
+//! process address spaces, the shared Flow journal, and the shared lease
+//! sidecar.
+
+use a3s_code_core::tools::{Tool, ToolContext, ToolExecutor, ToolOutput};
+use a3s_code_core::{
+    CrossProcessFlowEventStore, DynamicWorkflowControlSnapshot, DynamicWorkflowRuntime,
+    DynamicWorkflowTool, FlowDecisionClaimState, ToolCapabilities,
+};
+use a3s_flow::{FlowEngine, FlowEvent, FlowEventStore, WorkflowProgress};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::{Child, Command};
+
+const ROLE_ENV: &str = "A3S_DYNAMIC_WORKFLOW_CONTROL_ROLE";
+const WORKSPACE_ENV: &str = "A3S_DYNAMIC_WORKFLOW_CONTROL_WORKSPACE";
+const MARKER_ENV: &str = "A3S_DYNAMIC_WORKFLOW_CONTROL_MARKER";
+const GO_ENV: &str = "A3S_DYNAMIC_WORKFLOW_CONTROL_GO";
+const PROGRESS_ID_ENV: &str = "A3S_DYNAMIC_WORKFLOW_CONTROL_PROGRESS_ID";
+const RUN_ID: &str = "cross-process-control-run";
+const PROGRESS_RUN_ID: &str = "cross-process-progress-run";
+
+const WORKFLOW_SOURCE: &str = r#"
+async function run(ctx, inputs) {
+  if (inputs.kind === "workflow") {
+    const cancellationRequested = inputs.history.some((entry) =>
+      entry.event && entry.event.type === "run_cancellation_requested"
+    );
+    if (cancellationRequested) return { type: "cancel" };
+    if (inputs.step_outputs.work) {
+      return { type: "complete", output: { recovered: true } };
+    }
+    return {
+      type: "schedule_step",
+      step_id: "work",
+      step_name: "task",
+      input: {},
+      retry: { max_attempts: 1, delay_ms: 0 },
+    };
+  }
+  return await ctx.tool("task", inputs.input);
+}
+"#;
+
+struct CrashBlockingTask {
+    started_marker: PathBuf,
+}
+
+#[async_trait]
+impl Tool for CrashBlockingTask {
+    fn name(&self) -> &str {
+        "task"
+    }
+
+    fn description(&self) -> &str {
+        "A qualification-only task that keeps a worker process alive."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({"type": "object"})
+    }
+
+    fn capabilities(&self, _args: &Value) -> ToolCapabilities {
+        ToolCapabilities::conservative()
+    }
+
+    async fn execute(&self, _args: &Value, _ctx: &ToolContext) -> anyhow::Result<ToolOutput> {
+        tokio::fs::write(&self.started_marker, b"started").await?;
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Ok(ToolOutput::success("unexpectedly released"))
+    }
+}
+
+/// A fault-injecting event-store adapter used only by the process helper.
+/// It forces one optimistic conflict before delegating the real append, so
+/// Flow's bounded conflict retry is exercised deterministically.
+struct ConflictOnceStore {
+    inner: Arc<CrossProcessFlowEventStore>,
+    injected: AtomicBool,
+    progress_id: String,
+}
+
+#[async_trait]
+impl FlowEventStore for ConflictOnceStore {
+    async fn append(
+        &self,
+        run_id: &str,
+        event: FlowEvent,
+    ) -> a3s_flow::Result<a3s_flow::FlowEventEnvelope> {
+        self.inner.append(run_id, event).await
+    }
+
+    async fn append_if_sequence(
+        &self,
+        run_id: &str,
+        expected_sequence: u64,
+        event: FlowEvent,
+    ) -> a3s_flow::Result<a3s_flow::FlowEventEnvelope> {
+        if self.injected.swap(true, Ordering::SeqCst) {
+            return self
+                .inner
+                .append_if_sequence(run_id, expected_sequence, event)
+                .await;
+        }
+        let injected = FlowEvent::RunProgressRecorded {
+            progress: WorkflowProgress::new(format!("injected-{}", self.progress_id), 1)
+                .with_total(2),
+        };
+        match self
+            .inner
+            .append_if_sequence(run_id, expected_sequence, injected)
+            .await
+        {
+            Ok(_) | Err(a3s_flow::FlowError::EventConflict { .. }) => {}
+            Err(error) => return Err(error),
+        }
+        self.inner
+            .append_if_sequence(run_id, expected_sequence, event)
+            .await
+    }
+
+    async fn list(&self, run_id: &str) -> a3s_flow::Result<Vec<a3s_flow::FlowEventEnvelope>> {
+        self.inner.list(run_id).await
+    }
+
+    async fn list_run_ids(&self) -> a3s_flow::Result<Vec<String>> {
+        self.inner.list_run_ids().await
+    }
+}
+
+async fn wait_for_path(path: &Path) -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if tokio::fs::try_exists(path).await? {
+                return Ok::<(), anyhow::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("timed out waiting for {}", path.display()))??;
+    Ok(())
+}
+
+fn helper_command(
+    role: &str,
+    workspace: &Path,
+    marker: &Path,
+    go: Option<&Path>,
+) -> anyhow::Result<Command> {
+    let executable = std::env::current_exe()?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--exact")
+        .arg("dynamic_workflow_process_helper")
+        .arg("--nocapture")
+        .env(ROLE_ENV, role)
+        .env(WORKSPACE_ENV, workspace)
+        .env(MARKER_ENV, marker)
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(go) = go {
+        command.env(GO_ENV, go);
+    }
+    Ok(command)
+}
+
+async fn finish_child(child: Child, role: &str) -> anyhow::Result<()> {
+    let output = child.wait_with_output().await?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "{role} helper failed: status={}; stdout={}; stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dynamic_workflow_control_recovers_after_process_crash_and_retries_conflicts(
+) -> anyhow::Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let owner_ready = workspace.path().join("owner-ready");
+    let owner_started = workspace.path().join("owner-started");
+    let recovered = workspace.path().join("recovered.json");
+
+    let owner = helper_command("owner", workspace.path(), &owner_ready, None)?.spawn()?;
+    wait_for_path(&owner_ready).await?;
+    wait_for_path(&owner_started).await?;
+
+    let executor = ToolExecutor::new(workspace.path().display().to_string());
+    let observer_control = DynamicWorkflowTool::new(Arc::clone(executor.registry())).control(
+        RUN_ID,
+        WORKFLOW_SOURCE,
+        json!({}),
+        &executor.registry().context(),
+    )?;
+    let live = observer_control.inspect().await?;
+    assert!(matches!(
+        live.worker_lease,
+        FlowDecisionClaimState::Pending { .. }
+    ));
+    assert!(live.worker_lease.is_live_at(current_time_ms()));
+    let busy = observer_control
+        .request_cancellation(Some("operator probe".to_string()))
+        .await
+        .expect_err("a live worker must retain the lease");
+    assert!(
+        busy.to_string().contains("worker lease is busy"),
+        "{busy:#}"
+    );
+
+    let mut owner = owner;
+    owner.kill().await?;
+    let _ = owner.wait().await?;
+    // The killed process no longer renews. Wait past the explicit owner lease
+    // used by the helper before allowing takeover.
+    tokio::time::sleep(Duration::from_millis(450)).await;
+
+    let recovery = helper_command("recover", workspace.path(), &recovered, None)?.spawn()?;
+    finish_child(recovery, "recover").await?;
+    let recovered_snapshot: DynamicWorkflowControlSnapshot =
+        serde_json::from_slice(&tokio::fs::read(&recovered).await?)?;
+    assert_eq!(
+        recovered_snapshot.status,
+        a3s_flow::WorkflowRunStatus::Cancelled
+    );
+    assert!(recovered_snapshot.cancellation_requested);
+    assert!(matches!(
+        recovered_snapshot.worker_lease,
+        FlowDecisionClaimState::Completed { .. }
+    ));
+
+    // Build a second suspended run, then ask two independent helper
+    // processes to append progress through fault-injecting stores. Each
+    // helper forces an EventConflict once; Flow must reload and retry.
+    let progress_control = DynamicWorkflowTool::new(Arc::clone(executor.registry())).control(
+        PROGRESS_RUN_ID,
+        r#"async function run(ctx, inputs) {
+          return { type: "wait_until", wait_id: "external", resume_at: "2099-01-01T00:00:00Z" };
+        }"#,
+        json!({}),
+        &executor.registry().context(),
+    )?;
+    let progress = progress_control.drive().await?;
+    assert_eq!(progress.status, a3s_flow::WorkflowRunStatus::Suspended);
+    let progress_a_marker = workspace.path().join("progress-a-ready");
+    let progress_b_marker = workspace.path().join("progress-b-ready");
+    let progress_a = spawn_progress_helper(
+        workspace.path(),
+        "progress-a",
+        &progress_a_marker,
+        &workspace.path().join("progress-a-go"),
+    )
+    .await?;
+    let progress_b = spawn_progress_helper(
+        workspace.path(),
+        "progress-b",
+        &progress_b_marker,
+        &workspace.path().join("progress-b-go"),
+    )
+    .await?;
+    wait_for_path(&progress_a_marker).await?;
+    wait_for_path(&progress_b_marker).await?;
+    tokio::fs::write(workspace.path().join("progress-a-go"), b"go").await?;
+    tokio::fs::write(workspace.path().join("progress-b-go"), b"go").await?;
+    finish_child(progress_a, "progress-a").await?;
+    finish_child(progress_b, "progress-b").await?;
+    let history = progress_control.history().await?;
+    let progress_ids = history
+        .iter()
+        .filter_map(|event| match &event.event {
+            FlowEvent::RunProgressRecorded { progress } => Some(progress.progress_id.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(progress_ids.contains(&"progress-a"));
+    assert!(progress_ids.contains(&"progress-b"));
+    Ok(())
+}
+
+async fn spawn_progress_helper(
+    workspace: &Path,
+    progress_id: &str,
+    marker: &Path,
+    go: &Path,
+) -> anyhow::Result<Child> {
+    let mut command = helper_command("progress", workspace, marker, Some(go))?;
+    command.env(PROGRESS_ID_ENV, progress_id);
+    Ok(command.spawn()?)
+}
+
+fn current_time_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dynamic_workflow_process_helper() -> anyhow::Result<()> {
+    let Some(role) = std::env::var_os(ROLE_ENV) else {
+        return Ok(());
+    };
+    let role = role.to_string_lossy();
+    let workspace = PathBuf::from(std::env::var(WORKSPACE_ENV)?);
+    let marker = PathBuf::from(std::env::var(MARKER_ENV)?);
+    match role.as_ref() {
+        "owner" => {
+            let executor = ToolExecutor::new(workspace.display().to_string());
+            executor.register_dynamic_tool(Arc::new(CrashBlockingTask {
+                started_marker: workspace.join("owner-started"),
+            }));
+            let control = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+                .with_continuation_lease_ms(250)
+                .control(
+                    RUN_ID,
+                    WORKFLOW_SOURCE,
+                    json!({}),
+                    &executor.registry().context(),
+                )?;
+            tokio::fs::write(&marker, b"ready").await?;
+            let _ = control.drive().await?;
+        }
+        "recover" => {
+            let executor = ToolExecutor::new(workspace.display().to_string());
+            let control = DynamicWorkflowTool::new(Arc::clone(executor.registry()))
+                .with_continuation_lease_ms(1_000)
+                .control(
+                    RUN_ID,
+                    WORKFLOW_SOURCE,
+                    json!({}),
+                    &executor.registry().context(),
+                )?;
+            let snapshot = control
+                .request_cancellation(Some("recovered after owner crash".to_string()))
+                .await?;
+            tokio::fs::write(&marker, serde_json::to_vec(&snapshot)?).await?;
+        }
+        "progress" => {
+            let progress_id = std::env::var(PROGRESS_ID_ENV)?;
+            let go = PathBuf::from(std::env::var(GO_ENV)?);
+            let executor = ToolExecutor::new(workspace.display().to_string());
+            let inner = Arc::new(CrossProcessFlowEventStore::new(
+                a3s_code_core::dynamic_workflow_store_path(&workspace),
+            ));
+            let store = Arc::new(ConflictOnceStore {
+                inner,
+                injected: AtomicBool::new(false),
+                progress_id: progress_id.clone(),
+            });
+            let runtime = Arc::new(DynamicWorkflowRuntime::new(
+                Arc::clone(executor.registry()),
+                executor.registry().context(),
+                "async function run(ctx, inputs) { return { type: 'fail', error: 'unused' }; }",
+            ));
+            let engine = FlowEngine::new(store, runtime);
+            tokio::fs::write(&marker, b"ready").await?;
+            wait_for_path(&go).await?;
+            engine
+                .record_progress(
+                    PROGRESS_RUN_ID,
+                    WorkflowProgress::new(progress_id, 1).with_total(2),
+                )
+                .await?;
+        }
+        other => anyhow::bail!("unknown process-helper role {other}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a host-facing `DynamicWorkflowControl` for bounded inspection, trusted history, resume, and durable cancellation
- expose redacted claim inspection and typed host-owned Flow event-store injection
- serialize the local Flow JSONL adapter across processes without introducing a second workflow authority
- qualify killed-worker takeover, lease expiry, cancellation settlement, and optimistic event conflicts with independent processes

## Validation
- `cargo +stable fmt --all -- --check`
- `cargo +stable check -p a3s-code-core --all-targets`
- `cargo +stable clippy -p a3s-code-core --lib -- -D warnings`
- `cargo +stable clippy -p a3s-code-core --test dynamic_workflow_control_recovery -- -D warnings`
- focused dynamic workflow tests: 42 passed
- `cargo +stable test -p a3s-code-core --test dynamic_workflow_control_recovery -- --nocapture`: 2 passed
- `cargo +stable test -p a3s-code-core --doc`: 8 passed, 6 ignored
