### PR TITLE
feat(review): bind findings to evaluation records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -254,15 +254,24 @@ decides how to search, review, approve, retain, and publish results.
 
 | Gate | State | Code-owned outcome | Exit criteria |
 | --- | --- | --- | --- |
-| `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Eleven focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
+| `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Thirteen focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
 | `RESEARCH-EXEC1` | Planned | Host adapter that drives a research run through source capture, evidence append, artifact publication, and evaluator dispatch while retaining one Code Run identity | Integration tests prove restart, cancellation, contiguous evidence, artifact immutability, and exact Code/Use binding across a real workspace |
-| `RESEARCH-REVIEW1` | Planned | Host-owned reviewer composition over the generic evaluation substrate, projecting bounded findings and human decisions without a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral |
+| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding to an immutable evaluator result without introducing a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, or evidence drift |
 
 The delivered contract slice is documented in
 [Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
 small: it does not claim a complete project aggregate, scientific knowledge
 graph, package registry, or publication service. Those capabilities belong to
 the host, A3S Use, and Desktop phases in the cross-repository roadmap.
+
+The first reviewer-composition mechanism is now Code-owned: a
+`ResearchReviewFindingV1` can bind the exact immutable `EvaluationRecordV1`
+that produced it. The binding checks evaluator identity, parent Run identity,
+and inclusion of the evaluator's evidence snapshot digest, while preserving an
+`open` finding status until the host applies its rubric and an explicit human or
+policy resolution. Existing unbound v1 findings remain readable with their
+legacy digest identity; new bindings use a digest that includes the evaluator
+record, so result replacement cannot masquerade as the same finding.
 
 ### 3.3.1 Workflow result convergence
 

--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -100,6 +100,11 @@ pub struct ResearchReviewFindingV1 {
     pub location: Option<ResearchReviewLocationV1>,
     pub evidence_digests: Vec<String>,
     pub evaluator_id: String,
+    /// Optional digest of the immutable generic evaluation record that
+    /// produced this finding.  It is optional for compatibility with
+    /// findings created before evaluator-result binding was available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evaluation_record_digest: Option<String>,
     pub observed_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_digest: Option<String>,
@@ -136,6 +141,7 @@ impl ResearchReviewFindingV1 {
             location,
             evidence_digests,
             evaluator_id: evaluator_id.into(),
+            evaluation_record_digest: None,
             observed_at_ms,
             resolution_digest: None,
             finding_digest: String::new(),
@@ -152,6 +158,45 @@ impl ResearchReviewFindingV1 {
             return Err(ResearchContractError::DigestMismatch("findingDigest"));
         }
         Ok(())
+    }
+
+    /// Bind this finding to the exact generic evaluation record that produced
+    /// it.  The host still owns the rubric and finding projection, while Code
+    /// verifies that the evaluator, Run, and evidence identity cannot drift.
+    ///
+    /// The method consumes and returns the finding so callers cannot observe a
+    /// partially rebound value if validation fails.
+    pub fn bind_evaluation_record(
+        mut self,
+        record: &crate::evaluation::EvaluationRecordV1,
+    ) -> Result<Self, ResearchContractError> {
+        self.validate()?;
+        record
+            .validate()
+            .map_err(|_| ResearchContractError::InvalidField("evaluationRecord"))?;
+        if record.result.target.run_id != self.run_id {
+            return Err(ResearchContractError::InvalidField(
+                "evaluationRecord.target",
+            ));
+        }
+        if record.result.evaluator_id != self.evaluator_id {
+            return Err(ResearchContractError::InvalidField(
+                "evaluationRecord.evaluatorId",
+            ));
+        }
+        if self
+            .evidence_digests
+            .binary_search(&record.result.evidence_digest)
+            .is_err()
+        {
+            return Err(ResearchContractError::InvalidField(
+                "evaluationRecord.evidenceDigest",
+            ));
+        }
+        self.evaluation_record_digest = Some(record.record_digest.clone());
+        self.finding_digest = self.expected_digest()?;
+        self.validate()?;
+        Ok(self)
     }
 
     pub fn resolve(
@@ -229,12 +274,15 @@ impl ResearchReviewFindingV1 {
         if let Some(resolution_digest) = &self.resolution_digest {
             validate_digest_field("resolutionDigest", resolution_digest)?;
         }
+        if let Some(evaluation_record_digest) = &self.evaluation_record_digest {
+            validate_digest_field("evaluationRecordDigest", evaluation_record_digest)?;
+        }
         Ok(())
     }
 
     fn expected_digest(&self) -> Result<String, ResearchContractError> {
         #[derive(Serialize)]
-        struct Identity<'a> {
+        struct LegacyIdentity<'a> {
             schema: &'a str,
             finding_id: &'a str,
             project_id: &'a str,
@@ -250,9 +298,48 @@ impl ResearchReviewFindingV1 {
             observed_at_ms: u64,
             resolution_digest: Option<&'a str>,
         }
+        let Some(evaluation_record_digest) = self.evaluation_record_digest.as_deref() else {
+            return digest(
+                RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
+                &LegacyIdentity {
+                    schema: &self.schema,
+                    finding_id: &self.finding_id,
+                    project_id: &self.project_id,
+                    run_id: &self.run_id,
+                    artifact_digest: &self.artifact_digest,
+                    category: self.category,
+                    severity: self.severity,
+                    status: self.status,
+                    message: &self.message,
+                    location: &self.location,
+                    evidence_digests: &self.evidence_digests,
+                    evaluator_id: &self.evaluator_id,
+                    observed_at_ms: self.observed_at_ms,
+                    resolution_digest: self.resolution_digest.as_deref(),
+                },
+            );
+        };
+        #[derive(Serialize)]
+        struct BoundIdentity<'a> {
+            schema: &'a str,
+            finding_id: &'a str,
+            project_id: &'a str,
+            run_id: &'a str,
+            artifact_digest: &'a str,
+            category: ResearchReviewCategoryV1,
+            severity: ResearchReviewSeverityV1,
+            status: ResearchReviewStatusV1,
+            message: &'a str,
+            location: &'a Option<ResearchReviewLocationV1>,
+            evidence_digests: &'a [String],
+            evaluator_id: &'a str,
+            evaluation_record_digest: &'a str,
+            observed_at_ms: u64,
+            resolution_digest: Option<&'a str>,
+        }
         digest(
             RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
-            &Identity {
+            &BoundIdentity {
                 schema: &self.schema,
                 finding_id: &self.finding_id,
                 project_id: &self.project_id,
@@ -265,6 +352,7 @@ impl ResearchReviewFindingV1 {
                 location: &self.location,
                 evidence_digests: &self.evidence_digests,
                 evaluator_id: &self.evaluator_id,
+                evaluation_record_digest,
                 observed_at_ms: self.observed_at_ms,
                 resolution_digest: self.resolution_digest.as_deref(),
             },
@@ -327,6 +415,106 @@ mod tests {
         assert_eq!(
             finding.validate(),
             Err(ResearchContractError::InvalidField("resolutionDigest"))
+        );
+    }
+
+    #[test]
+    fn finding_binds_the_exact_evaluation_record_without_importing_a_rubric() {
+        let evidence_digest = digest('b');
+        let result = crate::evaluation::EvaluationResultV1::new(
+            "citation-reviewer",
+            crate::evaluation::ExecutionTargetV1::new("session-1", "run-1"),
+            "aux-1",
+            "observed",
+            serde_json::json!({"finding_count": 1}),
+            evidence_digest.clone(),
+        )
+        .unwrap();
+        let record = crate::evaluation::EvaluationRecordV1::new(result, 2).unwrap();
+        let finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Citation,
+            ResearchReviewSeverityV1::Warning,
+            "Citation does not support the claim.",
+            None,
+            vec![evidence_digest],
+            "citation-reviewer",
+            3,
+        )
+        .unwrap()
+        .bind_evaluation_record(&record)
+        .unwrap();
+
+        assert_eq!(
+            finding.evaluation_record_digest.as_deref(),
+            Some(record.record_digest.as_str())
+        );
+        assert!(finding.validate().is_ok());
+        let mut tampered = finding;
+        tampered.evaluation_record_digest = Some(digest('f'));
+        assert_eq!(
+            tampered.validate(),
+            Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+
+    #[test]
+    fn finding_rejects_a_record_from_another_run_or_evidence_window() {
+        let record = crate::evaluation::EvaluationRecordV1::new(
+            crate::evaluation::EvaluationResultV1::new(
+                "numeric-reviewer",
+                crate::evaluation::ExecutionTargetV1::new("session-1", "run-2"),
+                "aux-2",
+                "observed",
+                serde_json::json!({"finding_count": 1}),
+                digest('b'),
+            )
+            .unwrap(),
+            2,
+        )
+        .unwrap();
+        let finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Numeric,
+            ResearchReviewSeverityV1::Error,
+            "The value is not traceable.",
+            None,
+            vec![digest('b')],
+            "numeric-reviewer",
+            3,
+        )
+        .unwrap();
+        assert_eq!(
+            finding.clone().bind_evaluation_record(&record),
+            Err(ResearchContractError::InvalidField(
+                "evaluationRecord.target"
+            ))
+        );
+
+        let same_run = crate::evaluation::EvaluationRecordV1::new(
+            crate::evaluation::EvaluationResultV1::new(
+                "numeric-reviewer",
+                crate::evaluation::ExecutionTargetV1::new("session-1", "run-1"),
+                "aux-3",
+                "observed",
+                serde_json::json!({"finding_count": 1}),
+                digest('c'),
+            )
+            .unwrap(),
+            2,
+        )
+        .unwrap();
+        assert_eq!(
+            finding.bind_evaluation_record(&same_run),
+            Err(ResearchContractError::InvalidField(
+                "evaluationRecord.evidenceDigest"
+            ))
         );
     }
 

--- a/core/tests/evaluation_substrate.rs
+++ b/core/tests/evaluation_substrate.rs
@@ -1,11 +1,16 @@
 use a3s_code_core::evaluation::{
-    AuxiliaryCapabilityProfileV1, AuxiliaryExecutor, AuxiliaryRunContextV1, AuxiliaryRunError,
-    AuxiliaryRunService, AuxiliaryRunSpecV1, AuxiliaryRunStateV1, EvaluationRecordV1,
-    EvaluationResultSink, EvaluationResultV1, EvidenceContentModeV1, EvidenceReadRequestV1,
-    ExecutionFactRecorder, ExecutionFrameV1, ExecutionTargetV1, InMemoryAuxiliaryRunService,
-    InMemoryEvaluationResultStore, InMemoryExecutionFactJournal, RunEvidenceReader,
+    digest_bytes, AuxiliaryCapabilityProfileV1, AuxiliaryExecutor, AuxiliaryRunContextV1,
+    AuxiliaryRunError, AuxiliaryRunService, AuxiliaryRunSpecV1, AuxiliaryRunStateV1,
+    EvaluationRecordV1, EvaluationResultSink, EvaluationResultV1, EvidenceContentModeV1,
+    EvidenceReadRequestV1, ExecutionFactRecorder, ExecutionFrameV1, ExecutionTargetV1,
+    InMemoryAuxiliaryRunService, InMemoryEvaluationResultStore, InMemoryExecutionFactJournal,
+    RunEvidenceReader,
 };
 use a3s_code_core::{AgentEvent, InMemoryRunStore, RunEventRecord};
+use a3s_code_core::{
+    ResearchReviewCategoryV1, ResearchReviewFindingV1, ResearchReviewSeverityV1,
+    ResearchReviewStatusV1,
+};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Duration;
@@ -105,6 +110,69 @@ async fn evidence_to_auxiliary_to_result_is_publicly_composable() {
     let record = EvaluationRecordV1::new(result, 1).unwrap();
     assert!(store.write(record.clone()).await.unwrap().written);
     assert_eq!(store.list_for_target(&target).await, vec![record]);
+}
+
+#[tokio::test]
+async fn evaluator_result_binds_to_an_open_review_finding_without_implying_approval() {
+    let (runs, target, journal) = prepared_run().await;
+    let evidence = RunEvidenceReader::new(Arc::clone(&runs))
+        .with_facts(journal)
+        .read(EvidenceReadRequestV1::new(target.clone()))
+        .await
+        .unwrap();
+    let service = InMemoryAuxiliaryRunService::new(Arc::new(FixtureExecutor));
+    let spec = AuxiliaryRunSpecV1::new(
+        ExecutionFrameV1::root(target.clone()),
+        "review",
+        "inspect the bounded evidence",
+        evidence.snapshot_digest.clone(),
+    )
+    .with_id("aux-review")
+    .with_capabilities(AuxiliaryCapabilityProfileV1::tool_free());
+    let output = service
+        .spawn(spec, evidence.clone(), None)
+        .await
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+    let record = EvaluationRecordV1::new(
+        EvaluationResultV1::new(
+            "integration-evaluator",
+            target,
+            "aux-review",
+            "needs_review",
+            output.value,
+            evidence.snapshot_digest.clone(),
+        )
+        .unwrap(),
+        2,
+    )
+    .unwrap();
+
+    let finding = ResearchReviewFindingV1::new(
+        "finding-1",
+        "project-1",
+        "run-integration",
+        digest_bytes("review-artifact", b"report").to_string(),
+        ResearchReviewCategoryV1::Reproducibility,
+        ResearchReviewSeverityV1::Warning,
+        "The report needs an explicit environment receipt.",
+        None,
+        vec![evidence.snapshot_digest],
+        "integration-evaluator",
+        3,
+    )
+    .unwrap()
+    .bind_evaluation_record(&record)
+    .unwrap();
+
+    assert_eq!(finding.status, ResearchReviewStatusV1::Open);
+    assert_eq!(
+        finding.evaluation_record_digest.as_deref(),
+        Some(record.record_digest.as_str())
+    );
+    assert!(finding.validate().is_ok());
 }
 
 #[tokio::test]

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -26,7 +26,7 @@ interpret a review finding as approval.
 | `ResearchRunV1` | `a3s.code.research-run.v1` | Binds project revision, source/evidence snapshots, Code/Use capability identity, provider/model, reproducibility promise, and lifecycle status. |
 | `ResearchEvidenceFactV1` | `a3s.code.evidence-fact.v1` | Append-only, digest-only observation with a monotonic sequence and bounded metadata. |
 | `ResearchProvenanceReceiptV1` | `a3s.code.provenance-receipt.v1` | Binds an artifact to its inputs, workflow, code, environment, provider, optional model/seed, and validation output. |
-| `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; resolution and waiver are explicit lifecycle transitions. |
+| `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; an optional immutable evaluation-record binding prevents evaluator, Run, or evidence drift; resolution and waiver are explicit lifecycle transitions. |
 | `ResearchEventV1` | `a3s.code.science-event.v1` | Digest-only project/run event projection for Desktop and other hosts. |
 
 All IDs and text are bounded. Digests use the existing Code SHA-256 format.
@@ -60,7 +60,9 @@ raw model/tool output.
    `ResearchProvenanceReceiptV1`.
 4. Run a host-selected evaluator through the generic Code evaluation
    substrate, then project its bounded observations into
-   `ResearchReviewFindingV1` values.
+   `ResearchReviewFindingV1` values. Bind each finding to the exact
+   `EvaluationRecordV1` with `bind_evaluation_record`; Code verifies that the
+   evaluator, Run, and evidence snapshot match before accepting the binding.
 5. Let the host apply its rubric, human approval, retention, and publication
    policy; Code only validates the supplied identities and lifecycle.
 


### PR DESCRIPTION
## Summary
- bind ResearchReviewFindingV1 to the exact immutable EvaluationRecordV1 that produced it
- reject evaluator, Run, and evidence snapshot drift before binding
- preserve legacy unbound v1 finding digests and keep findings open until host policy resolves them
- add end-to-end reviewer composition qualification and update roadmap/docs

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings
- research unit tests: 16 passed
- evaluation substrate integration: 6 passed
- evaluation qualification: 8 passed