### PR TITLE
feat(core): expose provider pool health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added bounded provider-pool health evidence. `TaskScheduler::quota_health`
+  retains at most 64 recent digest-only quota epochs with admission, release,
+  cancellation, rejection, peak, and wait-time counters. Sessions expose the
+  composed `ModelGenerationPoolHealthSnapshot`, including local reservations
+  and shared-provider configuration, while credentials, routing labels, and
+  request payloads remain excluded. Nested admission rebinds preserve the
+  exact pool identity and independent pools remain isolated.
 - Added provider-aware model-generation admission. Built-in provider clients
   expose a digest-only `ModelGenerationPool` identity, and regular, streaming,
   and structured calls project that capacity into the existing agent-wide

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ explicit contracts. Use it from Rust, Node.js, Python, Go, or through the
   delegated children, direct tools, and dynamic workflows. Leaf generations
   reserve that capacity through the existing scheduler actor without creating a
   second queue; cancellation and dropped streams release both local and shared
-  reservations automatically.
+  reservations automatically. Rust hosts can inspect a secret-free
+  `ModelGenerationPoolHealthSnapshot`; the scheduler retains only a bounded
+  recent health window for completed pool epochs.
 - **Generation-fenced workflow replay.** New dynamic workflow runs pin the
   Code runtime build and expose a digest-only continuation identity derived
   from durable immutable facts. Changed source/input, conflicting step
@@ -198,7 +200,7 @@ telemetry remain opt-in.
 | Structured output       | Native provider formats or schema-validated prompt, partial parse, and repair fallback                                                                                                                                                  | Baseline                                                                                                                                                                  |
 | MCP and Skills          | Isolated MCP transports plus filesystem, registry, inline, and live session Skills                                                                                                                                                      | Configuration or live registration                                                                                                                                        |
 | Planning and delegation | Optional plans and goals, foreground/background workers, bounded parallel tasks, progress, and targeted cancellation                                                                                                                    | Manual tools independently configurable; automation opt-in                                                                                                                |
-| Priority scheduling     | Agent-wide `a3s-lane` priority/FIFO admission across sessions, direct tools, detached background children, and host workflows, with cancellation, starvation-safe aging, digest-only owner/provider quotas, quota-only leaf reservations, occupancy snapshots, and bounded cumulative health counters | Baseline; tune `task_scheduler`, select per-session `TaskPriority`, inspect `task_scheduler_stats()` or `task_scheduler_health()`; Rust hosts can use `TaskSchedulerQuota` for a scoped limit |
+| Priority scheduling     | Agent-wide `a3s-lane` priority/FIFO admission across sessions, direct tools, detached background children, and host workflows, with cancellation, starvation-safe aging, digest-only owner/provider quotas, quota-only leaf reservations, occupancy snapshots, and bounded cumulative health counters | Baseline; tune `task_scheduler`, select per-session `TaskPriority`, inspect `task_scheduler_stats()` or `task_scheduler_health()`; Rust hosts can use `TaskSchedulerQuota` for a scoped limit and `model_generation_pool_health()` for a session's provider pool |
 | Safe-point run control  | Typed, idempotent `steer` and cooperative `interrupt` requests with immutable Run identity, optimistic turn guards, bounded receipts, lifecycle Hooks, and durable event evidence                                                                 | Host invokes the Session control surface; requests never create a concurrent transcript operation and never change model, permissions, sandbox, or budget                    |
 | Programmable workflows  | Bounded QuickJS `program` calls, replayable A3S Flow-backed dynamic workflows, resumable step checkpoints, and digest-bound result receipts                                                                                              | `program` baseline; dynamic runtime explicitly registered                                                                                                                 |
 | Persistence             | Atomic snapshots, run events, traces, artifacts, verification, identity-bound workflow/Flow receipts, checkpoints, and optional RL trajectories                                                                                         | Configured store and host policy                                                                                                                                          |
@@ -333,6 +335,15 @@ actual blocking or streaming generation waits in the shared priority queue for
 the provider pool. Structured-output repairs release the first permit before
 the next call, so a single-flight provider cannot deadlock itself; a dropped
 stream releases its permit through the supervised proxy task.
+
+`AgentSession::model_generation_pool_health()` composes the local gate's
+reserved/available permits with the scheduler's digest-only per-pool counters.
+The scheduler keeps at most `TASK_SCHEDULER_QUOTA_HEALTH_RETENTION` idle quota
+epochs, so post-run admission, cancellation, and wait evidence remains useful
+without becoming a metrics store or retaining provider labels, credentials, or
+request payloads. A nested workflow rebind copies the exact pool identity while
+changing only its local limit; a different provider pool receives an independent
+health epoch and cannot consume the first pool's capacity.
 
 `Agent::new` accepts an ACL path or inline ACL. Build sessions asynchronously
 so configuration, stores, queues, MCP sources, and workspace services are

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,7 +58,7 @@ runtime mode. The cross-repository implementation plan is tracked in the
 | `WORKFLOW-CONTROL1` | Delivered | A host-facing dynamic-workflow control handle coordinates bounded inspection, trusted history, Flow durable cancellation/terminal transitions, identity-bound worker leases, and cross-process local event-store locking | Independent-process qualification covers busy ownership, killed-worker lease expiry/takeover, cancellation settlement, digest-only projections, and optimistic event-conflict retry; Flow remains the only workflow authority |
 | `WORKFLOW-OBS1` | Delivered | Scheduler and dynamic-workflow control diagnostics expose bounded admission, fairness, lease, and takeover counters without retaining task or workflow payloads | Independent resumed workers prove aging prevents starvation; scheduler wait/occupancy counters and durable claim-takeover counters converge while Flow history and the lease remain authoritative |
 | `WORKFLOW-QUOTA1` | Delivered | The existing scheduler actor enforces typed digest-only owner quotas for standalone Flow steps and detached Task children, propagates run identity through governed Tool contexts, and exposes a live quota projection without adding a queue or store | Mixed-owner progress, quota-blocked priority work, cancellation, identity/limit conflicts, malformed scopes, idle-state pruning, dynamic diagnostics, and detached fan-out qualification pass |
-| `MODEL-ADMISSION1` | Delivered | Provider/model capacity is represented by a typed digest-only `ModelGenerationPool`; regular, streaming, and structured calls reserve that capacity through quota-only admissions in the existing scheduler, with propagation through sessions, direct Tools, delegated children, and dynamic workflows | Cross-session and mixed-provider progress, local-plus-shared quota composition, structured repair without recursive deadlock, stream/cancellation release, endpoint-credential redaction, and the full Core regression suite pass |
+| `MODEL-ADMISSION1` | Delivered | Provider/model capacity is represented by a typed digest-only `ModelGenerationPool`; regular, streaming, and structured calls reserve that capacity through quota-only admissions in the existing scheduler, with propagation through sessions, direct Tools, delegated children, and dynamic workflows | Cross-session and mixed-provider progress, local-plus-shared quota composition, structured repair without recursive deadlock, stream/cancellation release, endpoint-credential redaction, bounded per-pool health/configuration evidence, and the full Core regression suite pass |
 
 Observation precedes mutation: `CAR-02` must provide useful read-only context
 diagnostics before `CAR-03` can reduce any Tool result. The first transform
@@ -464,9 +464,21 @@ payloads.
 Qualification covers two sessions sharing one provider pool, independent
 provider progress under a full global budget, atomic multi-quota admission,
 quota-only cancellation and release, managed stream lifetime, nested tighter
-workflow limits, and the complete 3,199-test Core library suite. This slice
+workflow limits, and the complete 3,205-test Core library suite. This slice
 does not add provider rate-limit policy, billing, or a second scheduler;
 Gateway and host policy remain the owners of those concerns.
+
+The admission-hardening follow-up adds `TaskScheduler::quota_health` as a
+read-only projection over the same actor. It records admission, release,
+cancellation, and rejection counts, peak occupancy, and bounded wait
+aggregates for one digest-only quota, retaining at most 64 idle epochs and
+pruning older identities deterministically. `ModelGenerationPoolHealthSnapshot`
+composes that shared view with each facade's local reserved/available permits
+and the immutable pool descriptor; `AgentSession::model_generation_pool_health()`
+is the host-facing Rust surface. Runtime rebinds copy the exact pool identity
+while allowing a tighter local limit, and distinct provider identities retain
+isolated health epochs. No provider label, endpoint credential, prompt, output,
+or task label is added to scheduler state.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/agent_api/session_builder.rs
+++ b/core/src/agent_api/session_builder.rs
@@ -199,15 +199,10 @@ fn finish_agent_session(
     let model_generation_admission =
         crate::llm::ModelGenerationAdmission::new(llm_client.model_generation_concurrency());
     let model_generation_admission = if let Some(pool) = llm_client.model_generation_pool() {
-        let quota = crate::task_scheduler::TaskSchedulerQuota::new(
-            pool.identity.clone(),
-            pool.max_concurrency().get(),
-        )
-        .map_err(|error| crate::error::CodeError::Config(error.to_string()))?;
         model_generation_admission
-            .with_scheduler_quota(
+            .with_model_generation_pool(
                 Arc::clone(&agent.task_scheduler),
-                quota,
+                pool,
                 opts.task_priority,
                 format!("model-generation:{}", resolved.session_id),
             )

--- a/core/src/agent_api/session_facade.rs
+++ b/core/src/agent_api/session_facade.rs
@@ -37,6 +37,17 @@ impl AgentSession {
         self.task_scheduler.health().await
     }
 
+    /// Return secret-free configuration and bounded health for this session's
+    /// provider/model generation pool, when the client publishes one.
+    pub async fn model_generation_pool_health(
+        &self,
+    ) -> std::result::Result<
+        Option<crate::llm::ModelGenerationPoolHealthSnapshot>,
+        crate::task_scheduler::TaskSchedulerError,
+    > {
+        self.model_generation_admission.pool_health().await
+    }
+
     /// Get a snapshot of command entries (name, description, optional usage).
     ///
     /// Acquires the command registry lock briefly and returns owned data.

--- a/core/src/agent_api/tests.rs
+++ b/core/src/agent_api/tests.rs
@@ -1165,6 +1165,20 @@ async fn concurrent_session_direct_generations_share_provider_admission() {
         queue_waits[1] >= 80,
         "the second direct generation should wait for session capacity: {queue_waits:?}"
     );
+    let pool_health = session
+        .model_generation_pool_health()
+        .await
+        .unwrap()
+        .expect("the test client publishes a provider pool");
+    let scheduler_health = pool_health
+        .scheduler
+        .expect("session provider admission is scheduler-bound");
+    assert!(scheduler_health.observed);
+    assert!(!scheduler_health.live);
+    assert_eq!(scheduler_health.active, 0);
+    assert_eq!(scheduler_health.pending, 0);
+    assert_eq!(scheduler_health.admitted, 2);
+    assert_eq!(scheduler_health.released, 2);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1215,6 +1229,17 @@ async fn independent_sessions_share_scheduler_backed_provider_generation_capacit
         1,
         "sessions sharing one provider pool must not exceed its capacity"
     );
+    let pool_health = first
+        .model_generation_pool_health()
+        .await
+        .unwrap()
+        .expect("the test client publishes a provider pool");
+    let scheduler_health = pool_health
+        .scheduler
+        .expect("session provider admission is scheduler-bound");
+    assert!(scheduler_health.observed);
+    assert!(scheduler_health.admitted >= 2);
+    assert!(scheduler_health.released >= 2);
     agent.close().await;
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -297,7 +297,8 @@ pub use llm::{
     clear_http_metrics_callback, set_http_metrics_callback, AnthropicClient, Attachment,
     ContentBlock, HttpMetricsCallback, HttpMetricsRecord, ImageSource, LlmClient, LlmResponse,
     Message, ModelGenerationAdmission, ModelGenerationAdmissionError, ModelGenerationConcurrency,
-    ModelGenerationPermit, ModelGenerationPool, ModelGenerationPoolError, OpenAiClient, TokenUsage,
+    ModelGenerationPermit, ModelGenerationPool, ModelGenerationPoolError,
+    ModelGenerationPoolHealthSnapshot, OpenAiClient, TokenUsage,
 };
 #[cfg(feature = "headless-search")]
 pub use moli_runtime::{
@@ -362,8 +363,9 @@ pub use subagent_task_tracker::{
 pub use task_scheduler::{
     TaskLease, TaskPriority, TaskPriorityCounts, TaskScheduler, TaskSchedulerConfig,
     TaskSchedulerError, TaskSchedulerHealthSnapshot, TaskSchedulerQuota,
-    TaskSchedulerQuotaSnapshot, TaskSchedulerStats, TASK_SCHEDULER_MAX_QUOTAS,
-    TASK_SCHEDULER_MAX_SCOPE_BYTES,
+    TaskSchedulerQuotaHealthSnapshot, TaskSchedulerQuotaSnapshot, TaskSchedulerStats,
+    TASK_SCHEDULER_MAX_QUOTAS, TASK_SCHEDULER_MAX_SCOPE_BYTES,
+    TASK_SCHEDULER_QUOTA_HEALTH_RETENTION,
 };
 pub use tools::{
     ImmutableContentAdapter, ImmutableContentAdapterBindingV1, ImmutableContentAdapterSession,

--- a/core/src/llm/admission.rs
+++ b/core/src/llm/admission.rs
@@ -208,6 +208,9 @@ struct BoundedAdmission {
     max_concurrency: NonZeroUsize,
     semaphore: Arc<Semaphore>,
     scheduler: Option<Arc<SchedulerBinding>>,
+    /// Optional immutable provider pool descriptor used by host diagnostics.
+    /// The descriptor contains only a digest identity and numeric capacity.
+    pool: Option<ModelGenerationPool>,
 }
 
 #[derive(Debug)]
@@ -227,6 +230,30 @@ pub struct ModelGenerationAdmission {
     bounded: Arc<BoundedAdmission>,
 }
 
+/// Read-only, secret-free configuration and occupancy evidence for one model
+/// generation pool.
+///
+/// `local_reserved` includes permits waiting for the shared scheduler after
+/// acquiring the local client gate; it is therefore intentionally distinct
+/// from provider calls that have reached the transport. The optional scheduler
+/// projection carries the same pool identity and retains a bounded recent
+/// health epoch after the final reservation is released.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ModelGenerationPoolHealthSnapshot {
+    /// Immutable provider/model capacity descriptor.
+    pub pool: ModelGenerationPool,
+    /// Effective local gate limit for this admission facade.
+    pub local_max_concurrency: usize,
+    /// Local permits currently reserved by this facade.
+    pub local_reserved: usize,
+    /// Local permits immediately available to this facade.
+    pub local_available: usize,
+    /// Shared scheduler health for this pool, when the facade is scheduler-bound.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<crate::task_scheduler::TaskSchedulerQuotaHealthSnapshot>,
+}
+
 impl ModelGenerationAdmission {
     pub fn new(concurrency: ModelGenerationConcurrency) -> Self {
         let max_concurrency = concurrency.max_concurrency();
@@ -234,6 +261,7 @@ impl ModelGenerationAdmission {
             max_concurrency,
             semaphore: Arc::new(Semaphore::new(max_concurrency.get())),
             scheduler: None,
+            pool: None,
         });
         Self { bounded }
     }
@@ -248,7 +276,46 @@ impl ModelGenerationAdmission {
         priority: crate::task_scheduler::TaskPriority,
         label: impl Into<String>,
     ) -> Result<Self, crate::task_scheduler::TaskSchedulerError> {
+        self.with_scheduler_binding(scheduler, quota, priority, label.into(), None)
+    }
+
+    /// Attach a provider pool descriptor and its shared scheduler quota.
+    ///
+    /// The pool is configuration evidence only; live reservations continue to
+    /// be owned by the existing scheduler actor and local semaphore.
+    pub fn with_model_generation_pool(
+        self,
+        scheduler: Arc<crate::task_scheduler::TaskScheduler>,
+        pool: ModelGenerationPool,
+        priority: crate::task_scheduler::TaskPriority,
+        label: impl Into<String>,
+    ) -> Result<Self, crate::task_scheduler::TaskSchedulerError> {
+        pool.validate().map_err(|error| {
+            crate::task_scheduler::TaskSchedulerError::InvalidConfig(error.to_string())
+        })?;
+        let quota = crate::task_scheduler::TaskSchedulerQuota::new(
+            pool.identity.clone(),
+            pool.max_concurrency.get(),
+        )?;
+        self.with_scheduler_binding(scheduler, quota, priority, label.into(), Some(pool))
+    }
+
+    fn with_scheduler_binding(
+        self,
+        scheduler: Arc<crate::task_scheduler::TaskScheduler>,
+        quota: crate::task_scheduler::TaskSchedulerQuota,
+        priority: crate::task_scheduler::TaskPriority,
+        label: String,
+        pool: Option<ModelGenerationPool>,
+    ) -> Result<Self, crate::task_scheduler::TaskSchedulerError> {
         quota.validate()?;
+        if let Some(pool) = &pool {
+            if pool.identity != quota.identity || pool.max_concurrency.get() != quota.max_active {
+                return Err(crate::task_scheduler::TaskSchedulerError::InvalidConfig(
+                    "model-generation pool and scheduler quota do not match".to_string(),
+                ));
+            }
+        }
         let bounded = Arc::new(BoundedAdmission {
             max_concurrency: self.bounded.max_concurrency,
             semaphore: Arc::clone(&self.bounded.semaphore),
@@ -256,8 +323,9 @@ impl ModelGenerationAdmission {
                 scheduler,
                 quota,
                 priority,
-                label: label.into(),
+                label,
             })),
+            pool,
         });
         Ok(Self { bounded })
     }
@@ -274,11 +342,12 @@ impl ModelGenerationAdmission {
         let Some(binding) = source.bounded.scheduler.as_ref() else {
             return Ok(self);
         };
-        self.with_scheduler_quota(
+        self.with_scheduler_binding(
             Arc::clone(&binding.scheduler),
             binding.quota.clone(),
             binding.priority,
-            label,
+            label.into(),
+            source.bounded.pool.clone(),
         )
     }
 
@@ -290,6 +359,33 @@ impl ModelGenerationAdmission {
     /// scheduler actor.
     pub(crate) fn has_scheduler_quota(&self) -> bool {
         self.bounded.scheduler.is_some()
+    }
+
+    /// Return secret-free pool configuration and point-in-time health.
+    ///
+    /// `None` means this admission was created for a custom client that did
+    /// not publish a [`ModelGenerationPool`].
+    pub async fn pool_health(
+        &self,
+    ) -> Result<Option<ModelGenerationPoolHealthSnapshot>, crate::task_scheduler::TaskSchedulerError>
+    {
+        let Some(pool) = self.bounded.pool.clone() else {
+            return Ok(None);
+        };
+        let local_max_concurrency = self.bounded.max_concurrency.get();
+        let local_available = self.bounded.semaphore.available_permits();
+        let local_reserved = local_max_concurrency.saturating_sub(local_available);
+        let scheduler = match self.bounded.scheduler.as_ref() {
+            Some(binding) => Some(binding.scheduler.quota_health(&binding.quota).await?),
+            None => None,
+        };
+        Ok(Some(ModelGenerationPoolHealthSnapshot {
+            pool,
+            local_max_concurrency,
+            local_reserved,
+            local_available,
+            scheduler,
+        }))
     }
 
     /// Wait for active-generation capacity without applying an active
@@ -635,6 +731,115 @@ mod tests {
         .expect("provider quota should be released")
         .unwrap();
         drop(replacement);
+        scheduler.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn pool_health_composes_local_and_scheduler_capacity_without_routing_text() {
+        let scheduler = Arc::new(
+            crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+                max_active: 1,
+                aging_interval_ms: 60_000,
+            })
+            .unwrap(),
+        );
+        let pool = ModelGenerationPool::for_client(
+            "secret-provider-name",
+            "secret-model-name",
+            Some("https://provider.test/v1/chat?api_key=secret"),
+            Some("private-account"),
+            ModelGenerationConcurrency::single_flight(),
+        )
+        .unwrap();
+        let admission = ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+            .with_model_generation_pool(
+                Arc::clone(&scheduler),
+                pool.clone(),
+                crate::task_scheduler::TaskPriority::Foreground,
+                "secret-session-label",
+            )
+            .unwrap();
+
+        let configured = admission.pool_health().await.unwrap().unwrap();
+        assert_eq!(configured.pool, pool);
+        assert_eq!(configured.local_max_concurrency, 1);
+        assert_eq!(configured.local_reserved, 0);
+        assert_eq!(configured.local_available, 1);
+        assert!(!configured.scheduler.as_ref().unwrap().observed);
+
+        let permit = admission.acquire(&CancellationToken::new()).await.unwrap();
+        let active = admission.pool_health().await.unwrap().unwrap();
+        assert_eq!(active.local_reserved, 1);
+        assert_eq!(active.local_available, 0);
+        assert!(active.scheduler.as_ref().unwrap().live);
+        assert_eq!(active.scheduler.as_ref().unwrap().active, 1);
+
+        drop(permit);
+        let retained = admission.pool_health().await.unwrap().unwrap();
+        assert_eq!(retained.local_reserved, 0);
+        assert_eq!(retained.scheduler.as_ref().unwrap().released, 1);
+        assert!(!retained.scheduler.as_ref().unwrap().live);
+        let encoded = serde_json::to_string(&retained).unwrap();
+        for secret in [
+            "secret-provider-name",
+            "secret-model-name",
+            "provider.test",
+            "api_key",
+            "private-account",
+            "secret-session-label",
+        ] {
+            assert!(!encoded.contains(secret), "snapshot leaked {secret}");
+        }
+        scheduler.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn nested_runtime_rebind_retains_the_exact_provider_pool_health() {
+        let scheduler = Arc::new(
+            crate::task_scheduler::TaskScheduler::new(crate::task_scheduler::TaskSchedulerConfig {
+                max_active: 1,
+                aging_interval_ms: 60_000,
+            })
+            .unwrap(),
+        );
+        let pool = ModelGenerationPool::for_endpoint(
+            "provider",
+            "model",
+            "https://provider.test",
+            ModelGenerationConcurrency::bounded(NonZeroUsize::new(2).unwrap()),
+        )
+        .unwrap();
+        let session = ModelGenerationAdmission::new(ModelGenerationConcurrency::bounded(
+            NonZeroUsize::new(2).unwrap(),
+        ))
+        .with_model_generation_pool(
+            Arc::clone(&scheduler),
+            pool.clone(),
+            crate::task_scheduler::TaskPriority::Foreground,
+            "session-generation",
+        )
+        .unwrap();
+        let nested = ModelGenerationAdmission::new(ModelGenerationConcurrency::single_flight())
+            .with_scheduler_quota_from(&session, "nested-generation")
+            .unwrap();
+
+        let health = nested.pool_health().await.unwrap().unwrap();
+        assert_eq!(health.pool, pool);
+        assert_eq!(health.local_max_concurrency, 1);
+        assert_eq!(health.scheduler.as_ref().unwrap().max_active, 2);
+        let permit = nested.acquire(&CancellationToken::new()).await.unwrap();
+        assert_eq!(
+            session
+                .pool_health()
+                .await
+                .unwrap()
+                .unwrap()
+                .scheduler
+                .unwrap()
+                .active,
+            1
+        );
+        drop(permit);
         scheduler.shutdown().await;
     }
 }

--- a/core/src/llm/mod.rs
+++ b/core/src/llm/mod.rs
@@ -19,6 +19,7 @@ pub mod zhipu;
 pub use admission::{
     ModelGenerationAdmission, ModelGenerationAdmissionError, ModelGenerationConcurrency,
     ModelGenerationPermit, ModelGenerationPool, ModelGenerationPoolError,
+    ModelGenerationPoolHealthSnapshot,
 };
 pub use anthropic::AnthropicClient;
 pub use codex_login::CodexLoginClient;

--- a/core/src/task_scheduler.rs
+++ b/core/src/task_scheduler.rs
@@ -7,7 +7,7 @@
 use crate::execution_identity::ExecutionIdentityV1;
 use a3s_lane::{Priority, PriorityItem, PriorityQueue};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -30,6 +30,13 @@ pub const TASK_SCHEDULER_MAX_SCOPE_BYTES: usize = 512;
 /// accounting predictable even when a host composes owner, provider, tenant,
 /// or other typed capacity descriptors.
 pub const TASK_SCHEDULER_MAX_QUOTAS: usize = 8;
+/// Maximum number of idle quota health epochs retained by one scheduler.
+///
+/// Live quotas are always observable. Once their final reservation and waiter
+/// settle, only this many most-recent digest-only records remain available for
+/// post-run diagnostics. The bound prevents ephemeral Run or provider
+/// identities from becoming an unbounded process history.
+pub const TASK_SCHEDULER_QUOTA_HEALTH_RETENTION: usize = 64;
 
 /// Relative importance of work admitted through an agent's shared scheduler.
 ///
@@ -218,6 +225,47 @@ pub struct TaskSchedulerQuotaSnapshot {
     pub pending: usize,
     /// Whether pending work is currently blocked by the owner quota.
     pub blocked: bool,
+}
+
+/// Bounded live-or-recent health for one scheduler quota identity.
+///
+/// Unlike [`TaskSchedulerQuotaSnapshot`], this projection retains cumulative
+/// counters for a small bounded window after a quota becomes idle. It contains
+/// only the validated digest identity and numeric capacity data; scheduler
+/// labels, provider routing text, prompts, and payloads are never retained.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TaskSchedulerQuotaHealthSnapshot {
+    /// Digest-only quota identity requested by the caller.
+    pub identity: ExecutionIdentityV1,
+    /// Immutable limit for this observed configuration epoch.
+    pub max_active: usize,
+    /// Whether this scheduler has observed the requested identity/limit epoch.
+    pub observed: bool,
+    /// Whether the quota currently has an active reservation or queued waiter.
+    pub live: bool,
+    /// Current active reservations for this identity.
+    pub active: usize,
+    /// Current queued requests for this identity.
+    pub pending: usize,
+    /// Whether pending work is currently blocked by this quota.
+    pub blocked: bool,
+    /// Successful admissions observed in the retained epoch.
+    pub admitted: u64,
+    /// Normally released reservations observed in the retained epoch.
+    pub released: u64,
+    /// Queued or active admissions cancelled by their caller.
+    pub cancelled: u64,
+    /// Pending admissions rejected while the scheduler was closing.
+    pub rejected: u64,
+    /// Highest simultaneous reservation count observed for this identity.
+    pub peak_active: usize,
+    /// Saturating sum of successful admission wait time in microseconds.
+    pub total_wait_micros: u64,
+    /// Mean successful admission wait time in microseconds.
+    pub average_wait_micros: u64,
+    /// Longest successful admission wait time in microseconds.
+    pub max_wait_micros: u64,
 }
 
 const fn default_max_active() -> usize {
@@ -562,6 +610,30 @@ impl TaskScheduler {
         rx.await.map_err(|_| TaskSchedulerError::Closed)?
     }
 
+    /// Return bounded cumulative health for one quota identity.
+    ///
+    /// The scheduler keeps a fixed number of recent idle quota epochs so a
+    /// host can inspect a completed provider generation without turning the
+    /// actor into an unbounded metrics store. A descriptor that has never been
+    /// admitted returns `observed = false` and zero counters.
+    pub async fn quota_health(
+        &self,
+        quota: &TaskSchedulerQuota,
+    ) -> Result<TaskSchedulerQuotaHealthSnapshot, TaskSchedulerError> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err(TaskSchedulerError::Closed);
+        }
+        quota.validate()?;
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(SchedulerMessage::QuotaHealth {
+                quota: quota.clone(),
+                reply: tx,
+            })
+            .map_err(|_| TaskSchedulerError::Closed)?;
+        rx.await.map_err(|_| TaskSchedulerError::Closed)?
+    }
+
     /// Return a consistent actor-owned occupancy snapshot.
     pub async fn stats(&self) -> Result<TaskSchedulerStats, TaskSchedulerError> {
         if self.closed.load(Ordering::Acquire) {
@@ -680,6 +752,10 @@ enum SchedulerMessage {
         quota: TaskSchedulerQuota,
         reply: oneshot::Sender<Result<TaskSchedulerQuotaSnapshot, TaskSchedulerError>>,
     },
+    QuotaHealth {
+        quota: TaskSchedulerQuota,
+        reply: oneshot::Sender<Result<TaskSchedulerQuotaHealthSnapshot, TaskSchedulerError>>,
+    },
     Shutdown(oneshot::Sender<()>),
 }
 
@@ -701,6 +777,10 @@ struct SchedulerState {
     cancelled: HashSet<u64>,
     active: HashMap<u64, ActiveAdmission>,
     quotas: HashMap<String, QuotaState>,
+    /// Recently idle quota epochs, bounded by
+    /// [`TASK_SCHEDULER_QUOTA_HEALTH_RETENTION`].
+    retained_quota_health: HashMap<String, QuotaState>,
+    retained_quota_order: VecDeque<String>,
     closing: bool,
     shutdown_waiters: Vec<oneshot::Sender<()>>,
     counters: SchedulerCounters,
@@ -717,6 +797,54 @@ struct QuotaState {
     max_active: usize,
     active: usize,
     pending: usize,
+    admitted: u64,
+    released: u64,
+    cancelled: u64,
+    rejected: u64,
+    peak_active: usize,
+    total_wait_micros: u64,
+    max_wait_micros: u64,
+}
+
+impl QuotaState {
+    fn new(identity: ExecutionIdentityV1, max_active: usize) -> Self {
+        Self {
+            identity,
+            max_active,
+            active: 0,
+            pending: 0,
+            admitted: 0,
+            released: 0,
+            cancelled: 0,
+            rejected: 0,
+            peak_active: 0,
+            total_wait_micros: 0,
+            max_wait_micros: 0,
+        }
+    }
+
+    fn health_snapshot(&self, live: bool) -> TaskSchedulerQuotaHealthSnapshot {
+        TaskSchedulerQuotaHealthSnapshot {
+            identity: self.identity.clone(),
+            max_active: self.max_active,
+            observed: true,
+            live,
+            active: self.active,
+            pending: self.pending,
+            blocked: self.pending > 0 && self.active >= self.max_active,
+            admitted: self.admitted,
+            released: self.released,
+            cancelled: self.cancelled,
+            rejected: self.rejected,
+            peak_active: self.peak_active,
+            total_wait_micros: self.total_wait_micros,
+            average_wait_micros: self
+                .total_wait_micros
+                .checked_div(self.admitted)
+                .unwrap_or(0),
+            max_wait_micros: self.max_wait_micros,
+        }
+    }
 }
 
 async fn run_scheduler(
@@ -729,6 +857,8 @@ async fn run_scheduler(
         pending: PriorityQueue::new(),
         cancelled: HashSet::new(),
         active: HashMap::new(),
+        retained_quota_health: HashMap::new(),
+        retained_quota_order: VecDeque::new(),
         quotas: HashMap::new(),
         closing: false,
         shutdown_waiters: Vec::new(),
@@ -757,7 +887,7 @@ async fn run_scheduler(
             SchedulerMessage::Cancel(id) => {
                 if let Some(active) = state.active.remove(&id) {
                     state.counters.cancelled = state.counters.cancelled.saturating_add(1);
-                    state.release_active_quotas(&active.quota_identities);
+                    state.release_active_quotas(&active.quota_identities, true);
                 } else {
                     state.cancelled.insert(id);
                     state.purge_cancelled();
@@ -768,7 +898,7 @@ async fn run_scheduler(
             SchedulerMessage::Release(id) => {
                 if let Some(active) = state.active.remove(&id) {
                     state.counters.released = state.counters.released.saturating_add(1);
-                    state.release_active_quotas(&active.quota_identities);
+                    state.release_active_quotas(&active.quota_identities, false);
                 }
                 state.dispatch();
                 state.finish_shutdown_if_idle();
@@ -786,6 +916,10 @@ async fn run_scheduler(
             }
             SchedulerMessage::QuotaStats { quota, reply } => {
                 let result = state.quota_snapshot(&quota);
+                let _ = reply.send(result);
+            }
+            SchedulerMessage::QuotaHealth { quota, reply } => {
+                let result = state.quota_health(&quota);
                 let _ = reply.send(result);
             }
             SchedulerMessage::Shutdown(reply) => {
@@ -812,6 +946,36 @@ async fn run_scheduler(
 }
 
 impl SchedulerState {
+    fn retain_quota_health(&mut self, key: String, state: QuotaState) {
+        self.retained_quota_health.remove(&key);
+        self.retained_quota_order
+            .retain(|candidate| candidate != &key);
+        self.retained_quota_health.insert(key.clone(), state);
+        self.retained_quota_order.push_back(key);
+        while self.retained_quota_order.len() > TASK_SCHEDULER_QUOTA_HEALTH_RETENTION {
+            let Some(evicted) = self.retained_quota_order.pop_front() else {
+                break;
+            };
+            self.retained_quota_health.remove(&evicted);
+        }
+    }
+
+    fn take_retained_quota_health(
+        &mut self,
+        key: &str,
+        identity: &ExecutionIdentityV1,
+        max_active: usize,
+    ) -> Option<QuotaState> {
+        let state = self.retained_quota_health.remove(key)?;
+        self.retained_quota_order
+            .retain(|candidate| candidate != key);
+        if state.identity == *identity && state.max_active == max_active {
+            Some(state)
+        } else {
+            None
+        }
+    }
+
     fn register_pending_quotas(
         &mut self,
         quotas: &[TaskSchedulerQuota],
@@ -831,12 +995,13 @@ impl SchedulerState {
         }
         for quota in quotas {
             let key = quota.identity.digest.clone();
-            self.quotas.entry(key).or_insert_with(|| QuotaState {
-                identity: quota.identity.clone(),
-                max_active: quota.max_active,
-                active: 0,
-                pending: 0,
-            });
+            if self.quotas.contains_key(&key) {
+                continue;
+            }
+            let state = self
+                .take_retained_quota_health(&key, &quota.identity, quota.max_active)
+                .unwrap_or_else(|| QuotaState::new(quota.identity.clone(), quota.max_active));
+            self.quotas.insert(key, state);
         }
         Ok(())
     }
@@ -846,6 +1011,7 @@ impl SchedulerState {
             let key = quota.identity.digest.as_str();
             if let Some(state) = self.quotas.get_mut(key) {
                 state.pending = state.pending.saturating_sub(1);
+                state.rejected = state.rejected.saturating_add(1);
             }
             self.prune_idle_quota(key);
         }
@@ -853,14 +1019,26 @@ impl SchedulerState {
 
     fn cancel_pending(&mut self, item: QueuedAdmission) {
         self.counters.cancelled = self.counters.cancelled.saturating_add(1);
-        self.reject_pending_quotas(&item.quotas);
+        for quota in &item.quotas {
+            let key = quota.identity.digest.as_str();
+            if let Some(state) = self.quotas.get_mut(key) {
+                state.pending = state.pending.saturating_sub(1);
+                state.cancelled = state.cancelled.saturating_add(1);
+            }
+            self.prune_idle_quota(key);
+        }
         let _ = item.ready.send(Err(TaskSchedulerError::Cancelled));
     }
 
-    fn release_active_quotas(&mut self, keys: &[String]) {
+    fn release_active_quotas(&mut self, keys: &[String], cancelled: bool) {
         for key in keys {
             if let Some(state) = self.quotas.get_mut(key) {
                 state.active = state.active.saturating_sub(1);
+                if cancelled {
+                    state.cancelled = state.cancelled.saturating_add(1);
+                } else {
+                    state.released = state.released.saturating_add(1);
+                }
             }
             self.prune_idle_quota(key);
         }
@@ -872,7 +1050,9 @@ impl SchedulerState {
             .get(key)
             .is_some_and(|state| state.active == 0 && state.pending == 0);
         if remove {
-            self.quotas.remove(key);
+            if let Some(state) = self.quotas.remove(key) {
+                self.retain_quota_health(key.to_owned(), state);
+            }
         }
     }
 
@@ -910,6 +1090,44 @@ impl SchedulerState {
             active: 0,
             pending: 0,
             blocked: false,
+        })
+    }
+
+    fn quota_health(
+        &self,
+        quota: &TaskSchedulerQuota,
+    ) -> Result<TaskSchedulerQuotaHealthSnapshot, TaskSchedulerError> {
+        quota.validate()?;
+        if let Some(state) = self.quotas.get(&quota.identity.digest) {
+            if state.identity != quota.identity || state.max_active != quota.max_active {
+                return Err(TaskSchedulerError::InvalidConfig(
+                    "scheduler quota identity is already registered with a different limit"
+                        .to_string(),
+                ));
+            }
+            return Ok(state.health_snapshot(true));
+        }
+        if let Some(state) = self.retained_quota_health.get(&quota.identity.digest) {
+            if state.identity == quota.identity && state.max_active == quota.max_active {
+                return Ok(state.health_snapshot(false));
+            }
+        }
+        Ok(TaskSchedulerQuotaHealthSnapshot {
+            identity: quota.identity.clone(),
+            max_active: quota.max_active,
+            observed: false,
+            live: false,
+            active: 0,
+            pending: 0,
+            blocked: false,
+            admitted: 0,
+            released: 0,
+            cancelled: 0,
+            rejected: 0,
+            peak_active: 0,
+            total_wait_micros: 0,
+            average_wait_micros: 0,
+            max_wait_micros: 0,
         })
     }
 
@@ -985,7 +1203,7 @@ impl SchedulerState {
             if item.ready.send(Ok(())).is_err() {
                 self.active.remove(&id);
                 self.counters.cancelled = self.counters.cancelled.saturating_add(1);
-                self.release_active_quotas(&quota_identities);
+                self.release_active_quotas(&quota_identities, true);
                 continue;
             }
             self.counters.admitted = self.counters.admitted.saturating_add(1);
@@ -993,6 +1211,15 @@ impl SchedulerState {
                 self.counters.total_wait_micros.saturating_add(wait_micros);
             self.counters.max_wait_micros = self.counters.max_wait_micros.max(wait_micros);
             self.counters.peak_active = self.counters.peak_active.max(self.global_active_count());
+            for quota_key in &quota_identities {
+                if let Some(quota_state) = self.quotas.get_mut(quota_key) {
+                    quota_state.admitted = quota_state.admitted.saturating_add(1);
+                    quota_state.total_wait_micros =
+                        quota_state.total_wait_micros.saturating_add(wait_micros);
+                    quota_state.max_wait_micros = quota_state.max_wait_micros.max(wait_micros);
+                    quota_state.peak_active = quota_state.peak_active.max(quota_state.active);
+                }
+            }
             tracing::trace!(
                 admission_id = id,
                 ?priority,

--- a/core/src/task_scheduler/tests.rs
+++ b/core/src/task_scheduler/tests.rs
@@ -924,3 +924,160 @@ async fn independent_quota_only_provider_progress_ignores_full_global_budget() {
     drop(global);
     scheduler.shutdown().await;
 }
+
+#[tokio::test]
+async fn quota_health_retains_bounded_counters_after_the_pool_becomes_idle() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let provider = TaskSchedulerQuota::for_scope("provider:health", 1).unwrap();
+    let first = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider-health:first",
+            &provider,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let waiting = {
+        let scheduler = Arc::clone(&scheduler);
+        let provider = provider.clone();
+        tokio::spawn(async move {
+            scheduler
+                .acquire_quota(
+                    TaskPriority::Background,
+                    "provider-health:waiting",
+                    &provider,
+                    &CancellationToken::new(),
+                )
+                .await
+        })
+    };
+    wait_for_pending(&scheduler, 1).await;
+    tokio::time::sleep(Duration::from_millis(2)).await;
+
+    let blocked = scheduler.quota_health(&provider).await.unwrap();
+    assert!(blocked.observed);
+    assert!(blocked.live);
+    assert_eq!(blocked.active, 1);
+    assert_eq!(blocked.pending, 1);
+    assert!(blocked.blocked);
+    assert_eq!(blocked.admitted, 1);
+    assert_eq!(blocked.released, 0);
+
+    drop(first);
+    let second = waiting.await.unwrap().unwrap();
+    let admitted = scheduler.quota_health(&provider).await.unwrap();
+    assert_eq!(admitted.active, 1);
+    assert_eq!(admitted.pending, 0);
+    assert_eq!(admitted.admitted, 2);
+    assert_eq!(admitted.released, 1);
+    assert_eq!(admitted.peak_active, 1);
+    assert!(admitted.total_wait_micros > 0);
+    assert!(admitted.max_wait_micros >= admitted.average_wait_micros);
+
+    drop(second);
+    let retained = scheduler.quota_health(&provider).await.unwrap();
+    assert!(retained.observed);
+    assert!(!retained.live);
+    assert_eq!(retained.active, 0);
+    assert_eq!(retained.pending, 0);
+    assert_eq!(retained.admitted, 2);
+    assert_eq!(retained.released, 2);
+    let encoded = serde_json::to_string(&retained).unwrap();
+    assert!(!encoded.contains("provider:health"));
+    assert!(!encoded.contains("provider-health:first"));
+    assert!(!encoded.contains("provider-health:waiting"));
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn quota_health_records_cancellation_and_isolation_between_provider_pools() {
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let provider_a = TaskSchedulerQuota::for_scope("provider:health-a", 1).unwrap();
+    let provider_b = TaskSchedulerQuota::for_scope("provider:health-b", 1).unwrap();
+    let holder = scheduler
+        .acquire_quota(
+            TaskPriority::Foreground,
+            "provider-health-a:holder",
+            &provider_a,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    let cancellation = CancellationToken::new();
+    let waiting = {
+        let scheduler = Arc::clone(&scheduler);
+        let provider_a = provider_a.clone();
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move {
+            scheduler
+                .acquire_quota(
+                    TaskPriority::Urgent,
+                    "provider-health-a:cancelled",
+                    &provider_a,
+                    &cancellation,
+                )
+                .await
+        })
+    };
+    wait_for_pending(&scheduler, 1).await;
+
+    let independent = scheduler
+        .acquire_quota(
+            TaskPriority::Maintenance,
+            "provider-health-b:independent",
+            &provider_b,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    cancellation.cancel();
+    assert!(matches!(
+        waiting.await.unwrap(),
+        Err(TaskSchedulerError::Cancelled)
+    ));
+
+    let health_a = scheduler.quota_health(&provider_a).await.unwrap();
+    let health_b = scheduler.quota_health(&provider_b).await.unwrap();
+    assert_eq!(health_a.cancelled, 1);
+    assert_eq!(health_a.admitted, 1);
+    assert_eq!(health_b.cancelled, 0);
+    assert_eq!(health_b.admitted, 1);
+    assert_eq!(health_b.active, 1);
+
+    drop(independent);
+    drop(holder);
+    scheduler.shutdown().await;
+}
+
+#[tokio::test]
+async fn retained_quota_health_has_a_hard_identity_bound() {
+    let scheduler = scheduler(1, 60_000);
+    let mut quotas = Vec::new();
+    for index in 0..=TASK_SCHEDULER_QUOTA_HEALTH_RETENTION {
+        let quota = TaskSchedulerQuota::for_scope(&format!("retained:{index}"), 1).unwrap();
+        let lease = scheduler
+            .acquire_quota(
+                TaskPriority::Maintenance,
+                format!("retained:{index}"),
+                &quota,
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        drop(lease);
+        // Actor-order the release before the next identity is inserted.
+        let _ = scheduler.quota_health(&quota).await.unwrap();
+        quotas.push(quota);
+    }
+
+    assert!(!scheduler.quota_health(&quotas[0]).await.unwrap().observed);
+    assert!(
+        scheduler
+            .quota_health(quotas.last().unwrap())
+            .await
+            .unwrap()
+            .observed
+    );
+    scheduler.shutdown().await;
+}

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -419,16 +419,28 @@ impl TaskExecutor {
         schedule_foreground: bool,
     ) -> Self {
         self.provider_admission = self.provider_quota.clone().and_then(|quota| {
-            crate::llm::ModelGenerationAdmission::new(
+            let admission = crate::llm::ModelGenerationAdmission::new(
                 self.llm_client.model_generation_concurrency(),
-            )
-            .with_scheduler_quota(
-                Arc::clone(&scheduler),
-                quota,
-                crate::task_scheduler::TaskPriority::Foreground,
-                "task-child-model-generation",
-            )
-            .ok()
+            );
+            if let Some(pool) = self.llm_client.model_generation_pool() {
+                admission
+                    .with_model_generation_pool(
+                        Arc::clone(&scheduler),
+                        pool,
+                        crate::task_scheduler::TaskPriority::Foreground,
+                        "task-child-model-generation",
+                    )
+                    .ok()
+            } else {
+                admission
+                    .with_scheduler_quota(
+                        Arc::clone(&scheduler),
+                        quota,
+                        crate::task_scheduler::TaskPriority::Foreground,
+                        "task-child-model-generation",
+                    )
+                    .ok()
+            }
         });
         self.task_scheduler = Some(scheduler);
         self.schedule_foreground = schedule_foreground;


### PR DESCRIPTION
## Summary

- retain at most 64 recent digest-only provider quota health epochs in the existing scheduler actor
- expose TaskScheduler::quota_health and AgentSession::model_generation_pool_health with local/shared capacity composition
- preserve exact provider pool identity across nested rebinds and cover cancellation, idle retention, isolation, redaction, and retention bounds
- update README, CHANGELOG, and ROADMAP

## Validation

- cargo +stable fmt --all -- --check
- cargo +stable check -p a3s-code-core --all-features
- cargo +stable clippy -p a3s-code-core --lib --tests --all-features -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo +stable doc -p a3s-code-core --no-deps
- focused quota_health and pool_health tests
- full Core run: 3204 passed, 1 pre-existing BM25/zvec native-index failure, 13 ignored; all new tests passed