### PR TITLE
feat(core): qualify provider-aware model admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added provider-aware model-generation admission. Built-in provider clients
+  expose a digest-only `ModelGenerationPool` identity, and regular, streaming,
+  and structured calls project that capacity into the existing agent-wide
+  scheduler across sessions, direct tools, delegated children, and dynamic
+  workflows. Quota-only leaf reservations avoid recursive single-slot
+  deadlocks; local and shared permits release on cancellation, provider
+  failure, repair boundaries, and dropped streams. Endpoint credentials,
+  prompts, outputs, and other secret material never enter the identity.
 - Added a typed per-owner admission quota to the existing agent-wide
   scheduler. `TaskSchedulerQuota` derives a bounded digest-only identity from a
   run or host scope, `acquire_with_quota` enforces the limit in the same actor

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   scheduler with a digest-only step identity and an owner quota; session-bound
   calls retain one outer scheduler lease to avoid nested single-slot
   deadlocks. Detached children inherit a run/session admission scope.
+- **Provider-aware generation admission.** Regular, streaming, and structured
+  model calls share one typed provider/model capacity identity across sessions,
+  delegated children, direct tools, and dynamic workflows. Leaf generations
+  reserve that capacity through the existing scheduler actor without creating a
+  second queue; cancellation and dropped streams release both local and shared
+  reservations automatically.
 - **Generation-fenced workflow replay.** New dynamic workflow runs pin the
   Code runtime build and expose a digest-only continuation identity derived
   from durable immutable facts. Changed source/input, conflicting step
@@ -192,7 +198,7 @@ telemetry remain opt-in.
 | Structured output       | Native provider formats or schema-validated prompt, partial parse, and repair fallback                                                                                                                                                  | Baseline                                                                                                                                                                  |
 | MCP and Skills          | Isolated MCP transports plus filesystem, registry, inline, and live session Skills                                                                                                                                                      | Configuration or live registration                                                                                                                                        |
 | Planning and delegation | Optional plans and goals, foreground/background workers, bounded parallel tasks, progress, and targeted cancellation                                                                                                                    | Manual tools independently configurable; automation opt-in                                                                                                                |
-| Priority scheduling     | Agent-wide `a3s-lane` priority/FIFO admission across sessions, direct tools, detached background children, and host workflows, with cancellation, starvation-safe aging, digest-only owner quotas, occupancy snapshots, and bounded cumulative health counters | Baseline; tune `task_scheduler`, select per-session `TaskPriority`, inspect `task_scheduler_stats()` or `task_scheduler_health()`; Rust hosts can use `TaskSchedulerQuota` for a scoped limit |
+| Priority scheduling     | Agent-wide `a3s-lane` priority/FIFO admission across sessions, direct tools, detached background children, and host workflows, with cancellation, starvation-safe aging, digest-only owner/provider quotas, quota-only leaf reservations, occupancy snapshots, and bounded cumulative health counters | Baseline; tune `task_scheduler`, select per-session `TaskPriority`, inspect `task_scheduler_stats()` or `task_scheduler_health()`; Rust hosts can use `TaskSchedulerQuota` for a scoped limit |
 | Safe-point run control  | Typed, idempotent `steer` and cooperative `interrupt` requests with immutable Run identity, optimistic turn guards, bounded receipts, lifecycle Hooks, and durable event evidence                                                                 | Host invokes the Session control surface; requests never create a concurrent transcript operation and never change model, permissions, sandbox, or budget                    |
 | Programmable workflows  | Bounded QuickJS `program` calls, replayable A3S Flow-backed dynamic workflows, resumable step checkpoints, and digest-bound result receipts                                                                                              | `program` baseline; dynamic runtime explicitly registered                                                                                                                 |
 | Persistence             | Atomic snapshots, run events, traces, artifacts, verification, identity-bound workflow/Flow receipts, checkpoints, and optional RL trajectories                                                                                         | Configured store and host policy                                                                                                                                          |
@@ -316,6 +322,17 @@ digest-only `run:<run_id>` (or `session:<session_id>` for low-level hosts)
 scope, so nested fan-out never reacquires the parent's single global lease.
 Quota snapshots are live projections; idle owner entries are pruned and global
 health counters remain the cumulative diagnostic surface.
+
+Provider adapters can additionally expose a `ModelGenerationPool`. Its identity
+is derived from non-secret provider/model routing facts (and an optional
+non-secret account scope), while endpoint credentials, paths, queries, prompts,
+and outputs are never retained. Session construction projects that identity into
+the same scheduler as a quota-only leaf reservation. Consequently, a normal
+session or child run still owns its one global orchestration lease, while each
+actual blocking or streaming generation waits in the shared priority queue for
+the provider pool. Structured-output repairs release the first permit before
+the next call, so a single-flight provider cannot deadlock itself; a dropped
+stream releases its permit through the supervised proxy task.
 
 `Agent::new` accepts an ACL path or inline ACL. Build sessions asynchronously
 so configuration, stores, queues, MCP sources, and workspace services are
@@ -1080,7 +1097,9 @@ credentials, refresh, and live session-scoped add/remove operations.
 
 Dynamic workflows can bound independently session-forked structured generation
 with `maxConcurrentGenerations` (1-4); providers without session forking remain
-single-flight. Flow step bodies also accept `maxConcurrentSteps` (1-32,
+single-flight. When the session exposes a `ModelGenerationPool`, that local
+bound is intersected with the provider pool in the shared scheduler, so a
+workflow cannot bypass capacity by forking clients. Flow step bodies also accept `maxConcurrentSteps` (1-32,
 default 4); waiting is cancellation-aware and starts the sandbox timeout only
 after admission. Every step has a digest-only identity derived from its run,
 step, handler, and bounded input. Durable completed-step recovery is bound to
@@ -1315,6 +1334,14 @@ Core owns lifecycle, ordering, and execution contracts. Public extension
 boundaries include `LlmClient`, `ContextProvider`, `MemoryStore`,
 `SessionStore`, workspace service traits, tools, permissions, confirmations,
 hooks, security, MCP transports, and graph stores.
+
+Model capacity is a resource boundary within that same execution contract. A
+session's orchestration admission consumes one global scheduler slot; each
+provider call acquires a quota-only reservation for its typed
+`ModelGenerationPool`. Both decisions use the one actor and priority queue,
+which preserves global fairness while allowing nested model calls to make
+progress under a single-slot run. The local semaphore and scheduler lease are
+owned by one RAII permit, including streaming and cancellation paths.
 
 Installable cognitive packages remain owned by A3S Use. Code consumes their
 exact immutable capability generations and projects local Tool, Skill, Agent,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,6 +58,7 @@ runtime mode. The cross-repository implementation plan is tracked in the
 | `WORKFLOW-CONTROL1` | Delivered | A host-facing dynamic-workflow control handle coordinates bounded inspection, trusted history, Flow durable cancellation/terminal transitions, identity-bound worker leases, and cross-process local event-store locking | Independent-process qualification covers busy ownership, killed-worker lease expiry/takeover, cancellation settlement, digest-only projections, and optimistic event-conflict retry; Flow remains the only workflow authority |
 | `WORKFLOW-OBS1` | Delivered | Scheduler and dynamic-workflow control diagnostics expose bounded admission, fairness, lease, and takeover counters without retaining task or workflow payloads | Independent resumed workers prove aging prevents starvation; scheduler wait/occupancy counters and durable claim-takeover counters converge while Flow history and the lease remain authoritative |
 | `WORKFLOW-QUOTA1` | Delivered | The existing scheduler actor enforces typed digest-only owner quotas for standalone Flow steps and detached Task children, propagates run identity through governed Tool contexts, and exposes a live quota projection without adding a queue or store | Mixed-owner progress, quota-blocked priority work, cancellation, identity/limit conflicts, malformed scopes, idle-state pruning, dynamic diagnostics, and detached fan-out qualification pass |
+| `MODEL-ADMISSION1` | Delivered | Provider/model capacity is represented by a typed digest-only `ModelGenerationPool`; regular, streaming, and structured calls reserve that capacity through quota-only admissions in the existing scheduler, with propagation through sessions, direct Tools, delegated children, and dynamic workflows | Cross-session and mixed-provider progress, local-plus-shared quota composition, structured repair without recursive deadlock, stream/cancellation release, endpoint-credential redaction, and the full Core regression suite pass |
 
 Observation precedes mutation: `CAR-02` must provide useful read-only context
 diagnostics before `CAR-03` can reduce any Tool result. The first transform
@@ -427,6 +428,45 @@ malformed and overlong scopes, idle-state pruning, dynamic-workflow diagnostic
 projection, and detached children sharing one run quota before using free
 capacity. No scope text, prompt, Tool payload, or workflow output is retained
 by the scheduler.
+
+### 3.3.8 Provider-aware model-generation admission
+
+Model generation is now a resource boundary rather than an incidental property
+of one `LlmClient` instance. A provider adapter may publish a
+`ModelGenerationPool` whose identity is derived from the provider, model,
+endpoint origin, and optional non-secret account scope. URL credentials,
+paths, queries, fragments, prompts, outputs, and transport headers are never
+retained in that identity. Built-in Anthropic, OpenAI-compatible, Zhipu, and
+Codex clients publish the descriptor; custom clients remain conservative and
+single-flight unless they opt into the typed contract.
+
+Session construction binds the pool descriptor to the existing agent scheduler
+as a second quota dimension. The session's normal Run/Tool admission still
+consumes one global slot, while each actual provider generation acquires a
+quota-only lease from the same actor and priority queue. This preserves one
+queue and one cancellation/release authority, lets independent providers use
+free capacity, and prevents a nested model call from deadlocking when the
+global scheduler is configured with `max_active = 1`. Local client capacity
+and the shared pool capacity are both enforced; a nested workflow gate copies
+the provider binding rather than bypassing it.
+
+The `LlmInvoker` boundary covers blocking, streaming, structured, and
+streaming-structured calls. A streaming lease is owned by its supervised proxy
+until EOF, terminal `Done`, cancellation, or receiver drop. Structured repair
+rounds release each call's lease before the next round, and an outer
+preadmitted permit is transferred to the first call exactly once. Foreground
+delegated children and Flow steps carry the provider quota into their own
+admission; background/global children retain the outer provider reservation
+and use a local gate to avoid recursive acquisition. Queue wait is reported in
+the existing structured-generation metadata without exposing labels or
+payloads.
+
+Qualification covers two sessions sharing one provider pool, independent
+provider progress under a full global budget, atomic multi-quota admission,
+quota-only cancellation and release, managed stream lifetime, nested tighter
+workflow limits, and the complete 3,199-test Core library suite. This slice
+does not add provider rate-limit policy, billing, or a second scheduler;
+Gateway and host policy remain the owners of those concerns.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/agent.rs
+++ b/core/src/agent.rs
@@ -951,6 +951,11 @@ impl SessionCommand for ToolCommand {
 pub(crate) struct AgentLoop {
     llm_client: Arc<dyn LlmClient>,
     model_generation_admission: crate::llm::ModelGenerationAdmission,
+    /// Whether the surrounding session explicitly owns this admission gate.
+    /// Compatibility/standalone loops keep the historical per-facade gate so
+    /// detached maintenance work (for example background memory extraction)
+    /// cannot stall the foreground turn.
+    shared_model_generation_admission: bool,
     tool_executor: Arc<ToolExecutor>,
     tool_context: ToolContext,
     config: AgentConfig,

--- a/core/src/agent/llm_invoker.rs
+++ b/core/src/agent/llm_invoker.rs
@@ -13,12 +13,15 @@ use crate::harness_evidence::{
 };
 use crate::llm::structured::{NativeStructuredSupport, StructuredDirective};
 use crate::llm::{
-    estimate_prompt_tokens, LlmClient, LlmResponse, Message, ModelGenerationConcurrency,
-    StreamEvent, TokenUsage, ToolDefinition,
+    estimate_prompt_tokens, LlmClient, LlmResponse, Message, ModelGenerationAdmission,
+    ModelGenerationConcurrency, ModelGenerationPermit, ModelGenerationPool, StreamEvent,
+    TokenUsage, ToolDefinition,
 };
+use anyhow::Context;
 use async_trait::async_trait;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -29,6 +32,9 @@ struct LlmInvoker {
     inner: Arc<dyn LlmClient>,
     invocation: InvocationContext,
     presentation_application: ModelPresentationApplicationV1,
+    model_generation_admission: ModelGenerationAdmission,
+    preadmitted_permit: Arc<Mutex<Option<Arc<ModelGenerationPermit>>>>,
+    queue_wait_micros: Arc<AtomicU64>,
 }
 
 /// The non-streaming model-call shapes handled by the middleware boundary.
@@ -290,20 +296,107 @@ fn model_request_identity(
 }
 
 impl LlmInvoker {
+    #[cfg(test)]
     fn new(inner: Arc<dyn LlmClient>, invocation: InvocationContext) -> Self {
+        let admission = ModelGenerationAdmission::new(inner.model_generation_concurrency());
+        Self::new_with_admission(inner, invocation, admission)
+    }
+
+    fn new_with_admission(
+        inner: Arc<dyn LlmClient>,
+        invocation: InvocationContext,
+        model_generation_admission: ModelGenerationAdmission,
+    ) -> Self {
         Self {
             inner,
             invocation,
             presentation_application: ModelPresentationApplicationV1::Auxiliary,
+            model_generation_admission,
+            preadmitted_permit: Arc::new(Mutex::new(None)),
+            queue_wait_micros: Arc::new(AtomicU64::new(0)),
         }
     }
 
-    fn profiled(inner: Arc<dyn LlmClient>, invocation: InvocationContext) -> Self {
+    fn profiled_with_admission(
+        inner: Arc<dyn LlmClient>,
+        invocation: InvocationContext,
+        model_generation_admission: ModelGenerationAdmission,
+    ) -> Self {
         Self {
             inner,
             invocation,
             presentation_application: ModelPresentationApplicationV1::Profiled,
+            model_generation_admission,
+            preadmitted_permit: Arc::new(Mutex::new(None)),
+            queue_wait_micros: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    fn with_preadmitted_permit(self, permit: Option<Arc<ModelGenerationPermit>>) -> Self {
+        if let Some(permit) = permit {
+            *self
+                .preadmitted_permit
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(permit);
+        }
+        self
+    }
+
+    fn with_inner_preserving_state(&self, inner: Arc<dyn LlmClient>) -> Self {
+        Self {
+            inner,
+            invocation: self.invocation.clone(),
+            presentation_application: self.presentation_application,
+            model_generation_admission: self.model_generation_admission.clone(),
+            preadmitted_permit: Arc::clone(&self.preadmitted_permit),
+            queue_wait_micros: Arc::clone(&self.queue_wait_micros),
+        }
+    }
+
+    fn rebound(
+        &self,
+        admission: ModelGenerationAdmission,
+        preadmitted: Option<Arc<ModelGenerationPermit>>,
+    ) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            invocation: self.invocation.clone(),
+            presentation_application: self.presentation_application,
+            model_generation_admission: admission,
+            preadmitted_permit: Arc::new(Mutex::new(preadmitted)),
+            queue_wait_micros: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    async fn acquire_model_generation(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> anyhow::Result<Arc<ModelGenerationPermit>> {
+        let preadmitted = self
+            .preadmitted_permit
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let permit = match preadmitted {
+            Some(permit) => permit,
+            None => Arc::new(
+                self.model_generation_admission
+                    .acquire(cancellation)
+                    .await
+                    .map_err(|error| anyhow::anyhow!(error))?,
+            ),
+        };
+        let queue_wait = permit.queue_wait().as_micros().min(u128::from(u64::MAX)) as u64;
+        self.queue_wait_micros
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                Some(value.saturating_add(queue_wait))
+            })
+            .ok();
+        Ok(permit)
+    }
+
+    fn take_queue_wait(&self) -> Duration {
+        Duration::from_micros(self.queue_wait_micros.swap(0, Ordering::Relaxed))
     }
 
     async fn invoke_response<F>(
@@ -323,6 +416,10 @@ impl LlmInvoker {
         )
         .await?;
         let usage_binding = self.record_model_evidence(observation).await?;
+        let _generation_permit = self
+            .acquire_model_generation(self.invocation.cancellation())
+            .await
+            .context("model-generation admission failed")?;
 
         let response = tokio::select! {
             biased;
@@ -406,7 +503,24 @@ impl LlmInvoker {
         .await?;
         let usage_binding = self.record_model_evidence(observation).await?;
 
+        // A streaming permit must live as long as the returned receiver, not
+        // merely until the provider returns that receiver. This keeps active
+        // capacity truthful while tokens are still being consumed and makes
+        // dropping the receiver the normal release path.
         let caller_signal = caller_cancellation.clone();
+        let generation_permit = tokio::select! {
+            biased;
+            _ = self.invocation.cancellation().cancelled() => {
+                return Err(anyhow::anyhow!("Operation cancelled by user"));
+            }
+            _ = caller_signal.cancelled() => {
+                return Err(anyhow::anyhow!("Operation cancelled by caller"));
+            }
+            permit = self.acquire_model_generation(self.invocation.cancellation()) => {
+                permit.context("model-generation admission failed")?
+            }
+        };
+
         let (provider_cancellation, cancellation_watcher) =
             self.combine_cancellation(caller_cancellation);
         let setup = setup(provider_cancellation.clone());
@@ -434,6 +548,7 @@ impl LlmInvoker {
             provider_cancellation,
             cancellation_watcher,
             usage_binding,
+            generation_permit,
         ))
     }
 
@@ -502,6 +617,7 @@ impl LlmInvoker {
         provider_cancellation: CancellationToken,
         cancellation_watcher: JoinHandle<()>,
         usage_binding: Option<ModelUsageBinding>,
+        _generation_permit: Arc<ModelGenerationPermit>,
     ) -> mpsc::Receiver<StreamEvent> {
         let (tx, rx) = mpsc::channel(64);
         let budget_guard = self.invocation.governance().budget_guard().cloned();
@@ -509,6 +625,10 @@ impl LlmInvoker {
         let invocation = self.invocation.clone();
 
         tokio::spawn(async move {
+            // Keep the admission lease attached to the proxy task until the
+            // provider stream reaches EOF, Done, cancellation, or the caller
+            // drops the receiver.
+            let _generation_permit = _generation_permit;
             loop {
                 let event = tokio::select! {
                     biased;
@@ -600,26 +720,42 @@ impl LlmClient for LlmInvoker {
         self.inner.model_generation_concurrency()
     }
 
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        self.inner.model_generation_pool()
+    }
+
+    fn bind_model_generation_admission(
+        &self,
+        admission: ModelGenerationAdmission,
+        preadmitted: Option<Arc<ModelGenerationPermit>>,
+    ) -> Option<Arc<dyn LlmClient>> {
+        Some(Arc::new(self.rebound(admission, preadmitted)))
+    }
+
+    fn model_generation_is_managed(&self) -> bool {
+        true
+    }
+
+    fn take_model_generation_queue_wait(&self) -> Duration {
+        self.take_queue_wait()
+    }
+
     fn fork_for_session(&self, session_id: &str) -> Option<Arc<dyn LlmClient>> {
         self.inner.fork_for_session(session_id).map(|inner| {
-            Arc::new(Self {
+            let mut scoped = Self::new_with_admission(
                 inner,
-                invocation: self.invocation.clone(),
-                presentation_application: self.presentation_application,
-            }) as Arc<dyn LlmClient>
+                self.invocation.clone(),
+                self.model_generation_admission.clone(),
+            );
+            scoped.presentation_application = self.presentation_application;
+            Arc::new(scoped) as Arc<dyn LlmClient>
         })
     }
 
     fn with_active_generation_timeout(&self, timeout: Duration) -> Option<Arc<dyn LlmClient>> {
         self.inner
             .with_active_generation_timeout(timeout)
-            .map(|inner| {
-                Arc::new(Self {
-                    inner,
-                    invocation: self.invocation.clone(),
-                    presentation_application: self.presentation_application,
-                }) as Arc<dyn LlmClient>
-            })
+            .map(|inner| Arc::new(self.with_inner_preserving_state(inner)) as Arc<dyn LlmClient>)
     }
 
     async fn complete(
@@ -689,11 +825,29 @@ impl LlmClient for LlmInvoker {
 }
 
 impl AgentLoop {
+    /// Select the admission scope for a provider facade. Session builders
+    /// explicitly install a shared gate so sibling facades participate in the
+    /// same provider pool; compatibility loops retain one gate per facade,
+    /// matching their historical detached-helper behavior.
+    pub(crate) fn model_generation_admission_for_client(
+        &self,
+        client: Option<&Arc<dyn LlmClient>>,
+    ) -> ModelGenerationAdmission {
+        if self.shared_model_generation_admission {
+            return self.model_generation_admission.clone();
+        }
+        let concurrency = client
+            .map(|client| client.model_generation_concurrency())
+            .unwrap_or_else(|| self.llm_client.model_generation_concurrency());
+        ModelGenerationAdmission::new(concurrency)
+    }
+
     pub(super) fn scoped_llm_client(&self, invocation: &InvocationContext) -> Arc<dyn LlmClient> {
         let provider_client = self
             .llm_client
             .fork_for_session(invocation.session_id())
             .unwrap_or_else(|| Arc::clone(&self.llm_client));
+        let admission = self.model_generation_admission_for_client(Some(&provider_client));
         let provider_client = self
             .config
             .llm_api_timeout_ms
@@ -701,7 +855,84 @@ impl AgentLoop {
                 provider_client.with_active_generation_timeout(Duration::from_millis(timeout_ms))
             })
             .unwrap_or(provider_client);
-        Arc::new(LlmInvoker::new(provider_client, invocation.clone()))
+        Arc::new(LlmInvoker::new_with_admission(
+            provider_client,
+            invocation.clone(),
+            admission,
+        ))
+    }
+
+    /// Build the governed provider facade for a tool context that may carry a
+    /// tighter generation gate and/or one already-acquired permit.
+    ///
+    /// Dynamic workflow steps use this path to replace the session admission
+    /// with their per-step bound while retaining the exact provider transport
+    /// (including account/session forking). A managed facade is rebound rather
+    /// than wrapped recursively; recursive facades would reserve the same
+    /// single-flight capacity twice.
+    pub(crate) fn scoped_llm_client_for_tool_context(
+        &self,
+        session_id: Option<&str>,
+        event_tx: &Option<mpsc::Sender<AgentEvent>>,
+        cancel_token: &CancellationToken,
+        admission: ModelGenerationAdmission,
+        preadmitted: Option<Arc<ModelGenerationPermit>>,
+        existing_client: Option<Arc<dyn LlmClient>>,
+    ) -> Arc<dyn LlmClient> {
+        let invocation = if let Some(invocation) = self
+            .bound_invocation
+            .as_ref()
+            .filter(|invocation| invocation.matches_parts(session_id, event_tx))
+        {
+            invocation.clone()
+        } else {
+            let run_id = self.bound_invocation.as_ref().map_or_else(
+                || {
+                    self.checkpoint_run_id
+                        .clone()
+                        .unwrap_or_else(|| format!("standalone-{}", uuid::Uuid::new_v4()))
+                },
+                |bound| format!("{}-aux-{}", bound.run_id(), uuid::Uuid::new_v4()),
+            );
+            self.invocation_context(run_id, session_id, event_tx.clone(), cancel_token.clone())
+        };
+
+        let provider_client = existing_client.unwrap_or_else(|| {
+            self.llm_client
+                .fork_for_session(session_id.unwrap_or(""))
+                .unwrap_or_else(|| Arc::clone(&self.llm_client))
+        });
+
+        if provider_client.model_generation_is_managed() {
+            if let Some(rebound) =
+                provider_client.bind_model_generation_admission(admission, preadmitted)
+            {
+                return self
+                    .config
+                    .llm_api_timeout_ms
+                    .and_then(|timeout_ms| {
+                        rebound.with_active_generation_timeout(Duration::from_millis(timeout_ms))
+                    })
+                    .unwrap_or(rebound);
+            }
+            // The marker and rebinding hook are one contract for governed
+            // facades. Keep the existing client if a third-party facade only
+            // implements the marker; wrapping it would create nested gates.
+            tracing::warn!("managed LLM client did not provide a model-generation rebinding hook");
+            return provider_client;
+        }
+
+        let provider_client = self
+            .config
+            .llm_api_timeout_ms
+            .and_then(|timeout_ms| {
+                provider_client.with_active_generation_timeout(Duration::from_millis(timeout_ms))
+            })
+            .unwrap_or(provider_client);
+        Arc::new(
+            LlmInvoker::new_with_admission(provider_client, invocation, admission)
+                .with_preadmitted_permit(preadmitted),
+        )
     }
 
     fn scoped_profiled_llm_client(&self, invocation: &InvocationContext) -> Arc<dyn LlmClient> {
@@ -709,6 +940,7 @@ impl AgentLoop {
             .llm_client
             .fork_for_session(invocation.session_id())
             .unwrap_or_else(|| Arc::clone(&self.llm_client));
+        let admission = self.model_generation_admission_for_client(Some(&provider_client));
         let provider_client = self
             .config
             .llm_api_timeout_ms
@@ -716,7 +948,11 @@ impl AgentLoop {
                 provider_client.with_active_generation_timeout(Duration::from_millis(timeout_ms))
             })
             .unwrap_or(provider_client);
-        Arc::new(LlmInvoker::profiled(provider_client, invocation.clone()))
+        Arc::new(LlmInvoker::profiled_with_admission(
+            provider_client,
+            invocation.clone(),
+            admission,
+        ))
     }
 
     /// Compatibility helper for internal paths not yet carrying the aggregate

--- a/core/src/agent/llm_invoker/tests.rs
+++ b/core/src/agent/llm_invoker/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::agent::invocation_context::InvocationGovernance;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 struct PendingStreamingClient {
@@ -11,6 +12,14 @@ struct CompletedStreamingClient;
 
 struct UsageRecordedGuard {
     recorded: Arc<tokio::sync::Notify>,
+}
+
+#[derive(Clone)]
+struct BlockingConcurrencyClient {
+    active: Arc<AtomicUsize>,
+    max_active: Arc<AtomicUsize>,
+    started: tokio::sync::mpsc::UnboundedSender<()>,
+    release: Arc<tokio::sync::Semaphore>,
 }
 
 #[test]
@@ -258,6 +267,226 @@ impl LlmClient for CompletedStreamingClient {
         .unwrap();
         Ok(rx)
     }
+}
+
+#[async_trait]
+impl LlmClient for BlockingConcurrencyClient {
+    async fn complete(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+    ) -> anyhow::Result<LlmResponse> {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        self.started.send(()).unwrap();
+        self.release.acquire().await.unwrap().forget();
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        Ok(LlmResponse {
+            message: Message::assistant("ok"),
+            usage: TokenUsage::default(),
+            stop_reason: Some("stop".to_string()),
+            token_logprobs: Vec::new(),
+            meta: None,
+        })
+    }
+
+    async fn complete_streaming(
+        &self,
+        _messages: &[Message],
+        _system: Option<&str>,
+        _tools: &[ToolDefinition],
+        _cancel_token: CancellationToken,
+    ) -> anyhow::Result<mpsc::Receiver<StreamEvent>> {
+        anyhow::bail!("streaming is not used by this test")
+    }
+}
+
+#[tokio::test]
+async fn independent_invokers_share_scheduler_backed_provider_capacity() {
+    let scheduler = Arc::new(
+        crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+            max_active: 1,
+            aging_interval_ms: 1_000,
+        })
+        .unwrap(),
+    );
+    let pool = ModelGenerationPool::for_endpoint(
+        "test-provider",
+        "test-model",
+        "https://provider.test",
+        ModelGenerationConcurrency::single_flight(),
+    )
+    .unwrap();
+    let quota = crate::task_scheduler::TaskSchedulerQuota::new(
+        pool.identity.clone(),
+        pool.max_concurrency().get(),
+    )
+    .unwrap();
+    let admission = |label: &'static str| {
+        ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+            .with_scheduler_quota(
+                Arc::clone(&scheduler),
+                quota.clone(),
+                crate::task_scheduler::TaskPriority::Foreground,
+                label,
+            )
+            .unwrap()
+    };
+    let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let active = Arc::new(AtomicUsize::new(0));
+    let max_active = Arc::new(AtomicUsize::new(0));
+    let client: Arc<dyn LlmClient> = Arc::new(BlockingConcurrencyClient {
+        active,
+        max_active: Arc::clone(&max_active),
+        started: started_tx,
+        release: Arc::clone(&release),
+    });
+    let first_invocation = InvocationContext::new(
+        Arc::<str>::from("provider-run-a"),
+        Arc::<str>::from("provider-session-a"),
+        CancellationToken::new(),
+        None,
+        InvocationGovernance::default(),
+    );
+    let second_invocation = InvocationContext::new(
+        Arc::<str>::from("provider-run-b"),
+        Arc::<str>::from("provider-session-b"),
+        CancellationToken::new(),
+        None,
+        InvocationGovernance::default(),
+    );
+    let first = Arc::new(LlmInvoker::new_with_admission(
+        Arc::clone(&client),
+        first_invocation,
+        admission("provider-a"),
+    ));
+    let second = Arc::new(LlmInvoker::new_with_admission(
+        Arc::clone(&client),
+        second_invocation,
+        admission("provider-b"),
+    ));
+
+    let first_call =
+        tokio::spawn(async move { first.complete(&[Message::user("first")], None, &[]).await });
+    started_rx.recv().await.unwrap();
+    let second_call =
+        tokio::spawn(async move { second.complete(&[Message::user("second")], None, &[]).await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), started_rx.recv())
+            .await
+            .is_err(),
+        "the second provider call must remain queued"
+    );
+    release.add_permits(1);
+    started_rx.recv().await.unwrap();
+    release.add_permits(1);
+    first_call.await.unwrap().unwrap();
+    second_call.await.unwrap().unwrap();
+
+    assert_eq!(max_active.load(Ordering::SeqCst), 1);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn streaming_provider_capacity_is_held_until_receiver_drop() {
+    let scheduler = Arc::new(
+        crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+            max_active: 1,
+            aging_interval_ms: 1_000,
+        })
+        .unwrap(),
+    );
+    let pool = ModelGenerationPool::for_endpoint(
+        "stream-provider",
+        "stream-model",
+        "https://provider.test",
+        ModelGenerationConcurrency::single_flight(),
+    )
+    .unwrap();
+    let quota = crate::task_scheduler::TaskSchedulerQuota::new(
+        pool.identity.clone(),
+        pool.max_concurrency().get(),
+    )
+    .unwrap();
+    let admission = || {
+        ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+            .with_scheduler_quota(
+                Arc::clone(&scheduler),
+                quota.clone(),
+                crate::task_scheduler::TaskPriority::Foreground,
+                "stream-generation",
+            )
+            .unwrap()
+    };
+    let provider_cancelled = Arc::new(tokio::sync::Notify::new());
+    let client: Arc<dyn LlmClient> = Arc::new(PendingStreamingClient {
+        provider_cancelled: Arc::clone(&provider_cancelled),
+    });
+    let first_invoker = Arc::new(LlmInvoker::new_with_admission(
+        Arc::clone(&client),
+        InvocationContext::new(
+            Arc::<str>::from("stream-run-a"),
+            Arc::<str>::from("stream-session-a"),
+            CancellationToken::new(),
+            None,
+            InvocationGovernance::default(),
+        ),
+        admission(),
+    ));
+    let second_invoker = Arc::new(LlmInvoker::new_with_admission(
+        Arc::clone(&client),
+        InvocationContext::new(
+            Arc::<str>::from("stream-run-b"),
+            Arc::<str>::from("stream-session-b"),
+            CancellationToken::new(),
+            None,
+            InvocationGovernance::default(),
+        ),
+        admission(),
+    ));
+
+    let first = first_invoker
+        .complete_streaming(
+            &[Message::user("first")],
+            None,
+            &[],
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let second_call = tokio::spawn(async move {
+        second_invoker
+            .complete_streaming(
+                &[Message::user("second")],
+                None,
+                &[],
+                CancellationToken::new(),
+            )
+            .await
+    });
+    for _ in 0..100 {
+        let snapshot = scheduler.quota_snapshot(&quota).await.unwrap();
+        if snapshot.pending == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(scheduler.quota_snapshot(&quota).await.unwrap().active, 1);
+    assert_eq!(scheduler.quota_snapshot(&quota).await.unwrap().pending, 1);
+
+    drop(first);
+    tokio::time::timeout(Duration::from_millis(100), provider_cancelled.notified())
+        .await
+        .expect("dropping the first stream must cancel its provider");
+    let second = tokio::time::timeout(Duration::from_millis(200), second_call)
+        .await
+        .expect("the second stream should acquire after receiver drop")
+        .unwrap()
+        .unwrap();
+    drop(second);
+    scheduler.shutdown().await;
 }
 
 #[tokio::test]

--- a/core/src/agent/loop_builder.rs
+++ b/core/src/agent/loop_builder.rs
@@ -17,6 +17,7 @@ impl AgentLoop {
         Self {
             llm_client,
             model_generation_admission,
+            shared_model_generation_admission: false,
             tool_executor,
             tool_context,
             config,
@@ -40,6 +41,7 @@ impl AgentLoop {
         admission: ModelGenerationAdmission,
     ) -> Self {
         self.model_generation_admission = admission;
+        self.shared_model_generation_admission = true;
         self
     }
 

--- a/core/src/agent/tool_invoker.rs
+++ b/core/src/agent/tool_invoker.rs
@@ -279,28 +279,23 @@ impl ScopedToolInvoker {
             .ok();
         }
 
-        let preadmitted = ctx.has_model_generation_permit();
-        let llm_client = if preadmitted {
-            ctx.llm_client().unwrap_or_else(|| {
-                self.agent.scoped_llm_client_for_parts(
-                    (!self.session_id.is_empty()).then_some(self.session_id.as_str()),
-                    &self.event_tx,
-                    &ctx.cancellation_token(),
-                )
-            })
-        } else {
-            self.agent.scoped_llm_client_for_parts(
-                (!self.session_id.is_empty()).then_some(self.session_id.as_str()),
-                &self.event_tx,
-                &ctx.cancellation_token(),
-            )
-        };
-        let model_generation_admission = if preadmitted {
-            ctx.model_generation_admission()
-                .unwrap_or_else(|| self.agent.model_generation_admission.clone())
-        } else {
-            self.agent.model_generation_admission.clone()
-        };
+        let existing_llm_client = ctx.llm_client();
+        let model_generation_admission = ctx.model_generation_admission().unwrap_or_else(|| {
+            self.agent
+                .model_generation_admission_for_client(existing_llm_client.as_ref())
+        });
+        // Claim an outer permit before constructing the provider facade. The
+        // facade consumes it for the first underlying generation, then
+        // releases it before any structured repair call can acquire again.
+        let preadmitted = ctx.model_generation_permit(&model_generation_admission);
+        let llm_client = self.agent.scoped_llm_client_for_tool_context(
+            (!self.session_id.is_empty()).then_some(self.session_id.as_str()),
+            &self.event_tx,
+            &ctx.cancellation_token(),
+            model_generation_admission.clone(),
+            preadmitted,
+            existing_llm_client,
+        );
         let governed_ctx = ctx
             .clone()
             .with_llm_client(llm_client)

--- a/core/src/agent_api/direct_tools.rs
+++ b/core/src/agent_api/direct_tools.rs
@@ -32,6 +32,7 @@ pub(super) struct DirectToolRuntime {
     closed: Arc<AtomicBool>,
     task_scheduler: Option<Arc<crate::task_scheduler::TaskScheduler>>,
     task_priority: crate::task_scheduler::TaskPriority,
+    provider_quota: Option<crate::task_scheduler::TaskSchedulerQuota>,
     security_provider: Option<Arc<dyn crate::security::SecurityProvider>>,
 }
 
@@ -46,6 +47,20 @@ impl DirectToolRuntime {
             closed: Arc::clone(&session.closed),
             task_scheduler: Some(Arc::clone(&session.task_scheduler)),
             task_priority: session.task_priority,
+            // Session-owned model-generation permits already reserve this
+            // provider quota through the shared scheduler. Avoid holding the
+            // same dimension across the whole host-tool call, which would
+            // recursively block a nested `generate_object` invocation.
+            provider_quota: (!session.model_generation_admission.has_scheduler_quota())
+                .then(|| session.llm_client.model_generation_pool())
+                .flatten()
+                .and_then(|pool| {
+                    crate::task_scheduler::TaskSchedulerQuota::new(
+                        pool.identity.clone(),
+                        pool.max_concurrency().get(),
+                    )
+                    .ok()
+                }),
             security_provider: session.config.security_provider.clone(),
         }
     }
@@ -155,10 +170,12 @@ impl DirectToolRuntime {
     async fn call_invocation(&self, invocation: ToolInvocation) -> Result<ToolCallResult> {
         self.ensure_open()?;
         let cancel = self.session_cancel.child_token();
-        let _task_lease = ExecutionCoordinator::acquire_optional_task(
+        let quotas = self.provider_quota.as_slice();
+        let _task_lease = ExecutionCoordinator::acquire_optional_task_with_quotas(
             self.task_scheduler.as_deref(),
             self.task_priority,
             format!("{}:tool:{}", self.session_id, invocation.name),
+            quotas,
             &self.session_id,
             &cancel,
             &self.closed,
@@ -389,6 +406,7 @@ mod tests {
             closed: Arc::new(AtomicBool::new(false)),
             task_scheduler: None,
             task_priority: crate::task_scheduler::TaskPriority::Interactive,
+            provider_quota: None,
             security_provider,
         }
     }
@@ -914,6 +932,7 @@ mod tests {
             closed: Arc::new(AtomicBool::new(false)),
             task_scheduler: None,
             task_priority: crate::task_scheduler::TaskPriority::Interactive,
+            provider_quota: None,
             security_provider: None,
         };
 

--- a/core/src/agent_api/direct_tools/event_stream.rs
+++ b/core/src/agent_api/direct_tools/event_stream.rs
@@ -107,6 +107,7 @@ impl DirectToolRuntime {
         let cancel = self.session_cancel.child_token();
         let task_scheduler = self.task_scheduler;
         let task_priority = self.task_priority;
+        let provider_quota = self.provider_quota;
         let closed = self.closed;
         let mut ctx = self.tool_context;
         ctx.agent_event_tx = Some(broadcast_tx);
@@ -116,10 +117,12 @@ impl DirectToolRuntime {
         let event_tx = Some(runtime_tx);
         let security_provider = self.security_provider;
         let handle = tokio::spawn(async move {
-            let _task_lease = ExecutionCoordinator::acquire_optional_task(
+            let quotas = provider_quota.as_slice();
+            let _task_lease = ExecutionCoordinator::acquire_optional_task_with_quotas(
                 task_scheduler.as_deref(),
                 task_priority,
                 format!("{session_id}:tool:{tool_name}"),
+                quotas,
                 &session_id,
                 &cancel,
                 &closed,

--- a/core/src/agent_api/direct_tools/governed_tests.rs
+++ b/core/src/agent_api/direct_tools/governed_tests.rs
@@ -109,6 +109,7 @@ fn runtime(
             closed: Arc::new(AtomicBool::new(false)),
             task_scheduler: None,
             task_priority: crate::task_scheduler::TaskPriority::Interactive,
+            provider_quota: None,
             security_provider: None,
         },
         calls,

--- a/core/src/agent_api/execution_coordinator.rs
+++ b/core/src/agent_api/execution_coordinator.rs
@@ -51,8 +51,31 @@ impl ExecutionCoordinator {
         cancellation: &CancellationToken,
         closed: &AtomicBool,
     ) -> Result<crate::task_scheduler::TaskLease> {
+        Self::acquire_task_with_quotas(
+            scheduler,
+            priority,
+            label,
+            &[],
+            session_id,
+            cancellation,
+            closed,
+        )
+        .await
+    }
+
+    /// Acquire a scheduler lease while atomically applying all supplied quota
+    /// dimensions. The empty slice preserves the legacy unconstrained path.
+    pub(super) async fn acquire_task_with_quotas(
+        scheduler: &crate::task_scheduler::TaskScheduler,
+        priority: crate::task_scheduler::TaskPriority,
+        label: String,
+        quotas: &[crate::task_scheduler::TaskSchedulerQuota],
+        session_id: &str,
+        cancellation: &CancellationToken,
+        closed: &AtomicBool,
+    ) -> Result<crate::task_scheduler::TaskLease> {
         scheduler
-            .acquire(priority, label, cancellation)
+            .acquire_with_quotas(priority, label, quotas, None, cancellation)
             .await
             .map_err(|error| match error {
                 crate::task_scheduler::TaskSchedulerError::Cancelled
@@ -74,23 +97,28 @@ impl ExecutionCoordinator {
             })
     }
 
-    /// Acquire an optional scheduler lease for control-plane operations that
-    /// may be constructed without a Session-owned scheduler (for example,
-    /// low-level direct-tool tests).
-    pub(super) async fn acquire_optional_task(
+    /// Optional-scheduler counterpart of [`Self::acquire_task_with_quotas`].
+    pub(super) async fn acquire_optional_task_with_quotas(
         scheduler: Option<&crate::task_scheduler::TaskScheduler>,
         priority: crate::task_scheduler::TaskPriority,
         label: String,
+        quotas: &[crate::task_scheduler::TaskSchedulerQuota],
         session_id: &str,
         cancellation: &CancellationToken,
         closed: &AtomicBool,
     ) -> Result<Option<crate::task_scheduler::TaskLease>> {
         match scheduler {
-            Some(scheduler) => {
-                Self::acquire_task(scheduler, priority, label, session_id, cancellation, closed)
-                    .await
-                    .map(Some)
-            }
+            Some(scheduler) => Self::acquire_task_with_quotas(
+                scheduler,
+                priority,
+                label,
+                quotas,
+                session_id,
+                cancellation,
+                closed,
+            )
+            .await
+            .map(Some),
             None => Ok(None),
         }
     }

--- a/core/src/agent_api/session_builder.rs
+++ b/core/src/agent_api/session_builder.rs
@@ -198,6 +198,23 @@ fn finish_agent_session(
     let llm_client = Arc::clone(&resolved.llm_client);
     let model_generation_admission =
         crate::llm::ModelGenerationAdmission::new(llm_client.model_generation_concurrency());
+    let model_generation_admission = if let Some(pool) = llm_client.model_generation_pool() {
+        let quota = crate::task_scheduler::TaskSchedulerQuota::new(
+            pool.identity.clone(),
+            pool.max_concurrency().get(),
+        )
+        .map_err(|error| crate::error::CodeError::Config(error.to_string()))?;
+        model_generation_admission
+            .with_scheduler_quota(
+                Arc::clone(&agent.task_scheduler),
+                quota,
+                opts.task_priority,
+                format!("model-generation:{}", resolved.session_id),
+            )
+            .map_err(|error| crate::error::CodeError::Config(error.to_string()))?
+    } else {
+        model_generation_admission
+    };
     let tool_executor = capabilities.tool_executor;
     let trace_sink = capabilities.trace_sink;
     let agent_registry = capabilities.agent_registry;

--- a/core/src/agent_api/tests.rs
+++ b/core/src/agent_api/tests.rs
@@ -680,6 +680,16 @@ impl LlmClient for NonRetryableStreamingClient {
 
 #[async_trait::async_trait]
 impl LlmClient for SessionAdmissionClient {
+    fn model_generation_pool(&self) -> Option<crate::llm::ModelGenerationPool> {
+        crate::llm::ModelGenerationPool::for_endpoint(
+            "test-provider",
+            "test-model",
+            "https://provider.test",
+            crate::llm::ModelGenerationConcurrency::single_flight(),
+        )
+        .ok()
+    }
+
     async fn complete(
         &self,
         _messages: &[Message],
@@ -1155,6 +1165,57 @@ async fn concurrent_session_direct_generations_share_provider_admission() {
         queue_waits[1] >= 80,
         "the second direct generation should wait for session capacity: {queue_waits:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn independent_sessions_share_scheduler_backed_provider_generation_capacity() {
+    let dir = tempfile::tempdir().unwrap();
+    let client = Arc::new(SessionAdmissionClient::default());
+    let agent = Agent::from_config(test_config()).await.unwrap();
+    let options = |id: &str| {
+        SessionOptions::new()
+            .with_session_id(id)
+            .with_llm_client(client.clone())
+            .with_planning_mode(crate::prompts::PlanningMode::Disabled)
+            .with_continuation(false)
+    };
+    let first = Arc::new(
+        agent
+            .session_async(dir.path().to_string_lossy(), Some(options("provider-a")))
+            .await
+            .unwrap(),
+    );
+    let second = Arc::new(
+        agent
+            .session_async(dir.path().to_string_lossy(), Some(options("provider-b")))
+            .await
+            .unwrap(),
+    );
+    let args = serde_json::json!({
+        "schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {"ok": {"type": "boolean"}},
+            "required": ["ok"]
+        },
+        "schema_name": "shared_provider",
+        "prompt": "Return an object whose ok field is true.",
+        "mode": "prompt",
+        "max_repair_attempts": 0,
+        "timeout_ms": 2_000
+    });
+    let (first_result, second_result) = tokio::join!(
+        first.tool("generate_object", args.clone()),
+        second.tool("generate_object", args)
+    );
+    assert!(first_result.unwrap().exit_code == 0);
+    assert!(second_result.unwrap().exit_code == 0);
+    assert_eq!(
+        client.max_active.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "sessions sharing one provider pool must not exceed its capacity"
+    );
+    agent.close().await;
 }
 
 #[tokio::test]

--- a/core/src/dynamic_workflow.rs
+++ b/core/src/dynamic_workflow.rs
@@ -70,6 +70,27 @@ fn dynamic_workflow_scheduler_quota_limit(limits: &DynamicWorkflowScriptLimits) 
         .clamp(1, MAX_MAX_CONCURRENT_STEPS)
 }
 
+fn provider_quota_for_context(
+    context: &ToolContext,
+) -> Option<crate::task_scheduler::TaskSchedulerQuota> {
+    if context
+        .model_generation_admission()
+        .is_some_and(|admission| admission.has_scheduler_quota())
+    {
+        // The session-owned generation gate already reserves this exact pool
+        // through the shared scheduler. Holding it again on the enclosing Flow
+        // step would make a single-flight provider recursively wait on itself.
+        return None;
+    }
+    let client = context.llm_client()?;
+    let pool = client.model_generation_pool()?;
+    crate::task_scheduler::TaskSchedulerQuota::new(
+        pool.identity.clone(),
+        pool.max_concurrency().get(),
+    )
+    .ok()
+}
+
 /// Runtime build used to pin newly-created dynamic workflow runs.
 ///
 /// Deployments that need a stronger revision identity can provide an explicit
@@ -568,6 +589,9 @@ pub struct DynamicWorkflowRuntime {
     /// Optional owner quota for direct script-backed Flow steps. The quota is
     /// enforced by the same scheduler actor as global capacity.
     scheduler_quota: Option<crate::task_scheduler::TaskSchedulerQuota>,
+    /// Provider/model capacity projected into the same scheduler actor as
+    /// workflow-step admission.
+    provider_quota: Option<crate::task_scheduler::TaskSchedulerQuota>,
     continuation_lease: Option<Arc<DynamicWorkflowLease>>,
 }
 
@@ -577,6 +601,7 @@ impl DynamicWorkflowRuntime {
         context: ToolContext,
         source: impl Into<String>,
     ) -> Self {
+        let provider_quota = provider_quota_for_context(&context);
         let allowed_tools = default_allowed_tools(&registry);
         // Session/agent callers install the governed gateway in ToolContext.
         // The raw registry adapter is retained only for explicit low-level
@@ -595,6 +620,7 @@ impl DynamicWorkflowRuntime {
             task_scheduler: None,
             admit_steps_globally: false,
             scheduler_quota: None,
+            provider_quota,
             continuation_lease: None,
         }
     }
@@ -609,7 +635,24 @@ impl DynamicWorkflowRuntime {
         self.parallel_generation_admission = NonZeroUsize::new(generation_concurrency)
             .filter(|maximum| maximum.get() > 1)
             .map(|maximum| {
-                ModelGenerationAdmission::new(ModelGenerationConcurrency::bounded(maximum))
+                let admission =
+                    ModelGenerationAdmission::new(ModelGenerationConcurrency::bounded(maximum));
+                match self.context.model_generation_admission() {
+                    Some(session_admission) => match admission.clone().with_scheduler_quota_from(
+                        &session_admission,
+                        "dynamic-workflow-model-generation",
+                    ) {
+                        Ok(admission) => admission,
+                        Err(error) => {
+                            tracing::warn!(
+                                %error,
+                                "failed to project session provider quota into dynamic workflow admission"
+                            );
+                            admission
+                        }
+                    },
+                    None => admission,
+                }
             });
         let step_concurrency = limits
             .max_concurrent_steps
@@ -707,28 +750,37 @@ impl DynamicWorkflowRuntime {
                 "flow:{}:{}:{}",
                 invocation.run_id, invocation.step_id, invocation.step_name
             );
-            let task_lease = match self.scheduler_quota.as_ref() {
-                Some(quota) => {
-                    scheduler
-                        .acquire_with_quota(
-                            SchedulerTaskPriority::Foreground,
-                            label,
-                            quota,
-                            Some(identity),
-                            &self.context.cancellation_token(),
-                        )
-                        .await
+            let mut quotas = Vec::with_capacity(2);
+            if let Some(quota) = self.scheduler_quota.as_ref() {
+                quotas.push(quota.clone());
+            }
+            if let Some(quota) = self.provider_quota.as_ref() {
+                if !quotas
+                    .iter()
+                    .any(|candidate| candidate.identity == quota.identity)
+                {
+                    quotas.push(quota.clone());
                 }
-                None => {
-                    scheduler
-                        .acquire_with_identity(
-                            SchedulerTaskPriority::Foreground,
-                            label,
-                            Some(identity),
-                            &self.context.cancellation_token(),
-                        )
-                        .await
-                }
+            }
+            let task_lease = if quotas.is_empty() {
+                scheduler
+                    .acquire_with_identity(
+                        SchedulerTaskPriority::Foreground,
+                        label,
+                        Some(identity),
+                        &self.context.cancellation_token(),
+                    )
+                    .await
+            } else {
+                scheduler
+                    .acquire_with_quotas(
+                        SchedulerTaskPriority::Foreground,
+                        label,
+                        &quotas,
+                        Some(identity),
+                        &self.context.cancellation_token(),
+                    )
+                    .await
             }
             .map_err(|error| a3s_flow::FlowError::Runtime(error.to_string()))?;
             lease = lease.with_task_lease(task_lease);

--- a/core/src/execution_identity.rs
+++ b/core/src/execution_identity.rs
@@ -27,6 +27,13 @@ pub const FLOW_STEP_IDENTITY_DOMAIN_V1: &str = "a3s.code.flow-step.identity.v1";
 /// workflow claims or result identities.
 pub const TASK_ADMISSION_SCOPE_IDENTITY_DOMAIN_V1: &str =
     "a3s.code.task-admission-scope.identity.v1";
+/// Identity domain for a provider/model generation-capacity pool.
+///
+/// Pool identities deliberately bind only non-secret routing facts. API keys,
+/// session tokens, prompts, and request payloads must never influence or
+/// appear in a scheduler capacity key.
+pub const MODEL_GENERATION_POOL_IDENTITY_DOMAIN_V1: &str =
+    "a3s.code.model-generation-pool.identity.v1";
 /// Identity domain for the immutable input portion of a dynamic workflow.
 pub const DYNAMIC_WORKFLOW_INPUT_IDENTITY_DOMAIN_V1: &str =
     "a3s.code.dynamic-workflow.input.identity.v1";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -297,7 +297,7 @@ pub use llm::{
     clear_http_metrics_callback, set_http_metrics_callback, AnthropicClient, Attachment,
     ContentBlock, HttpMetricsCallback, HttpMetricsRecord, ImageSource, LlmClient, LlmResponse,
     Message, ModelGenerationAdmission, ModelGenerationAdmissionError, ModelGenerationConcurrency,
-    ModelGenerationPermit, OpenAiClient, TokenUsage,
+    ModelGenerationPermit, ModelGenerationPool, ModelGenerationPoolError, OpenAiClient, TokenUsage,
 };
 #[cfg(feature = "headless-search")]
 pub use moli_runtime::{
@@ -362,7 +362,8 @@ pub use subagent_task_tracker::{
 pub use task_scheduler::{
     TaskLease, TaskPriority, TaskPriorityCounts, TaskScheduler, TaskSchedulerConfig,
     TaskSchedulerError, TaskSchedulerHealthSnapshot, TaskSchedulerQuota,
-    TaskSchedulerQuotaSnapshot, TaskSchedulerStats, TASK_SCHEDULER_MAX_SCOPE_BYTES,
+    TaskSchedulerQuotaSnapshot, TaskSchedulerStats, TASK_SCHEDULER_MAX_QUOTAS,
+    TASK_SCHEDULER_MAX_SCOPE_BYTES,
 };
 pub use tools::{
     ImmutableContentAdapter, ImmutableContentAdapterBindingV1, ImmutableContentAdapterSession,

--- a/core/src/llm/admission.rs
+++ b/core/src/llm/admission.rs
@@ -9,8 +9,168 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use thiserror::Error;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::CancellationToken;
+
+const MODEL_GENERATION_POOL_MAX_COMPONENT_BYTES: usize = 256;
+
+/// Errors returned while deriving a provider/model capacity pool identity.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ModelGenerationPoolError {
+    #[error("model-generation pool {field} is empty or exceeds {limit} bytes")]
+    InvalidComponent { field: &'static str, limit: usize },
+    #[error("model-generation pool {field} contains a control character")]
+    ControlCharacter { field: &'static str },
+    #[error("model-generation pool endpoint is invalid or has no host")]
+    InvalidEndpoint,
+    #[error("model-generation pool endpoint must not contain credentials")]
+    EndpointCredentials,
+    #[error("model-generation pool identity is invalid: {0}")]
+    InvalidIdentity(String),
+    #[error("model-generation pool concurrency must be greater than zero")]
+    InvalidConcurrency,
+}
+
+/// Digest-only provider/model capacity metadata.
+///
+/// The pool is intentionally a descriptor, not an executor or semaphore. Its
+/// identity binds the non-secret routing facts that share a provider capacity
+/// budget; the scheduler or a local admission gate owns the live reservation.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ModelGenerationPool {
+    /// Domain-separated digest of provider, model, endpoint origin, and
+    /// optional non-secret account scope.
+    pub identity: crate::execution_identity::ExecutionIdentityV1,
+    /// Maximum active generations for this pool.
+    pub max_concurrency: NonZeroUsize,
+}
+
+impl ModelGenerationPool {
+    /// Build a pool from an already-derived identity.
+    pub fn new(
+        identity: crate::execution_identity::ExecutionIdentityV1,
+        max_concurrency: NonZeroUsize,
+    ) -> Result<Self, ModelGenerationPoolError> {
+        identity
+            .validate()
+            .map_err(|error| ModelGenerationPoolError::InvalidIdentity(error.to_string()))?;
+        Ok(Self {
+            identity,
+            max_concurrency,
+        })
+    }
+
+    /// Derive a stable pool from non-secret provider routing metadata.
+    ///
+    /// Endpoint paths, queries, fragments, and credentials are deliberately
+    /// discarded. Two clients that address the same origin/model therefore
+    /// share one capacity key even when their API path configuration differs.
+    pub fn for_client(
+        provider: &str,
+        model: &str,
+        endpoint: Option<&str>,
+        account_id: Option<&str>,
+        concurrency: ModelGenerationConcurrency,
+    ) -> Result<Self, ModelGenerationPoolError> {
+        let provider = bounded_component("provider", provider)?;
+        let model = bounded_component("model", model)?;
+        let endpoint_origin = endpoint.map(endpoint_origin).transpose()?;
+        let account_id = account_id
+            .map(|value| bounded_component("accountId", value))
+            .transpose()?;
+        let identity = crate::execution_identity::ExecutionIdentityV1::derive(
+            crate::execution_identity::MODEL_GENERATION_POOL_IDENTITY_DOMAIN_V1,
+            &serde_json::json!({
+                "provider": provider,
+                "model": model,
+                "endpoint_origin": endpoint_origin,
+                "account_id": account_id,
+            }),
+        )
+        .map_err(|error| ModelGenerationPoolError::InvalidIdentity(error.to_string()))?;
+        Self::new(identity, concurrency.max_concurrency())
+    }
+
+    /// Convenience constructor for clients with a concrete endpoint URL.
+    pub fn for_endpoint(
+        provider: &str,
+        model: &str,
+        endpoint: &str,
+        concurrency: ModelGenerationConcurrency,
+    ) -> Result<Self, ModelGenerationPoolError> {
+        Self::for_client(provider, model, Some(endpoint), None, concurrency)
+    }
+
+    /// Convenience constructor for account-scoped clients.
+    pub fn for_account_endpoint(
+        provider: &str,
+        model: &str,
+        endpoint: &str,
+        account_id: &str,
+        concurrency: ModelGenerationConcurrency,
+    ) -> Result<Self, ModelGenerationPoolError> {
+        Self::for_client(
+            provider,
+            model,
+            Some(endpoint),
+            Some(account_id),
+            concurrency,
+        )
+    }
+
+    pub fn identity(&self) -> &crate::execution_identity::ExecutionIdentityV1 {
+        &self.identity
+    }
+
+    pub const fn max_concurrency(&self) -> NonZeroUsize {
+        self.max_concurrency
+    }
+
+    pub fn validate(&self) -> Result<(), ModelGenerationPoolError> {
+        self.identity
+            .validate()
+            .map_err(|error| ModelGenerationPoolError::InvalidIdentity(error.to_string()))?;
+        if self.max_concurrency.get() == 0 {
+            return Err(ModelGenerationPoolError::InvalidConcurrency);
+        }
+        Ok(())
+    }
+}
+
+fn bounded_component(field: &'static str, value: &str) -> Result<String, ModelGenerationPoolError> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > MODEL_GENERATION_POOL_MAX_COMPONENT_BYTES {
+        return Err(ModelGenerationPoolError::InvalidComponent {
+            field,
+            limit: MODEL_GENERATION_POOL_MAX_COMPONENT_BYTES,
+        });
+    }
+    if value
+        .chars()
+        .any(|character| character.is_control() || matches!(character, '\u{2028}' | '\u{2029}'))
+    {
+        return Err(ModelGenerationPoolError::ControlCharacter { field });
+    }
+    Ok(value.to_string())
+}
+
+fn endpoint_origin(value: &str) -> Result<String, ModelGenerationPoolError> {
+    let parsed =
+        url::Url::parse(value.trim()).map_err(|_| ModelGenerationPoolError::InvalidEndpoint)?;
+    if parsed.host_str().is_none() || parsed.scheme().is_empty() {
+        return Err(ModelGenerationPoolError::InvalidEndpoint);
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(ModelGenerationPoolError::EndpointCredentials);
+    }
+    let origin = parsed.origin().ascii_serialization();
+    if origin == "null" {
+        return Err(ModelGenerationPoolError::InvalidEndpoint);
+    }
+    Ok(origin)
+}
 
 /// Bounded active model-generation capacity reported by an
 /// [`LlmClient`](super::LlmClient).
@@ -47,6 +207,15 @@ impl Default for ModelGenerationConcurrency {
 struct BoundedAdmission {
     max_concurrency: NonZeroUsize,
     semaphore: Arc<Semaphore>,
+    scheduler: Option<Arc<SchedulerBinding>>,
+}
+
+#[derive(Debug)]
+struct SchedulerBinding {
+    scheduler: Arc<crate::task_scheduler::TaskScheduler>,
+    quota: crate::task_scheduler::TaskSchedulerQuota,
+    priority: crate::task_scheduler::TaskPriority,
+    label: String,
 }
 
 /// Shared admission gate derived from a typed provider concurrency contract.
@@ -64,12 +233,63 @@ impl ModelGenerationAdmission {
         let bounded = Arc::new(BoundedAdmission {
             max_concurrency,
             semaphore: Arc::new(Semaphore::new(max_concurrency.get())),
+            scheduler: None,
         });
         Self { bounded }
     }
 
+    /// Attach a provider/model quota to this gate without creating another
+    /// queue. Each permit reserves the quota through the existing scheduler
+    /// actor, while the local semaphore retains the client's own contract.
+    pub fn with_scheduler_quota(
+        self,
+        scheduler: Arc<crate::task_scheduler::TaskScheduler>,
+        quota: crate::task_scheduler::TaskSchedulerQuota,
+        priority: crate::task_scheduler::TaskPriority,
+        label: impl Into<String>,
+    ) -> Result<Self, crate::task_scheduler::TaskSchedulerError> {
+        quota.validate()?;
+        let bounded = Arc::new(BoundedAdmission {
+            max_concurrency: self.bounded.max_concurrency,
+            semaphore: Arc::clone(&self.bounded.semaphore),
+            scheduler: Some(Arc::new(SchedulerBinding {
+                scheduler,
+                quota,
+                priority,
+                label: label.into(),
+            })),
+        });
+        Ok(Self { bounded })
+    }
+
+    /// Copy the scheduler-backed provider reservation from another admission
+    /// while retaining this gate's local concurrency. This is used by nested
+    /// workflow steps that impose a tighter local limit but must still count
+    /// against the session/provider pool in the one shared scheduler actor.
+    pub(crate) fn with_scheduler_quota_from(
+        self,
+        source: &Self,
+        label: impl Into<String>,
+    ) -> Result<Self, crate::task_scheduler::TaskSchedulerError> {
+        let Some(binding) = source.bounded.scheduler.as_ref() else {
+            return Ok(self);
+        };
+        self.with_scheduler_quota(
+            Arc::clone(&binding.scheduler),
+            binding.quota.clone(),
+            binding.priority,
+            label,
+        )
+    }
+
     pub fn concurrency(&self) -> ModelGenerationConcurrency {
         ModelGenerationConcurrency::bounded(self.bounded.max_concurrency)
+    }
+
+    /// Whether every permit also reserves a quota through the shared
+    /// scheduler actor.
+    pub(crate) fn has_scheduler_quota(&self) -> bool {
+        self.bounded.scheduler.is_some()
     }
 
     /// Wait for active-generation capacity without applying an active
@@ -90,9 +310,29 @@ impl ModelGenerationAdmission {
                 ModelGenerationAdmissionError::Closed
             })?,
         };
+        // Take the local contract first. A scheduler quota-only lease is a
+        // scarcer shared resource; acquiring it second prevents a session
+        // waiting on its own local semaphore from hoarding provider capacity.
+        let scheduler_lease = if let Some(binding) = self.bounded.scheduler.as_ref() {
+            Some(
+                binding
+                    .scheduler
+                    .acquire_quota(
+                        binding.priority,
+                        binding.label.clone(),
+                        &binding.quota,
+                        cancellation,
+                    )
+                    .await
+                    .map_err(ModelGenerationAdmissionError::from_scheduler_error)?,
+            )
+        } else {
+            None
+        };
         Ok(ModelGenerationPermit {
             admission: Arc::clone(&self.bounded),
             _bounded: permit,
+            _scheduler: scheduler_lease,
             queue_wait: queued_at.elapsed(),
         })
     }
@@ -119,6 +359,7 @@ impl Default for ModelGenerationAdmission {
 pub struct ModelGenerationPermit {
     admission: Arc<BoundedAdmission>,
     _bounded: OwnedSemaphorePermit,
+    _scheduler: Option<crate::task_scheduler::TaskLease>,
     queue_wait: Duration,
 }
 
@@ -128,7 +369,7 @@ impl ModelGenerationPermit {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ModelGenerationAdmissionError {
     #[error("model-generation admission cancelled by caller")]
     Cancelled,
@@ -136,6 +377,20 @@ pub enum ModelGenerationAdmissionError {
     Closed,
     #[error("model-generation permit belongs to a different admission gate")]
     ForeignPermit,
+    #[error("scheduler-backed model-generation admission failed: {0}")]
+    Scheduler(String),
+}
+
+impl ModelGenerationAdmissionError {
+    fn from_scheduler_error(error: crate::task_scheduler::TaskSchedulerError) -> Self {
+        match error {
+            crate::task_scheduler::TaskSchedulerError::Cancelled => Self::Cancelled,
+            crate::task_scheduler::TaskSchedulerError::Closed => Self::Closed,
+            crate::task_scheduler::TaskSchedulerError::InvalidConfig(message) => {
+                Self::Scheduler(message)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -174,5 +429,212 @@ mod tests {
         .expect("cancelled waiter must release its queue position")
         .expect("replacement permit");
         drop(replacement);
+    }
+
+    #[test]
+    fn pool_identity_uses_only_non_secret_endpoint_origin() {
+        let concurrency = ModelGenerationConcurrency::bounded(NonZeroUsize::new(2).unwrap());
+        let first = ModelGenerationPool::for_client(
+            "openai-compatible",
+            "model-a",
+            Some("https://example.test:443/v1/chat/completions?key=ignored"),
+            None,
+            concurrency,
+        )
+        .unwrap();
+        let second = ModelGenerationPool::for_client(
+            "openai-compatible",
+            "model-a",
+            Some("https://example.test:443/another-path"),
+            None,
+            concurrency,
+        )
+        .unwrap();
+        assert_eq!(first.identity, second.identity);
+        assert_eq!(first.max_concurrency(), NonZeroUsize::new(2).unwrap());
+        let encoded = serde_json::to_string(&first).unwrap();
+        assert!(!encoded.contains("ignored"));
+        assert!(!encoded.contains("example.test:443/v1"));
+    }
+
+    #[test]
+    fn pool_identity_separates_provider_model_and_account() {
+        let concurrency = ModelGenerationConcurrency::single_flight();
+        let base = ModelGenerationPool::for_endpoint(
+            "provider-a",
+            "model-a",
+            "https://example.test",
+            concurrency,
+        )
+        .unwrap();
+        let provider = ModelGenerationPool::for_endpoint(
+            "provider-b",
+            "model-a",
+            "https://example.test",
+            concurrency,
+        )
+        .unwrap();
+        let model = ModelGenerationPool::for_endpoint(
+            "provider-a",
+            "model-b",
+            "https://example.test",
+            concurrency,
+        )
+        .unwrap();
+        let account = ModelGenerationPool::for_account_endpoint(
+            "provider-a",
+            "model-a",
+            "https://example.test",
+            "account-1",
+            concurrency,
+        )
+        .unwrap();
+        assert_ne!(base.identity, provider.identity);
+        assert_ne!(base.identity, model.identity);
+        assert_ne!(base.identity, account.identity);
+    }
+
+    #[tokio::test]
+    async fn tighter_nested_gate_retains_the_session_scheduler_quota() {
+        let scheduler = Arc::new(
+            crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+                max_active: 1,
+                aging_interval_ms: 1_000,
+            })
+            .unwrap(),
+        );
+        let quota =
+            crate::task_scheduler::TaskSchedulerQuota::for_scope("provider-session", 1).unwrap();
+        let session = ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+            .with_scheduler_quota(
+                Arc::clone(&scheduler),
+                quota,
+                crate::task_scheduler::TaskPriority::Foreground,
+                "session-generation",
+            )
+            .unwrap();
+        let nested = ModelGenerationAdmission::new(ModelGenerationConcurrency::bounded(
+            NonZeroUsize::new(2).unwrap(),
+        ))
+        .with_scheduler_quota_from(&session, "nested-generation")
+        .unwrap();
+
+        let holder = session.acquire(&CancellationToken::new()).await.unwrap();
+        let cancellation = CancellationToken::new();
+        let waiting = tokio::spawn({
+            let nested = nested.clone();
+            let cancellation = cancellation.clone();
+            async move { nested.acquire(&cancellation).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+        drop(holder);
+        let permit = tokio::time::timeout(Duration::from_millis(100), waiting)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        drop(permit);
+        scheduler.shutdown().await;
+    }
+
+    #[test]
+    fn pool_rejects_credentials_and_unbounded_components() {
+        let concurrency = ModelGenerationConcurrency::single_flight();
+        assert!(matches!(
+            ModelGenerationPool::for_endpoint(
+                "provider",
+                "model",
+                "https://user:secret@example.test/v1",
+                concurrency,
+            ),
+            Err(ModelGenerationPoolError::EndpointCredentials)
+        ));
+        assert!(matches!(
+            ModelGenerationPool::for_endpoint(
+                &"p".repeat(MODEL_GENERATION_POOL_MAX_COMPONENT_BYTES + 1),
+                "model",
+                "https://example.test",
+                concurrency,
+            ),
+            Err(ModelGenerationPoolError::InvalidComponent {
+                field: "provider",
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn scheduler_backed_gates_share_provider_capacity_across_sessions() {
+        let scheduler = Arc::new(
+            crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+                max_active: 1,
+                aging_interval_ms: 60_000,
+            })
+            .unwrap(),
+        );
+        let pool = ModelGenerationPool::for_endpoint(
+            "provider",
+            "model",
+            "https://example.test",
+            ModelGenerationConcurrency::single_flight(),
+        )
+        .unwrap();
+        let quota = crate::task_scheduler::TaskSchedulerQuota::new(
+            pool.identity.clone(),
+            pool.max_concurrency().get(),
+        )
+        .unwrap();
+        let admission_a =
+            ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+                .with_scheduler_quota(
+                    Arc::clone(&scheduler),
+                    quota.clone(),
+                    crate::task_scheduler::TaskPriority::Foreground,
+                    "model-generation:session-a",
+                )
+                .unwrap();
+        let admission_b =
+            ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+                .with_scheduler_quota(
+                    Arc::clone(&scheduler),
+                    quota.clone(),
+                    crate::task_scheduler::TaskPriority::Foreground,
+                    "model-generation:session-b",
+                )
+                .unwrap();
+        let first = admission_a
+            .acquire(&CancellationToken::new())
+            .await
+            .unwrap();
+        let cancellation = CancellationToken::new();
+        let waiting = tokio::spawn({
+            let admission = admission_b.clone();
+            let cancellation = cancellation.clone();
+            async move { admission.acquire(&cancellation).await }
+        });
+        for _ in 0..100 {
+            if scheduler.quota_snapshot(&quota).await.unwrap().pending == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(scheduler.quota_snapshot(&quota).await.unwrap().active, 1);
+        assert_eq!(scheduler.quota_snapshot(&quota).await.unwrap().pending, 1);
+        cancellation.cancel();
+        assert!(matches!(
+            waiting.await.unwrap(),
+            Err(ModelGenerationAdmissionError::Cancelled)
+        ));
+        drop(first);
+        let replacement = tokio::time::timeout(
+            Duration::from_millis(100),
+            admission_b.acquire(&CancellationToken::new()),
+        )
+        .await
+        .expect("provider quota should be released")
+        .unwrap();
+        drop(replacement);
+        scheduler.shutdown().await;
     }
 }

--- a/core/src/llm/anthropic.rs
+++ b/core/src/llm/anthropic.rs
@@ -3,7 +3,7 @@
 use super::http::{default_http_client, normalize_base_url, HttpClient};
 use super::structured;
 use super::types::*;
-use super::LlmClient;
+use super::{LlmClient, ModelGenerationPool};
 use crate::retry::{AttemptOutcome, RetryConfig};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -282,6 +282,16 @@ impl AnthropicClient {
 
 #[async_trait]
 impl LlmClient for AnthropicClient {
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        ModelGenerationPool::for_endpoint(
+            &self.provider_name,
+            &self.model,
+            &self.base_url,
+            self.model_generation_concurrency(),
+        )
+        .ok()
+    }
+
     async fn complete(
         &self,
         messages: &[Message],

--- a/core/src/llm/codex_login.rs
+++ b/core/src/llm/codex_login.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::llm::http::ReqwestHttpClient;
 use crate::llm::{
     default_http_client, structured, ContentBlock, HttpClient, LlmClient, LlmResponse,
-    LlmResponseMeta, Message, StreamEvent, TokenUsage, ToolDefinition,
+    LlmResponseMeta, Message, ModelGenerationPool, StreamEvent, TokenUsage, ToolDefinition,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -120,6 +120,17 @@ impl CodexLoginClient {
 
 #[async_trait]
 impl LlmClient for CodexLoginClient {
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        ModelGenerationPool::for_account_endpoint(
+            "codex",
+            &self.model,
+            CODEX_BASE,
+            &self.account_id,
+            self.model_generation_concurrency(),
+        )
+        .ok()
+    }
+
     fn with_active_generation_timeout(
         &self,
         timeout: std::time::Duration,

--- a/core/src/llm/mod.rs
+++ b/core/src/llm/mod.rs
@@ -18,7 +18,7 @@ pub mod zhipu;
 // Re-export public types
 pub use admission::{
     ModelGenerationAdmission, ModelGenerationAdmissionError, ModelGenerationConcurrency,
-    ModelGenerationPermit,
+    ModelGenerationPermit, ModelGenerationPool, ModelGenerationPoolError,
 };
 pub use anthropic::AnthropicClient;
 pub use codex_login::CodexLoginClient;
@@ -53,6 +53,43 @@ pub trait LlmClient: Send + Sync {
     /// strings.
     fn model_generation_concurrency(&self) -> ModelGenerationConcurrency {
         ModelGenerationConcurrency::single_flight()
+    }
+
+    /// Describe the non-secret provider/model capacity pool shared by this
+    /// client. The default is `None` for custom clients that do not expose a
+    /// stable routing identity; they retain the existing per-client gate.
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        None
+    }
+
+    /// Rebind a governed model facade to an invocation-owned generation gate.
+    ///
+    /// This is primarily used when a nested workflow supplies a tighter
+    /// admission gate than the surrounding session (for example, a Flow step
+    /// with its own `maxConcurrentGenerations` limit). Raw provider clients do
+    /// not need to implement this hook; the agent runtime can wrap them. A
+    /// client that already owns model-generation admission should preserve the
+    /// provider transport while replacing the facade's gate and, when given,
+    /// consuming the one pre-admitted permit exactly once.
+    fn bind_model_generation_admission(
+        &self,
+        _admission: ModelGenerationAdmission,
+        _preadmitted: Option<std::sync::Arc<ModelGenerationPermit>>,
+    ) -> Option<std::sync::Arc<dyn LlmClient>> {
+        None
+    }
+
+    /// Whether this client already applies the model-generation admission
+    /// contract around every provider call. Built-in run-bound clients use
+    /// this marker so structured tools do not acquire the same permit twice.
+    fn model_generation_is_managed(&self) -> bool {
+        false
+    }
+
+    /// Take queue wait accumulated by a managed client since the previous
+    /// observation. Unmanaged clients report zero.
+    fn take_model_generation_queue_wait(&self) -> Duration {
+        Duration::ZERO
     }
 
     /// Derive a provider client bound to one logical agent session.

--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -3,7 +3,7 @@
 use super::http::{default_http_client, normalize_base_url, HttpClient};
 use super::structured;
 use super::types::*;
-use super::LlmClient;
+use super::{LlmClient, ModelGenerationPool};
 use crate::llm::types::{ToolResultContent, ToolResultContentField};
 use crate::retry::{AttemptOutcome, RetryConfig};
 use anyhow::{Context, Result};
@@ -529,6 +529,16 @@ impl OpenAiClient {
 
 #[async_trait]
 impl LlmClient for OpenAiClient {
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        ModelGenerationPool::for_endpoint(
+            &self.provider_name,
+            &self.model,
+            &self.base_url,
+            self.model_generation_concurrency(),
+        )
+        .ok()
+    }
+
     async fn complete(
         &self,
         messages: &[Message],

--- a/core/src/llm/zhipu.rs
+++ b/core/src/llm/zhipu.rs
@@ -6,7 +6,7 @@
 use super::openai::OpenAiClient;
 use super::structured;
 use super::types::*;
-use super::LlmClient;
+use super::{LlmClient, ModelGenerationPool};
 use crate::retry::RetryConfig;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -68,6 +68,10 @@ impl ZhipuClient {
 
 #[async_trait]
 impl LlmClient for ZhipuClient {
+    fn model_generation_pool(&self) -> Option<ModelGenerationPool> {
+        self.0.model_generation_pool()
+    }
+
     async fn complete(
         &self,
         messages: &[Message],

--- a/core/src/task_scheduler.rs
+++ b/core/src/task_scheduler.rs
@@ -24,6 +24,12 @@ const DEFAULT_AGING_INTERVAL_MS: u64 = 30_000;
 /// snapshot; the bound only prevents an untrusted host from forcing an
 /// unbounded identity-derivation allocation.
 pub const TASK_SCHEDULER_MAX_SCOPE_BYTES: usize = 512;
+/// Maximum number of independent quota dimensions accepted by one admission.
+///
+/// Keeping this bound small makes the scheduler actor's validation and live
+/// accounting predictable even when a host composes owner, provider, tenant,
+/// or other typed capacity descriptors.
+pub const TASK_SCHEDULER_MAX_QUOTAS: usize = 8;
 
 /// Relative importance of work admitted through an agent's shared scheduler.
 ///
@@ -113,23 +119,24 @@ impl TaskSchedulerConfig {
     }
 }
 
-/// Immutable owner quota carried by one scheduler admission request.
+/// Immutable capacity quota carried by one scheduler admission request.
 ///
 /// The quota is deliberately a descriptor rather than a second queue or
 /// semaphore. The scheduler actor remains the only authority that decides
-/// whether work owns a global slot; it additionally refuses to admit more than
-/// `max_active` requests for this digest-only owner identity at once.
+/// whether work owns a global slot or a quota-only reservation; it additionally
+/// refuses to admit more than `max_active` requests for this digest-only
+/// capacity identity at once.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TaskSchedulerQuota {
-    /// Digest-only identity of the run/host scope consuming capacity.
+    /// Digest-only identity of the run/host/provider scope consuming capacity.
     pub identity: ExecutionIdentityV1,
-    /// Maximum global scheduler slots this owner may hold concurrently.
+    /// Maximum reservations this capacity identity may hold concurrently.
     pub max_active: usize,
 }
 
 impl TaskSchedulerQuota {
-    /// Build and validate an owner quota descriptor.
+    /// Build and validate a capacity quota descriptor.
     pub fn new(
         identity: ExecutionIdentityV1,
         max_active: usize,
@@ -204,7 +211,8 @@ pub struct TaskSchedulerQuotaSnapshot {
     pub identity: ExecutionIdentityV1,
     /// Immutable owner limit used for this live projection.
     pub max_active: usize,
-    /// Global scheduler slots currently owned by this quota identity.
+    /// Active reservations currently owned by this quota identity. This may
+    /// include quota-only leaf leases in addition to global scheduler slots.
     pub active: usize,
     /// Requests from this owner waiting in the global queue.
     pub pending: usize,
@@ -278,7 +286,9 @@ pub struct TaskSchedulerStats {
 pub struct TaskSchedulerHealthSnapshot {
     /// Configured global capacity.
     pub max_active: usize,
-    /// Number of leases currently held.
+    /// Number of global scheduler slots currently held. Quota-only leaf
+    /// reservations are visible through their quota snapshots but do not
+    /// consume this global occupancy counter.
     pub active: usize,
     /// Number of requests waiting for a lease.
     pub pending: usize,
@@ -358,14 +368,59 @@ impl TaskScheduler {
         identity: Option<ExecutionIdentityV1>,
         cancellation: &CancellationToken,
     ) -> Result<TaskLease, TaskSchedulerError> {
-        self.acquire_inner(priority, label.into(), None, identity, cancellation)
+        self.acquire_inner(
+            priority,
+            label.into(),
+            Vec::new(),
+            identity,
+            true,
+            cancellation,
+        )
+        .await
+    }
+
+    /// Wait for one or more quota dimensions without consuming another
+    /// global execution slot.
+    ///
+    /// This is used at leaf resource boundaries (for example, one model
+    /// generation inside an already-admitted session run). The request still
+    /// enters the same priority queue and actor as global admissions, so a
+    /// provider limit cannot be bypassed with a local semaphore and a
+    /// max-active=1 session does not deadlock while a nested model call waits.
+    pub async fn acquire_quota(
+        &self,
+        priority: TaskPriority,
+        label: impl Into<String>,
+        quota: &TaskSchedulerQuota,
+        cancellation: &CancellationToken,
+    ) -> Result<TaskLease, TaskSchedulerError> {
+        self.acquire_quotas(priority, label, std::slice::from_ref(quota), cancellation)
             .await
     }
 
-    /// Wait until this task owns a global execution slot subject to an
-    /// owner-level quota. The quota reservation is made in the same scheduler
-    /// actor as global admission, so a caller cannot bypass it by creating a
-    /// fresh local semaphore or executor handle.
+    /// Multi-dimensional quota-only counterpart of [`Self::acquire_quota`].
+    pub async fn acquire_quotas(
+        &self,
+        priority: TaskPriority,
+        label: impl Into<String>,
+        quotas: &[TaskSchedulerQuota],
+        cancellation: &CancellationToken,
+    ) -> Result<TaskLease, TaskSchedulerError> {
+        self.acquire_inner(
+            priority,
+            label.into(),
+            quotas.to_vec(),
+            None,
+            false,
+            cancellation,
+        )
+        .await
+    }
+
+    /// Wait until this task owns a global execution slot subject to a capacity
+    /// quota. The quota reservation is made in the same scheduler actor as
+    /// global admission, so a caller cannot bypass it by creating a fresh local
+    /// semaphore or executor handle.
     pub async fn acquire_with_quota(
         &self,
         priority: TaskPriority,
@@ -377,8 +432,32 @@ impl TaskScheduler {
         self.acquire_inner(
             priority,
             label.into(),
-            Some(quota.clone()),
+            vec![quota.clone()],
             identity,
+            true,
+            cancellation,
+        )
+        .await
+    }
+
+    /// Wait until this task owns a global execution slot subject to multiple
+    /// immutable quota dimensions. All dimensions are evaluated by the same
+    /// scheduler actor, so a caller cannot bypass one limit by splitting the
+    /// request across independent local gates.
+    pub async fn acquire_with_quotas(
+        &self,
+        priority: TaskPriority,
+        label: impl Into<String>,
+        quotas: &[TaskSchedulerQuota],
+        identity: Option<ExecutionIdentityV1>,
+        cancellation: &CancellationToken,
+    ) -> Result<TaskLease, TaskSchedulerError> {
+        self.acquire_inner(
+            priority,
+            label.into(),
+            quotas.to_vec(),
+            identity,
+            true,
             cancellation,
         )
         .await
@@ -388,8 +467,9 @@ impl TaskScheduler {
         &self,
         priority: TaskPriority,
         label: String,
-        quota: Option<TaskSchedulerQuota>,
+        quotas: Vec<TaskSchedulerQuota>,
         identity: Option<ExecutionIdentityV1>,
+        global_slot: bool,
         cancellation: &CancellationToken,
     ) -> Result<TaskLease, TaskSchedulerError> {
         if self.closed.load(Ordering::Acquire) {
@@ -403,12 +483,31 @@ impl TaskScheduler {
                 TaskSchedulerError::InvalidConfig(format!("execution identity is invalid: {error}"))
             })?;
         }
-        if let Some(quota) = &quota {
+        if quotas.len() > TASK_SCHEDULER_MAX_QUOTAS {
+            return Err(TaskSchedulerError::InvalidConfig(format!(
+                "task admission cannot contain more than {TASK_SCHEDULER_MAX_QUOTAS} quota dimensions"
+            )));
+        }
+        if !global_slot && quotas.is_empty() {
+            return Err(TaskSchedulerError::InvalidConfig(
+                "quota-only admission requires at least one quota dimension".to_string(),
+            ));
+        }
+        let mut quota_digests = HashSet::with_capacity(quotas.len());
+        for quota in &quotas {
             quota.validate()?;
+            if !quota_digests.insert(quota.identity.digest.clone()) {
+                return Err(TaskSchedulerError::InvalidConfig(
+                    "task admission contains duplicate quota identities".to_string(),
+                ));
+            }
         }
 
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let quota_identity = quota.as_ref().map(|quota| quota.identity.clone());
+        let quota_identities = quotas
+            .iter()
+            .map(|quota| quota.identity.clone())
+            .collect::<Vec<_>>();
         let (ready_tx, ready_rx) = oneshot::channel();
         self.tx
             .send(SchedulerMessage::Enqueue(QueuedAdmission {
@@ -417,7 +516,8 @@ impl TaskScheduler {
                 effective_priority: priority.lane_priority(),
                 label,
                 identity: identity.clone(),
-                quota,
+                quotas,
+                global_slot,
                 enqueued_at: Instant::now(),
                 ready: ready_tx,
             }))
@@ -436,7 +536,8 @@ impl TaskScheduler {
                     tx: self.tx.clone(),
                     released: false,
                     identity,
-                    quota_identity,
+                    quota_identities,
+                    global_slot,
                 })
             }
         }
@@ -501,13 +602,20 @@ impl TaskScheduler {
     }
 }
 
-/// RAII ownership of one globally admitted execution slot.
+/// RAII ownership of one scheduler admission.
+///
+/// A normal lease consumes one global execution slot. A lease returned by
+/// [`TaskScheduler::acquire_quota`] reserves only its quota dimensions, which
+/// lets a leaf resource (such as a model generation) compose with an already
+/// held session slot without recursive scheduler deadlock.
+#[derive(Debug)]
 pub struct TaskLease {
     id: u64,
     tx: mpsc::UnboundedSender<SchedulerMessage>,
     released: bool,
     identity: Option<ExecutionIdentityV1>,
-    quota_identity: Option<ExecutionIdentityV1>,
+    quota_identities: Vec<ExecutionIdentityV1>,
+    global_slot: bool,
 }
 
 impl TaskLease {
@@ -523,7 +631,21 @@ impl TaskLease {
 
     /// Digest-only owner quota identity applied to this admission, when any.
     pub fn quota_identity(&self) -> Option<&ExecutionIdentityV1> {
-        self.quota_identity.as_ref()
+        self.quota_identities.first()
+    }
+
+    /// All digest-only quota identities applied to this admission.
+    ///
+    /// The slice is empty for an unconstrained global admission. The first
+    /// identity is retained by [`Self::quota_identity`] for compatibility
+    /// with callers that only used the original single-quota API.
+    pub fn quota_identities(&self) -> &[ExecutionIdentityV1] {
+        &self.quota_identities
+    }
+
+    /// Whether this lease consumes one of the scheduler's global slots.
+    pub const fn consumes_global_slot(&self) -> bool {
+        self.global_slot
     }
 }
 
@@ -542,7 +664,8 @@ struct QueuedAdmission {
     effective_priority: Priority,
     label: String,
     identity: Option<ExecutionIdentityV1>,
-    quota: Option<TaskSchedulerQuota>,
+    quotas: Vec<TaskSchedulerQuota>,
+    global_slot: bool,
     enqueued_at: Instant,
     ready: oneshot::Sender<Result<(), TaskSchedulerError>>,
 }
@@ -585,7 +708,8 @@ struct SchedulerState {
 
 struct ActiveAdmission {
     priority: TaskPriority,
-    quota_identity: Option<String>,
+    quota_identities: Vec<String>,
+    global_slot: bool,
 }
 
 struct QuotaState {
@@ -617,11 +741,11 @@ async fn run_scheduler(
                 if state.closing {
                     state.counters.rejected = state.counters.rejected.saturating_add(1);
                     let _ = item.ready.send(Err(TaskSchedulerError::Closed));
-                } else if let Err(error) = state.register_pending_quota(item.quota.as_ref()) {
+                } else if let Err(error) = state.register_pending_quotas(&item.quotas) {
                     state.counters.rejected = state.counters.rejected.saturating_add(1);
                     let _ = item.ready.send(Err(error));
                 } else {
-                    if let Some(quota) = item.quota.as_ref() {
+                    for quota in &item.quotas {
                         if let Some(quota_state) = state.quotas.get_mut(&quota.identity.digest) {
                             quota_state.pending = quota_state.pending.saturating_add(1);
                         }
@@ -633,7 +757,7 @@ async fn run_scheduler(
             SchedulerMessage::Cancel(id) => {
                 if let Some(active) = state.active.remove(&id) {
                     state.counters.cancelled = state.counters.cancelled.saturating_add(1);
-                    state.release_active_quota(active.quota_identity.as_deref());
+                    state.release_active_quotas(&active.quota_identities);
                 } else {
                     state.cancelled.insert(id);
                     state.purge_cancelled();
@@ -644,7 +768,7 @@ async fn run_scheduler(
             SchedulerMessage::Release(id) => {
                 if let Some(active) = state.active.remove(&id) {
                     state.counters.released = state.counters.released.saturating_add(1);
-                    state.release_active_quota(active.quota_identity.as_deref());
+                    state.release_active_quotas(&active.quota_identities);
                 }
                 state.dispatch();
                 state.finish_shutdown_if_idle();
@@ -670,7 +794,7 @@ async fn run_scheduler(
                 while let Some(item) = state.pending.pop() {
                     let item = item.into_value();
                     state.counters.rejected = state.counters.rejected.saturating_add(1);
-                    state.reject_pending_quota(item.quota.as_ref());
+                    state.reject_pending_quotas(&item.quotas);
                     let _ = item.ready.send(Err(TaskSchedulerError::Closed));
                 }
                 state.cancelled.clear();
@@ -688,65 +812,58 @@ async fn run_scheduler(
 }
 
 impl SchedulerState {
-    fn register_pending_quota(
+    fn register_pending_quotas(
         &mut self,
-        quota: Option<&TaskSchedulerQuota>,
+        quotas: &[TaskSchedulerQuota],
     ) -> Result<(), TaskSchedulerError> {
-        let Some(quota) = quota else {
-            return Ok(());
-        };
-        let key = quota.identity.digest.clone();
-        match self.quotas.get(&key) {
-            Some(existing)
-                if existing.identity != quota.identity
-                    || existing.max_active != quota.max_active =>
-            {
-                Err(TaskSchedulerError::InvalidConfig(
-                    "scheduler quota identity is already registered with a different limit"
-                        .to_string(),
-                ))
-            }
-            Some(_) => Ok(()),
-            None => {
-                self.quotas.insert(
-                    key,
-                    QuotaState {
-                        identity: quota.identity.clone(),
-                        max_active: quota.max_active,
-                        active: 0,
-                        pending: 0,
-                    },
-                );
-                Ok(())
+        // Validate every existing registration before inserting any new state;
+        // a later conflict must not leave a partially registered descriptor.
+        for quota in quotas {
+            let key = quota.identity.digest.as_str();
+            if let Some(existing) = self.quotas.get(key) {
+                if existing.identity != quota.identity || existing.max_active != quota.max_active {
+                    return Err(TaskSchedulerError::InvalidConfig(
+                        "scheduler quota identity is already registered with a different limit"
+                            .to_string(),
+                    ));
+                }
             }
         }
+        for quota in quotas {
+            let key = quota.identity.digest.clone();
+            self.quotas.entry(key).or_insert_with(|| QuotaState {
+                identity: quota.identity.clone(),
+                max_active: quota.max_active,
+                active: 0,
+                pending: 0,
+            });
+        }
+        Ok(())
     }
 
-    fn reject_pending_quota(&mut self, quota: Option<&TaskSchedulerQuota>) {
-        let Some(quota) = quota else {
-            return;
-        };
-        let key = quota.identity.digest.as_str();
-        if let Some(state) = self.quotas.get_mut(key) {
-            state.pending = state.pending.saturating_sub(1);
+    fn reject_pending_quotas(&mut self, quotas: &[TaskSchedulerQuota]) {
+        for quota in quotas {
+            let key = quota.identity.digest.as_str();
+            if let Some(state) = self.quotas.get_mut(key) {
+                state.pending = state.pending.saturating_sub(1);
+            }
+            self.prune_idle_quota(key);
         }
-        self.prune_idle_quota(key);
     }
 
     fn cancel_pending(&mut self, item: QueuedAdmission) {
         self.counters.cancelled = self.counters.cancelled.saturating_add(1);
-        self.reject_pending_quota(item.quota.as_ref());
+        self.reject_pending_quotas(&item.quotas);
         let _ = item.ready.send(Err(TaskSchedulerError::Cancelled));
     }
 
-    fn release_active_quota(&mut self, key: Option<&str>) {
-        let Some(key) = key else {
-            return;
-        };
-        if let Some(state) = self.quotas.get_mut(key) {
-            state.active = state.active.saturating_sub(1);
+    fn release_active_quotas(&mut self, keys: &[String]) {
+        for key in keys {
+            if let Some(state) = self.quotas.get_mut(key) {
+                state.active = state.active.saturating_sub(1);
+            }
+            self.prune_idle_quota(key);
         }
-        self.prune_idle_quota(key);
     }
 
     fn prune_idle_quota(&mut self, key: &str) {
@@ -759,13 +876,12 @@ impl SchedulerState {
         }
     }
 
-    fn quota_allows(&self, quota: Option<&TaskSchedulerQuota>) -> bool {
-        let Some(quota) = quota else {
-            return true;
-        };
-        self.quotas
-            .get(&quota.identity.digest)
-            .is_some_and(|state| state.active < state.max_active)
+    fn quota_allows(&self, quotas: &[TaskSchedulerQuota]) -> bool {
+        quotas.iter().all(|quota| {
+            self.quotas
+                .get(&quota.identity.digest)
+                .is_some_and(|state| state.active < state.max_active)
+        })
     }
 
     fn quota_snapshot(
@@ -830,19 +946,24 @@ impl SchedulerState {
             return;
         }
         self.apply_aging();
-        while self.active.len() < self.config.max_active {
-            let Some(item) = self.pop_admissible() else {
+        loop {
+            // Recompute after every admission: quota-only leases may continue
+            // while global capacity is full, but a second global lease must
+            // never slip past the configured max-active bound.
+            let global_capacity_available = self.global_active_count() < self.config.max_active;
+            let Some(item) = self.pop_admissible(global_capacity_available) else {
                 break;
             };
             let id = item.id;
             let priority = item.priority;
             let label = item.label;
             let identity = item.identity;
-            let quota_identity = item
-                .quota
-                .as_ref()
-                .map(|quota| quota.identity.digest.clone());
-            if let Some(quota_key) = quota_identity.as_deref() {
+            let quota_identities = item
+                .quotas
+                .iter()
+                .map(|quota| quota.identity.digest.clone())
+                .collect::<Vec<_>>();
+            for quota_key in &quota_identities {
                 if let Some(quota_state) = self.quotas.get_mut(quota_key) {
                     quota_state.pending = quota_state.pending.saturating_sub(1);
                     quota_state.active = quota_state.active.saturating_add(1);
@@ -857,20 +978,21 @@ impl SchedulerState {
                 id,
                 ActiveAdmission {
                     priority,
-                    quota_identity: quota_identity.clone(),
+                    quota_identities: quota_identities.clone(),
+                    global_slot: item.global_slot,
                 },
             );
             if item.ready.send(Ok(())).is_err() {
                 self.active.remove(&id);
                 self.counters.cancelled = self.counters.cancelled.saturating_add(1);
-                self.release_active_quota(quota_identity.as_deref());
+                self.release_active_quotas(&quota_identities);
                 continue;
             }
             self.counters.admitted = self.counters.admitted.saturating_add(1);
             self.counters.total_wait_micros =
                 self.counters.total_wait_micros.saturating_add(wait_micros);
             self.counters.max_wait_micros = self.counters.max_wait_micros.max(wait_micros);
-            self.counters.peak_active = self.counters.peak_active.max(self.active.len());
+            self.counters.peak_active = self.counters.peak_active.max(self.global_active_count());
             tracing::trace!(
                 admission_id = id,
                 ?priority,
@@ -885,10 +1007,10 @@ impl SchedulerState {
     }
 
     /// Claim the first queued item that is eligible under both global capacity
-    /// and its owner quota. Items blocked by one owner remain queued while
-    /// independent owners can make progress, preventing a single fan-out from
-    /// monopolizing the shared scheduler.
-    fn pop_admissible(&mut self) -> Option<QueuedAdmission> {
+    /// and all of its capacity quotas. Items blocked by one identity remain
+    /// queued while independent identities can make progress, preventing a
+    /// single fan-out from monopolizing the shared scheduler.
+    fn pop_admissible(&mut self, global_capacity_available: bool) -> Option<QueuedAdmission> {
         let mut retained: Vec<PriorityItem<QueuedAdmission>> = Vec::new();
         let mut selected = None;
         while let Some(item) = self.pending.pop() {
@@ -896,7 +1018,10 @@ impl SchedulerState {
                 self.cancel_pending(item.into_value());
                 continue;
             }
-            if selected.is_none() && self.quota_allows(item.value().quota.as_ref()) {
+            if selected.is_none()
+                && (!item.value().global_slot || global_capacity_available)
+                && self.quota_allows(&item.value().quotas)
+            {
                 selected = Some(item.into_value());
             } else {
                 retained.push(item);
@@ -941,7 +1066,9 @@ impl SchedulerState {
     fn snapshot(&self) -> TaskSchedulerStats {
         let mut active_by_priority = TaskPriorityCounts::default();
         for active in self.active.values() {
-            active_by_priority.increment(active.priority);
+            if active.global_slot {
+                active_by_priority.increment(active.priority);
+            }
         }
         let mut pending_by_priority = TaskPriorityCounts::default();
         for item in self.pending.ordered() {
@@ -958,11 +1085,11 @@ impl SchedulerState {
                     TaskPriority::Maintenance => active_by_priority.maintenance,
                 })
                 .sum::<usize>(),
-            self.active.len()
+            self.global_active_count()
         );
         TaskSchedulerStats {
             max_active: self.config.max_active,
-            active: self.active.len(),
+            active: self.global_active_count(),
             pending: self.pending.len(),
             active_by_priority,
             pending_by_priority,
@@ -1001,6 +1128,13 @@ impl SchedulerState {
                 let _ = waiter.send(());
             }
         }
+    }
+
+    fn global_active_count(&self) -> usize {
+        self.active
+            .values()
+            .filter(|active| active.global_slot)
+            .count()
     }
 }
 

--- a/core/src/task_scheduler/tests.rs
+++ b/core/src/task_scheduler/tests.rs
@@ -101,6 +101,55 @@ async fn strict_priority_and_fifo_are_enforced_globally() {
 }
 
 #[tokio::test]
+async fn global_capacity_is_recomputed_after_each_admission() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let blocker = scheduler
+        .acquire(
+            TaskPriority::Interactive,
+            "capacity-blocker",
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let (admitted_tx, mut admitted_rx) = mpsc::unbounded_channel();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let mut tasks = Vec::new();
+    for index in 0..3 {
+        let scheduler = Arc::clone(&scheduler);
+        let admitted_tx = admitted_tx.clone();
+        let release = Arc::clone(&release);
+        tasks.push(tokio::spawn(async move {
+            let lease = scheduler
+                .acquire(
+                    TaskPriority::Foreground,
+                    format!("capacity-{index}"),
+                    &CancellationToken::new(),
+                )
+                .await
+                .unwrap();
+            admitted_tx.send(index).unwrap();
+            release.acquire().await.unwrap().forget();
+            drop(lease);
+        }));
+    }
+    wait_for_pending(&scheduler, 3).await;
+    drop(blocker);
+    assert!(admitted_rx.recv().await.is_some());
+    assert_eq!(scheduler.stats().await.unwrap().active, 1);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), admitted_rx.recv())
+            .await
+            .is_err(),
+        "a second global lease must not be admitted while capacity is full"
+    );
+    release.add_permits(3);
+    for task in tasks {
+        task.await.unwrap();
+    }
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
 async fn cancellation_does_not_consume_capacity() {
     let scheduler = Arc::new(scheduler(1, 60_000));
     let blocker = scheduler
@@ -613,5 +662,265 @@ async fn idle_quota_state_is_pruned_before_a_new_limit_is_registered() {
         .unwrap();
     assert_eq!(second.quota_identity(), Some(replacement.identity()));
     drop(second);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn multiple_quota_dimensions_are_atomic_and_release_together() {
+    let scheduler = Arc::new(scheduler(2, 60_000));
+    let owner = TaskSchedulerQuota::for_scope("run:multi", 2).unwrap();
+    let provider = TaskSchedulerQuota::for_scope("provider:shared", 1).unwrap();
+    let first = scheduler
+        .acquire_with_quotas(
+            TaskPriority::Foreground,
+            "multi:first",
+            &[owner.clone(), provider.clone()],
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        first.quota_identities(),
+        &[owner.identity.clone(), provider.identity.clone()]
+    );
+
+    // The provider dimension blocks this request even though the owner still
+    // has one free slot. No partial owner reservation is visible.
+    let cancellation = CancellationToken::new();
+    let waiting = {
+        let scheduler = Arc::clone(&scheduler);
+        let owner = owner.clone();
+        let provider = provider.clone();
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move {
+            scheduler
+                .acquire_with_quotas(
+                    TaskPriority::Foreground,
+                    "multi:waiting",
+                    &[owner, provider],
+                    None,
+                    &cancellation,
+                )
+                .await
+        })
+    };
+    wait_for_pending(&scheduler, 1).await;
+    assert_eq!(scheduler.quota_snapshot(&owner).await.unwrap().active, 1);
+    assert_eq!(scheduler.quota_snapshot(&owner).await.unwrap().pending, 1);
+    assert!(scheduler.quota_snapshot(&provider).await.unwrap().blocked);
+
+    cancellation.cancel();
+    assert!(matches!(
+        waiting.await.unwrap(),
+        Err(TaskSchedulerError::Cancelled)
+    ));
+    assert_eq!(scheduler.quota_snapshot(&owner).await.unwrap().pending, 0);
+    assert_eq!(scheduler.quota_snapshot(&provider).await.unwrap().active, 1);
+    drop(first);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn independent_provider_quota_can_progress_under_global_capacity() {
+    let scheduler = Arc::new(scheduler(2, 60_000));
+    let provider_a = TaskSchedulerQuota::for_scope("provider:a", 1).unwrap();
+    let provider_b = TaskSchedulerQuota::for_scope("provider:b", 1).unwrap();
+    let holder = scheduler
+        .acquire_with_quota(
+            TaskPriority::Foreground,
+            "provider-a:holder",
+            &provider_a,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let blocked_a = {
+        let scheduler = Arc::clone(&scheduler);
+        let provider_a = provider_a.clone();
+        tokio::spawn(async move {
+            scheduler
+                .acquire_with_quota(
+                    TaskPriority::Foreground,
+                    "provider-a:blocked",
+                    &provider_a,
+                    None,
+                    &CancellationToken::new(),
+                )
+                .await
+        })
+    };
+    wait_for_pending(&scheduler, 1).await;
+    let b = scheduler
+        .acquire_with_quota(
+            TaskPriority::Foreground,
+            "provider-b:independent",
+            &provider_b,
+            None,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        scheduler.quota_snapshot(&provider_b).await.unwrap().active,
+        1
+    );
+    drop(b);
+    drop(holder);
+    let a = blocked_a.await.unwrap().unwrap();
+    drop(a);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn duplicate_quota_dimensions_are_rejected_before_enqueue() {
+    let scheduler = scheduler(1, 60_000);
+    let quota = TaskSchedulerQuota::for_scope("duplicate", 1).unwrap();
+    let result = scheduler
+        .acquire_with_quotas(
+            TaskPriority::Foreground,
+            "duplicate",
+            &[quota.clone(), quota],
+            None,
+            &CancellationToken::new(),
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(TaskSchedulerError::InvalidConfig(message))
+            if message.contains("duplicate quota")
+    ));
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn quota_only_admission_does_not_consume_global_slot() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let provider = TaskSchedulerQuota::for_scope("provider:leaf", 1).unwrap();
+    let global = scheduler
+        .acquire(
+            TaskPriority::Interactive,
+            "global",
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let leaf = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider:leaf-generation",
+            &provider,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert!(!leaf.consumes_global_slot());
+    assert!(global.consumes_global_slot());
+    assert_eq!(scheduler.stats().await.unwrap().active, 1);
+    assert_eq!(scheduler.quota_snapshot(&provider).await.unwrap().active, 1);
+    drop(leaf);
+    drop(global);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn quota_only_cancellation_releases_provider_state_and_allows_retry() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let provider = TaskSchedulerQuota::for_scope("provider:cancel", 1).unwrap();
+    let holder = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider:holder",
+            &provider,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let cancellation = CancellationToken::new();
+    let waiting = {
+        let scheduler = Arc::clone(&scheduler);
+        let provider = provider.clone();
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move {
+            scheduler
+                .acquire_quota(
+                    TaskPriority::Foreground,
+                    "provider:cancelled",
+                    &provider,
+                    &cancellation,
+                )
+                .await
+        })
+    };
+    wait_for_pending(&scheduler, 1).await;
+    cancellation.cancel();
+    assert!(matches!(
+        waiting.await.unwrap(),
+        Err(TaskSchedulerError::Cancelled)
+    ));
+    assert_eq!(
+        scheduler.quota_snapshot(&provider).await.unwrap().pending,
+        0
+    );
+    drop(holder);
+    let retry = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider:retry",
+            &provider,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    drop(retry);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn independent_quota_only_provider_progress_ignores_full_global_budget() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let global = scheduler
+        .acquire(
+            TaskPriority::Interactive,
+            "global-holder",
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let provider_a = TaskSchedulerQuota::for_scope("provider:quota-a", 1).unwrap();
+    let provider_b = TaskSchedulerQuota::for_scope("provider:quota-b", 1).unwrap();
+    let a = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider-a-generation",
+            &provider_a,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let b = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider-b-generation",
+            &provider_b,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert!(!a.consumes_global_slot());
+    assert!(!b.consumes_global_slot());
+    assert_eq!(scheduler.stats().await.unwrap().active, 1);
+    assert_eq!(
+        scheduler.quota_snapshot(&provider_a).await.unwrap().active,
+        1
+    );
+    assert_eq!(
+        scheduler.quota_snapshot(&provider_b).await.unwrap().active,
+        1
+    );
+    drop(b);
+    drop(a);
+    drop(global);
     scheduler.shutdown().await;
 }

--- a/core/src/tools/builtin/generate_object.rs
+++ b/core/src/tools/builtin/generate_object.rs
@@ -265,17 +265,43 @@ impl Tool for GenerateObjectTool {
             max_repair_attempts,
         };
 
+        let admission = ctx
+            .model_generation_admission()
+            .unwrap_or_else(|| self.admission.clone());
+        let mut preadmitted = ctx.model_generation_permit(&admission);
         let llm_client = ctx
             .llm_client()
             .unwrap_or_else(|| Arc::clone(&self.llm_client));
         let active_timeout = Duration::from_millis(timeout_ms);
-        let llm_client = llm_client
+        let mut llm_client = llm_client
             .with_active_generation_timeout(active_timeout)
             .unwrap_or(llm_client);
-        let admission = ctx
-            .model_generation_admission()
-            .unwrap_or_else(|| self.admission.clone());
-        let preadmitted = ctx.model_generation_permit(&admission);
+        // A governed LlmInvoker admits each underlying provider call. If an
+        // outer workflow already acquired a permit, transfer it into that
+        // facade for the first call; holding it around the whole structured
+        // repair transaction would recursively deadlock a single-flight pool.
+        let managed_generation = if llm_client.model_generation_is_managed() {
+            // Pass a clone so a third-party managed facade that declines the
+            // rebinding hook does not accidentally consume the only outer
+            // permit. In that fallback case the ordinary outer admission path
+            // remains responsible for the call.
+            match llm_client.bind_model_generation_admission(admission.clone(), preadmitted.clone())
+            {
+                Some(rebound) => {
+                    llm_client = rebound;
+                    preadmitted = None;
+                    true
+                }
+                None => {
+                    tracing::warn!(
+                        "managed LLM client did not provide a model-generation rebinding hook"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
         let cancellation = ctx.cancellation_token();
         let generation = async {
             if let Some(ref tx) = ctx.event_tx {
@@ -322,19 +348,23 @@ impl Tool for GenerateObjectTool {
                 .await
             }
         };
-        let execution = run_generation_with_admission(
-            &admission,
-            preadmitted,
-            &cancellation,
-            active_timeout,
-            generation,
-        )
-        .await;
-        let admission_metadata = generation_admission_metadata(
-            admission.concurrency(),
-            execution.queue_wait,
-            timeout_ms,
-        );
+        let execution = if managed_generation {
+            run_generation_without_admission(&cancellation, active_timeout, generation).await
+        } else {
+            run_generation_with_admission(
+                &admission,
+                preadmitted,
+                &cancellation,
+                active_timeout,
+                generation,
+            )
+            .await
+        };
+        let queue_wait = execution
+            .queue_wait
+            .saturating_add(llm_client.take_model_generation_queue_wait());
+        let admission_metadata =
+            generation_admission_metadata(admission.concurrency(), queue_wait, timeout_ms);
         let result = execution.result;
 
         match result {
@@ -505,6 +535,31 @@ where
     };
     drop(permit);
     GenerationExecution { result, queue_wait }
+}
+
+/// Run a structured transaction whose individual provider calls are admitted
+/// by a governed [`LlmClient`] facade. The outer deadline still covers the
+/// complete initial-plus-repair transaction, but no second semaphore is held
+/// around it (which would deadlock a single-flight provider while the facade
+/// is trying to start its first call).
+async fn run_generation_without_admission<T, F>(
+    cancellation: &tokio_util::sync::CancellationToken,
+    active_timeout: Duration,
+    generation: F,
+) -> GenerationExecution<T>
+where
+    F: Future<Output = anyhow::Result<T>>,
+{
+    let result = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => Err(GenerationStop::Cancelled),
+        _ = tokio::time::sleep(active_timeout) => Err(GenerationStop::TimedOut),
+        result = generation => result.map_err(GenerationStop::Failed),
+    };
+    GenerationExecution {
+        result,
+        queue_wait: Duration::ZERO,
+    }
 }
 
 fn generation_admission_metadata(

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -161,6 +161,17 @@ mod parallel_execution;
 
 const MAX_PARALLEL_TASKS_PER_CALL: usize = 32;
 
+fn provider_quota_for_client(
+    client: &dyn LlmClient,
+) -> Option<crate::task_scheduler::TaskSchedulerQuota> {
+    let pool = client.model_generation_pool()?;
+    crate::task_scheduler::TaskSchedulerQuota::new(
+        pool.identity.clone(),
+        pool.max_concurrency().get(),
+    )
+    .ok()
+}
+
 /// Task executor for delegated child runs.
 #[derive(Clone)]
 pub struct TaskExecutor {
@@ -211,6 +222,14 @@ pub struct TaskExecutor {
     /// Transient run/host scope used to derive the owner quota. Only the
     /// digest-derived identity crosses into the scheduler actor.
     admission_scope: Option<String>,
+    /// Provider/model capacity projected into the same scheduler actor as
+    /// owner admission. This is metadata only; the scheduler remains the
+    /// single live reservation authority.
+    provider_quota: Option<crate::task_scheduler::TaskSchedulerQuota>,
+    /// Shared provider admission for foreground child runs. Background runs
+    /// already hold `provider_quota` on their outer scheduler lease and use a
+    /// local child gate to avoid recursively reserving that same dimension.
+    provider_admission: Option<crate::llm::ModelGenerationAdmission>,
 }
 
 impl TaskExecutor {
@@ -220,6 +239,7 @@ impl TaskExecutor {
         llm_client: Arc<dyn LlmClient>,
         workspace: String,
     ) -> Self {
+        let provider_quota = provider_quota_for_client(llm_client.as_ref());
         Self {
             registry,
             llm_client,
@@ -242,6 +262,8 @@ impl TaskExecutor {
             task_scheduler: None,
             schedule_foreground: false,
             admission_scope: None,
+            provider_quota,
+            provider_admission: None,
         }
     }
 
@@ -262,6 +284,7 @@ impl TaskExecutor {
         workspace: String,
         mcp_managers: Vec<Arc<McpManager>>,
     ) -> Self {
+        let provider_quota = provider_quota_for_client(llm_client.as_ref());
         Self {
             registry,
             llm_client,
@@ -284,6 +307,8 @@ impl TaskExecutor {
             task_scheduler: None,
             schedule_foreground: false,
             admission_scope: None,
+            provider_quota,
+            provider_admission: None,
         }
     }
 
@@ -393,6 +418,18 @@ impl TaskExecutor {
         scheduler: Arc<crate::task_scheduler::TaskScheduler>,
         schedule_foreground: bool,
     ) -> Self {
+        self.provider_admission = self.provider_quota.clone().and_then(|quota| {
+            crate::llm::ModelGenerationAdmission::new(
+                self.llm_client.model_generation_concurrency(),
+            )
+            .with_scheduler_quota(
+                Arc::clone(&scheduler),
+                quota,
+                crate::task_scheduler::TaskPriority::Foreground,
+                "task-child-model-generation",
+            )
+            .ok()
+        });
         self.task_scheduler = Some(scheduler);
         self.schedule_foreground = schedule_foreground;
         self
@@ -606,44 +643,52 @@ impl TaskExecutor {
             };
         let _task_lease = if params.background || self.schedule_foreground {
             match &self.task_scheduler {
-                Some(scheduler) => Some(if let Some(quota) = admission_quota.as_ref() {
-                    scheduler
-                        .acquire_with_quota(
-                            if params.background {
-                                crate::task_scheduler::TaskPriority::Background
-                            } else {
-                                crate::task_scheduler::TaskPriority::Foreground
-                            },
-                            format!(
-                                "{}:subagent:{}",
-                                parent_session_id.unwrap_or("host"),
-                                task_id
-                            ),
-                            quota,
-                            execution_identity.clone(),
-                            &cancel_token,
-                        )
-                        .await
-                        .map_err(|error| anyhow::anyhow!(error))?
-                } else {
-                    scheduler
-                        .acquire_with_identity(
-                            if params.background {
-                                crate::task_scheduler::TaskPriority::Background
-                            } else {
-                                crate::task_scheduler::TaskPriority::Foreground
-                            },
-                            format!(
-                                "{}:subagent:{}",
-                                parent_session_id.unwrap_or("host"),
-                                task_id
-                            ),
-                            execution_identity.clone(),
-                            &cancel_token,
-                        )
-                        .await
-                        .map_err(|error| anyhow::anyhow!(error))?
-                }),
+                Some(scheduler) => {
+                    let mut quotas = Vec::with_capacity(2);
+                    if let Some(quota) = admission_quota.as_ref() {
+                        quotas.push(quota.clone());
+                    }
+                    if let Some(quota) = self.provider_quota.as_ref() {
+                        if !quotas
+                            .iter()
+                            .any(|candidate| candidate.identity == quota.identity)
+                        {
+                            quotas.push(quota.clone());
+                        }
+                    }
+                    let priority = if params.background {
+                        crate::task_scheduler::TaskPriority::Background
+                    } else {
+                        crate::task_scheduler::TaskPriority::Foreground
+                    };
+                    let label = format!(
+                        "{}:subagent:{}",
+                        parent_session_id.unwrap_or("host"),
+                        task_id
+                    );
+                    Some(if quotas.is_empty() {
+                        scheduler
+                            .acquire_with_identity(
+                                priority,
+                                label,
+                                execution_identity.clone(),
+                                &cancel_token,
+                            )
+                            .await
+                            .map_err(|error| anyhow::anyhow!(error))?
+                    } else {
+                        scheduler
+                            .acquire_with_quotas(
+                                priority,
+                                label,
+                                &quotas,
+                                execution_identity.clone(),
+                                &cancel_token,
+                            )
+                            .await
+                            .map_err(|error| anyhow::anyhow!(error))?
+                    })
+                }
                 None => None,
             }
         } else {
@@ -803,6 +848,11 @@ impl TaskExecutor {
             tool_context,
             child_config,
         );
+        if !params.background && !self.schedule_foreground {
+            if let Some(admission) = &self.provider_admission {
+                agent_loop = agent_loop.with_model_generation_admission(admission.clone());
+            }
+        }
         if let Some(runtime) = capability_runtime {
             agent_loop = agent_loop.with_capability_runtime(runtime);
         }

--- a/core/src/tools/types.rs
+++ b/core/src/tools/types.rs
@@ -683,10 +683,6 @@ impl ToolContext {
             .and_then(|reservation| reservation.claim(admission))
     }
 
-    pub(crate) fn has_model_generation_permit(&self) -> bool {
-        self.model_generation_permit.is_some()
-    }
-
     pub(crate) fn with_host_direct_policy(
         mut self,
         policy: super::invocation::HostDirectPolicy,


### PR DESCRIPTION
## Summary
- model provider pools now expose digest-only typed capacity identities
- one scheduler actor handles owner/provider multi-quota and quota-only leaf admissions
- regular, streaming, structured, direct-tool, delegated-task, and dynamic-workflow paths share cancellation-safe admission
- document the boundary and add cross-session, cancellation, stream-lifetime, and full-regression qualification

## Validation
- cargo +stable fmt --all
- cargo +stable clippy -p a3s-code-core --lib --tests --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo +stable doc -p a3s-code-core --no-deps
- cargo +stable test -p a3s-code-core --lib (3,200 passed; 13 ignored)