### PR TITLE
feat(sdk): expose provider pool health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added cross-host provider-pool health consumption. Node.js, Python, and Go
+  sessions expose the same secret-free local/shared projection (the Go JSONL
+  bridge advertises `session_model_generation_pool_health`), and capability
+  discovery lists the read-only operation. A repeated noisy-neighbor
+  qualification confirms independent provider pools continue making progress
+  while a blocked pool's waiters are cancelled and retained counters settle.
 - Added bounded provider-pool health evidence. `TaskScheduler::quota_health`
   retains at most 64 recent digest-only quota epochs with admission, release,
   cancellation, rejection, peak, and wait-time counters. Sessions expose the

--- a/README.md
+++ b/README.md
@@ -345,6 +345,15 @@ request payloads. A nested workflow rebind copies the exact pool identity while
 changing only its local limit; a different provider pool receives an independent
 health epoch and cannot consume the first pool's capacity.
 
+The same read-only projection is available to Node.js as
+`session.modelGenerationPoolHealth()`, Python as
+`session.model_generation_pool_health()`, and Go as
+`session.ModelGenerationPoolHealth(ctx)`. The Go JSONL bridge advertises
+`session_model_generation_pool_health`; hosts can discover it through the
+capability catalog before opting into the diagnostic surface. A repeated
+noisy-neighbor qualification keeps independent provider pools progressing
+while blocked waiters are cancelled and their bounded counters settle.
+
 `Agent::new` accepts an ACL path or inline ACL. Build sessions asynchronously
 so configuration, stores, queues, MCP sources, and workspace services are
 resolved before the first turn.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -468,17 +468,23 @@ workflow limits, and the complete 3,205-test Core library suite. This slice
 does not add provider rate-limit policy, billing, or a second scheduler;
 Gateway and host policy remain the owners of those concerns.
 
-The admission-hardening follow-up adds `TaskScheduler::quota_health` as a
-read-only projection over the same actor. It records admission, release,
-cancellation, and rejection counts, peak occupancy, and bounded wait
-aggregates for one digest-only quota, retaining at most 64 idle epochs and
-pruning older identities deterministically. `ModelGenerationPoolHealthSnapshot`
-composes that shared view with each facade's local reserved/available permits
-and the immutable pool descriptor; `AgentSession::model_generation_pool_health()`
-is the host-facing Rust surface. Runtime rebinds copy the exact pool identity
-while allowing a tighter local limit, and distinct provider identities retain
-isolated health epochs. No provider label, endpoint credential, prompt, output,
-or task label is added to scheduler state.
+The admission-hardening follow-up landed in Code `386d75b1` and now adds
+cross-host consumption plus noisy-neighbor qualification. Node.js, Python, and
+Go sessions expose the same read-only `ModelGenerationPoolHealthSnapshot`; the
+versioned Go bridge advertises `session_model_generation_pool_health`, and the
+capability catalog carries the operation for discovery. A repeated eight-cycle
+qualification with twelve blocked waiters per cycle proves an independent
+provider pool continues to admit work under a full global budget while
+cancellation, release, and bounded retention counters settle. No provider
+label, endpoint credential, prompt, output, or task label is added to scheduler
+state.
+
+The next admission slice is **P3/KRN-8 host qualification evidence**: exercise
+the common projection through real Node/Python/Go runtime fixtures and retain
+only bounded aggregate outcomes for release diagnostics. It must remain
+read-only metadata, avoid a second scheduler or metrics store, preserve the
+single Flow lease authority, and keep Gateway/host policy responsible for rate
+limits and billing.
 
 ### 3.4 Scoped capability program
 

--- a/core/src/sdk_capabilities.rs
+++ b/core/src/sdk_capabilities.rs
@@ -126,7 +126,7 @@ const CAPABILITY_SPECS: &[CapabilitySpec] = &[
         id: "priority_scheduling",
         category: "orchestration",
         description: "Share bounded priority/FIFO admission and observe scheduler occupancy, fairness, and lifecycle counters.",
-        operations: &["session.task_scheduler_stats", "session.task_scheduler_health", "session.queue_stats", "session.set_lane_handler"],
+        operations: &["session.task_scheduler_stats", "session.task_scheduler_health", "session.model_generation_pool_health", "session.queue_stats", "session.set_lane_handler"],
         host_owned: false,
     },
     CapabilitySpec {

--- a/core/src/task_scheduler/tests.rs
+++ b/core/src/task_scheduler/tests.rs
@@ -1081,3 +1081,85 @@ async fn retained_quota_health_has_a_hard_identity_bound() {
     );
     scheduler.shutdown().await;
 }
+
+#[tokio::test]
+async fn noisy_provider_waiters_do_not_starve_independent_pool_progress() {
+    const CYCLES: usize = 8;
+    const NOISY_WAITERS_PER_CYCLE: usize = 12;
+    let scheduler = Arc::new(scheduler(1, 60_000));
+    let noisy = TaskSchedulerQuota::for_scope("provider:noisy", 1).unwrap();
+    let independent = TaskSchedulerQuota::for_scope("provider:independent", 1).unwrap();
+
+    for cycle in 0..CYCLES {
+        let holder = scheduler
+            .acquire_quota(
+                TaskPriority::Foreground,
+                format!("noisy-holder-{cycle}"),
+                &noisy,
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let mut cancellations = Vec::with_capacity(NOISY_WAITERS_PER_CYCLE);
+        let mut waiters = Vec::with_capacity(NOISY_WAITERS_PER_CYCLE);
+        for waiter in 0..NOISY_WAITERS_PER_CYCLE {
+            let cancellation = CancellationToken::new();
+            let task = tokio::spawn({
+                let scheduler = Arc::clone(&scheduler);
+                let noisy = noisy.clone();
+                let cancellation = cancellation.clone();
+                async move {
+                    scheduler
+                        .acquire_quota(
+                            TaskPriority::Urgent,
+                            format!("noisy-waiter-{cycle}-{waiter}"),
+                            &noisy,
+                            &cancellation,
+                        )
+                        .await
+                }
+            });
+            cancellations.push(cancellation);
+            waiters.push(task);
+        }
+        wait_for_pending(&scheduler, NOISY_WAITERS_PER_CYCLE).await;
+
+        let independent_lease = tokio::time::timeout(
+            Duration::from_millis(100),
+            scheduler.acquire_quota(
+                TaskPriority::Maintenance,
+                format!("independent-{cycle}"),
+                &independent,
+                &CancellationToken::new(),
+            ),
+        )
+        .await
+        .expect("an independent provider must bypass noisy quota waiters")
+        .unwrap();
+        drop(independent_lease);
+
+        for cancellation in cancellations {
+            cancellation.cancel();
+        }
+        for waiter in waiters {
+            assert!(matches!(
+                waiter.await.unwrap(),
+                Err(TaskSchedulerError::Cancelled)
+            ));
+        }
+        drop(holder);
+    }
+
+    let noisy_health = scheduler.quota_health(&noisy).await.unwrap();
+    let independent_health = scheduler.quota_health(&independent).await.unwrap();
+    assert!(!noisy_health.live);
+    assert_eq!(noisy_health.admitted, CYCLES as u64);
+    assert_eq!(
+        noisy_health.cancelled,
+        (CYCLES * NOISY_WAITERS_PER_CYCLE) as u64
+    );
+    assert_eq!(noisy_health.released, CYCLES as u64);
+    assert_eq!(independent_health.admitted, CYCLES as u64);
+    assert_eq!(independent_health.released, CYCLES as u64);
+    scheduler.shutdown().await;
+}

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -290,6 +290,11 @@ snapshot, not a capacity reservation. `TaskSchedulerHealth` adds bounded
 cumulative admissions, releases, cancellations, aging promotions, peak
 occupancy, and wait-time aggregates without retaining task payloads.
 
+`session.ModelGenerationPoolHealth(ctx)` returns a secret-free local/shared
+provider-pool projection when the configured client publishes a typed pool. It
+includes bounded recent admission counters and local reserved/available
+permits; clients without a pool descriptor receive `nil`.
+
 ## Memory maintenance health
 
 `session.MemoryMaintenanceHealth(ctx)` reads the same non-sensitive lifecycle

--- a/sdk/go/agent_test.go
+++ b/sdk/go/agent_test.go
@@ -34,8 +34,19 @@ func TestTaskSchedulerStatsUseStableAgentAndSessionOperations(t *testing.T) {
 				if params["session_handle"] != "session-1" {
 					t.Fatalf("unexpected session health params: %#v", params)
 				}
+			case "session_model_generation_pool_health":
+				if params["session_handle"] != "session-1" {
+					t.Fatalf("unexpected provider-pool health params: %#v", params)
+				}
 			default:
 				t.Fatalf("unexpected operation %q", operation)
+			}
+			if operation == "session_model_generation_pool_health" {
+				return &ModelGenerationPoolHealthSnapshot{
+					Pool:                ModelGenerationPool{MaxConcurrency: 2},
+					LocalMaxConcurrency: 1,
+					LocalAvailable:      1,
+				}, nil
 			}
 			return TaskSchedulerStats{
 				MaxActive: 4,
@@ -64,6 +75,10 @@ func TestTaskSchedulerStatsUseStableAgentAndSessionOperations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	poolHealth, err := session.ModelGenerationPoolHealth(context.Background())
+	if err != nil || poolHealth == nil || poolHealth.Pool.MaxConcurrency != 2 {
+		t.Fatalf("unexpected provider-pool health: %#v, %v", poolHealth, err)
+	}
 	if agentStats.MaxActive != 4 || sessionStats.PendingByPriority.Background != 1 {
 		t.Fatalf("unexpected scheduler stats: agent=%#v session=%#v", agentStats, sessionStats)
 	}
@@ -75,6 +90,7 @@ func TestTaskSchedulerStatsUseStableAgentAndSessionOperations(t *testing.T) {
 		"session_task_scheduler_stats",
 		"agent_task_scheduler_health",
 		"session_task_scheduler_health",
+		"session_model_generation_pool_health",
 	}
 	if got := runtime.operations(); !slices.Equal(got, want) {
 		t.Fatalf("operations = %v, want %v", got, want)

--- a/sdk/go/bridge/src/lib.rs
+++ b/sdk/go/bridge/src/lib.rs
@@ -70,6 +70,7 @@ pub const BRIDGE_OPERATIONS: &[&str] = &[
     "session_info",
     "session_task_scheduler_stats",
     "session_task_scheduler_health",
+    "session_model_generation_pool_health",
     "session_memory_maintenance_health",
     "session_workspace_retrieval_status",
     "session_semantic_search",
@@ -879,6 +880,14 @@ impl BridgeState {
                     .request_session(&request.params)
                     .await?
                     .task_scheduler_health()
+                    .await?;
+                encode(health)
+            }
+            "session_model_generation_pool_health" => {
+                let health = self
+                    .request_session(&request.params)
+                    .await?
+                    .model_generation_pool_health()
                     .await?;
                 encode(health)
             }

--- a/sdk/go/internal/bridge/protocol.go
+++ b/sdk/go/internal/bridge/protocol.go
@@ -46,6 +46,7 @@ var RequiredOperations = []string{
 	"session_info",
 	"session_task_scheduler_stats",
 	"session_task_scheduler_health",
+	"session_model_generation_pool_health",
 	"session_memory_maintenance_health",
 	"session_workspace_retrieval_status",
 	"session_semantic_search",

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -114,6 +114,50 @@ type TaskSchedulerHealthSnapshot struct {
 	Closed            bool               `json:"closed"`
 }
 
+// ExecutionIdentityV1 is the digest-only identity used by provider-pool
+// diagnostics. It contains no provider labels, credentials, or request data.
+type ExecutionIdentityV1 struct {
+	Schema string `json:"schema"`
+	Domain string `json:"domain"`
+	Digest string `json:"digest"`
+}
+
+// ModelGenerationPool describes one provider/model capacity budget.
+type ModelGenerationPool struct {
+	Identity       ExecutionIdentityV1 `json:"identity"`
+	MaxConcurrency uint64              `json:"maxConcurrency"`
+}
+
+// TaskSchedulerQuotaHealthSnapshot contains bounded health for one provider
+// quota identity and its current or most-recent idle epoch.
+type TaskSchedulerQuotaHealthSnapshot struct {
+	Identity          ExecutionIdentityV1 `json:"identity"`
+	MaxActive         uint64              `json:"maxActive"`
+	Observed          bool                `json:"observed"`
+	Live              bool                `json:"live"`
+	Active            uint64              `json:"active"`
+	Pending           uint64              `json:"pending"`
+	Blocked           bool                `json:"blocked"`
+	Admitted          uint64              `json:"admitted"`
+	Released          uint64              `json:"released"`
+	Cancelled         uint64              `json:"cancelled"`
+	Rejected          uint64              `json:"rejected"`
+	PeakActive        uint64              `json:"peakActive"`
+	TotalWaitMicros   uint64              `json:"totalWaitMicros"`
+	AverageWaitMicros uint64              `json:"averageWaitMicros"`
+	MaxWaitMicros     uint64              `json:"maxWaitMicros"`
+}
+
+// ModelGenerationPoolHealthSnapshot composes local gate occupancy with the
+// optional shared scheduler projection for one session.
+type ModelGenerationPoolHealthSnapshot struct {
+	Pool                ModelGenerationPool               `json:"pool"`
+	LocalMaxConcurrency uint64                            `json:"localMaxConcurrency"`
+	LocalReserved       uint64                            `json:"localReserved"`
+	LocalAvailable      uint64                            `json:"localAvailable"`
+	Scheduler           *TaskSchedulerQuotaHealthSnapshot `json:"scheduler,omitempty"`
+}
+
 // DefaultSecurityProvider enables Core's built-in taint tracking and output
 // sanitization. Its concrete type is the provider selection; callers do not
 // pass a raw backend name.

--- a/sdk/go/session.go
+++ b/sdk/go/session.go
@@ -129,6 +129,19 @@ func (session *Session) TaskSchedulerHealth(ctx context.Context) (TaskSchedulerH
 	return result, err
 }
 
+// ModelGenerationPoolHealth returns secret-free local and shared capacity
+// health for this session's provider/model pool. A nil result means the
+// configured client does not publish a typed pool descriptor.
+func (session *Session) ModelGenerationPoolHealth(ctx context.Context) (*ModelGenerationPoolHealthSnapshot, error) {
+	const op = "session_model_generation_pool_health"
+	if err := validateSession(session, ctx, op); err != nil {
+		return nil, err
+	}
+	var result *ModelGenerationPoolHealthSnapshot
+	err := session.runtime.Request(ctx, op, session.params(), &result)
+	return result, err
+}
+
 // Send executes one prompt and waits for the complete response. A nil history
 // uses and updates the session's internal conversation history.
 func (session *Session) Send(

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -240,6 +240,11 @@ diagnostic snapshot, not a capacity reservation. `taskSchedulerHealth()` adds
 bounded cumulative admissions, releases, cancellations, aging promotions,
 peak occupancy, and wait-time aggregates without retaining task payloads.
 
+`session.modelGenerationPoolHealth()` returns a secret-free local/shared
+provider-pool projection when the configured client publishes a typed pool. It
+includes bounded recent admission counters and local reserved/available
+permits; clients without a pool descriptor receive `null`.
+
 ## Memory maintenance health
 
 `session.memoryMaintenanceHealth()` returns the same non-sensitive lifecycle

--- a/sdk/node/generated.d.ts
+++ b/sdk/node/generated.d.ts
@@ -46,6 +46,43 @@ export interface TaskSchedulerHealthSnapshot {
   maxWaitMicros: number
   closed: boolean
 }
+/** Digest-only execution identity used by provider-pool diagnostics. */
+export interface ExecutionIdentityV1 {
+  schema: string
+  domain: string
+  digest: string
+}
+/** Provider/model capacity descriptor exposed to host diagnostics. */
+export interface ModelGenerationPool {
+  identity: ExecutionIdentityV1
+  maxConcurrency: number
+}
+/** Bounded health for one digest-only provider quota. */
+export interface TaskSchedulerQuotaHealthSnapshot {
+  identity: ExecutionIdentityV1
+  maxActive: number
+  observed: boolean
+  live: boolean
+  active: number
+  pending: number
+  blocked: boolean
+  admitted: number
+  released: number
+  cancelled: number
+  rejected: number
+  peakActive: number
+  totalWaitMicros: number
+  averageWaitMicros: number
+  maxWaitMicros: number
+}
+/** Secret-free local and shared provider-pool health for one session. */
+export interface ModelGenerationPoolHealthSnapshot {
+  pool: ModelGenerationPool
+  localMaxConcurrency: number
+  localReserved: number
+  localAvailable: number
+  scheduler?: TaskSchedulerQuotaHealthSnapshot
+}
 /** Result of admitting a host-selected run ID for detached execution. */
 export interface AgentRunSpawnObject {
   snapshot: any
@@ -1437,6 +1474,8 @@ export declare class Session {
    * for the scheduler shared by this session and its siblings.
    */
   taskSchedulerHealth(): Promise<TaskSchedulerHealthSnapshot>
+  /** Return secret-free local and shared provider-pool health for this session. */
+  modelGenerationPoolHealth(): Promise<ModelGenerationPoolHealthSnapshot | null>
   /**
    * Send a prompt or request and wait for the complete response.
    *

--- a/sdk/node/src/lib.rs
+++ b/sdk/node/src/lib.rs
@@ -95,6 +95,8 @@ use a3s_code_core::{
     PlanningMode as RustPlanningMode, SessionOptions as RustSessionOptions,
     TaskPriorityCounts as RustTaskPriorityCounts, TaskSchedulerStats as RustTaskSchedulerStats,
     TaskSchedulerHealthSnapshot as RustTaskSchedulerHealthSnapshot,
+    ModelGenerationPoolHealthSnapshot as RustModelGenerationPoolHealthSnapshot,
+    TaskSchedulerQuotaHealthSnapshot as RustTaskSchedulerQuotaHealthSnapshot,
     SdkCapability as RustSdkCapability, AGENT_EVENT_TYPES_V1, EVENT_ENVELOPE_V1_VERSION,
 };
 use napi::Either;
@@ -273,6 +275,102 @@ impl From<RustTaskSchedulerHealthSnapshot> for TaskSchedulerHealthSnapshot {
             average_wait_micros: scheduler_counter(value.average_wait_micros),
             max_wait_micros: scheduler_counter(value.max_wait_micros),
             closed: value.closed,
+        }
+    }
+}
+
+/// Digest-only execution identity used by provider-pool diagnostics.
+#[napi(object)]
+#[derive(Clone)]
+pub struct ExecutionIdentityV1 {
+    pub schema: String,
+    pub domain: String,
+    pub digest: String,
+}
+
+/// Provider/model capacity descriptor exposed to host diagnostics.
+#[napi(object)]
+#[derive(Clone)]
+pub struct ModelGenerationPool {
+    pub identity: ExecutionIdentityV1,
+    pub max_concurrency: i64,
+}
+
+/// Bounded health for one digest-only provider quota.
+#[napi(object)]
+#[derive(Clone)]
+pub struct TaskSchedulerQuotaHealthSnapshot {
+    pub identity: ExecutionIdentityV1,
+    pub max_active: i64,
+    pub observed: bool,
+    pub live: bool,
+    pub active: i64,
+    pub pending: i64,
+    pub blocked: bool,
+    pub admitted: i64,
+    pub released: i64,
+    pub cancelled: i64,
+    pub rejected: i64,
+    pub peak_active: i64,
+    pub total_wait_micros: i64,
+    pub average_wait_micros: i64,
+    pub max_wait_micros: i64,
+}
+
+/// Secret-free local and shared provider-pool health for one session.
+#[napi(object)]
+#[derive(Clone)]
+pub struct ModelGenerationPoolHealthSnapshot {
+    pub pool: ModelGenerationPool,
+    pub local_max_concurrency: i64,
+    pub local_reserved: i64,
+    pub local_available: i64,
+    pub scheduler: Option<TaskSchedulerQuotaHealthSnapshot>,
+}
+
+impl From<a3s_code_core::execution_identity::ExecutionIdentityV1> for ExecutionIdentityV1 {
+    fn from(value: a3s_code_core::execution_identity::ExecutionIdentityV1) -> Self {
+        Self {
+            schema: value.schema,
+            domain: value.domain,
+            digest: value.digest,
+        }
+    }
+}
+
+impl From<RustTaskSchedulerQuotaHealthSnapshot> for TaskSchedulerQuotaHealthSnapshot {
+    fn from(value: RustTaskSchedulerQuotaHealthSnapshot) -> Self {
+        Self {
+            identity: value.identity.into(),
+            max_active: scheduler_count(value.max_active),
+            observed: value.observed,
+            live: value.live,
+            active: scheduler_count(value.active),
+            pending: scheduler_count(value.pending),
+            blocked: value.blocked,
+            admitted: scheduler_counter(value.admitted),
+            released: scheduler_counter(value.released),
+            cancelled: scheduler_counter(value.cancelled),
+            rejected: scheduler_counter(value.rejected),
+            peak_active: scheduler_count(value.peak_active),
+            total_wait_micros: scheduler_counter(value.total_wait_micros),
+            average_wait_micros: scheduler_counter(value.average_wait_micros),
+            max_wait_micros: scheduler_counter(value.max_wait_micros),
+        }
+    }
+}
+
+impl From<RustModelGenerationPoolHealthSnapshot> for ModelGenerationPoolHealthSnapshot {
+    fn from(value: RustModelGenerationPoolHealthSnapshot) -> Self {
+        Self {
+            pool: ModelGenerationPool {
+                identity: value.pool.identity.into(),
+                max_concurrency: scheduler_count(value.pool.max_concurrency.get()),
+            },
+            local_max_concurrency: scheduler_count(value.local_max_concurrency),
+            local_reserved: scheduler_count(value.local_reserved),
+            local_available: scheduler_count(value.local_available),
+            scheduler: value.scheduler.map(Into::into),
         }
     }
 }

--- a/sdk/node/src/session.rs
+++ b/sdk/node/src/session.rs
@@ -36,6 +36,20 @@ impl Session {
             .map_err(node_task_scheduler_error)
     }
 
+    /// Return secret-free local and shared capacity health for this session's
+    /// provider/model generation pool, when the configured client publishes
+    /// one. The shared projection retains only a bounded digest-only epoch.
+    #[napi]
+    pub async fn model_generation_pool_health(
+        &self,
+    ) -> napi::Result<Option<ModelGenerationPoolHealthSnapshot>> {
+        self.inner
+            .model_generation_pool_health()
+            .await
+            .map(|health| health.map(ModelGenerationPoolHealthSnapshot::from))
+            .map_err(node_task_scheduler_error)
+    }
+
     /// Send a prompt or request and wait for the complete response.
     ///
     /// `send("prompt")` is the compact prompt-first form. `send({ prompt,

--- a/sdk/node/test-types.ts
+++ b/sdk/node/test-types.ts
@@ -163,6 +163,7 @@ void _session.correlationId
 void _session.hasMemory
 void _session.taskSchedulerStats()
 void _session.taskSchedulerHealth()
+void _session.modelGenerationPoolHealth()
 void _session.memoryMaintenanceHealth()
 void _session.workspaceRetrievalStatus()
 void _session.semanticSearch({ query: 'session cleanup', limit: 5 })

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -329,6 +329,11 @@ snapshots, not capacity reservations. `task_scheduler_health()` returns
 bounded cumulative admissions, releases, cancellations, aging promotions,
 peak occupancy, and wait-time aggregates without retaining task payloads.
 
+`session.model_generation_pool_health()` returns a secret-free local/shared
+provider-pool projection when the configured client publishes a typed pool. It
+includes bounded recent admission counters and local reserved/available
+permits; clients without a pool descriptor receive `None`.
+
 ## Memory maintenance health
 
 `session.memory_maintenance_health()` returns a typed, non-sensitive lifecycle

--- a/sdk/python/src/session.rs
+++ b/sdk/python/src/session.rs
@@ -87,6 +87,21 @@ impl PySession {
         task_scheduler_health_to_py(py, &health)
     }
 
+    /// Return secret-free local and shared provider/model generation-pool
+    /// health, or ``None`` when the configured client publishes no pool.
+    fn model_generation_pool_health(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let session = self.inner.clone();
+        let health = py
+            .allow_threads(move || get_runtime().block_on(session.model_generation_pool_health()))
+            .map_err(py_task_scheduler_error)?;
+        let json = serde_json::to_string(&health).map_err(|error| {
+            PyRuntimeError::new_err(format!(
+                "Failed to serialize model-generation pool health: {error}"
+            ))
+        })?;
+        json_string_to_py(py, &json)
+    }
+
     /// Observe periodic pruning and host-owned consolidation for this session.
     fn memory_maintenance_health(&self, py: Python<'_>) -> PyResult<PyObject> {
         memory_maintenance_health_to_py(py, &self.inner.memory_maintenance_health())


### PR DESCRIPTION
## Summary

- expose the secret-free ModelGenerationPoolHealthSnapshot through Node.js, Python, and Go sessions
- add the versioned Go bridge operation and capability-catalog discovery
- add an eight-cycle noisy-neighbor qualification with twelve blocked waiters per cycle
- document the cross-host diagnostic contract and bounded evidence

## Validation

- cargo +stable fmt --all -- --check
- cargo +stable clippy --manifest-path core/Cargo.toml --lib --tests --all-features -- -D warnings
- cargo +stable check --manifest-path sdk/node/Cargo.toml --all-features
- cargo +stable check --manifest-path sdk/python/Cargo.toml --all-features
- cargo +stable check --manifest-path sdk/go/bridge/Cargo.toml --all-features
- cargo +stable test --manifest-path sdk/go/bridge/Cargo.toml --lib --quiet (22 passed)
- go test ./... (passed)
- noisy_provider_waiters_do_not_starve_independent_pool_progress (passed)
- npm run test:types not run: local Node dependencies are not installed; Node strict Clippy is blocked by a pre-existing moli_runtime unwrap_or_default lint