### PR TITLE
feat(review): add bounded finding batches

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -254,9 +254,9 @@ decides how to search, review, approve, retain, and publish results.
 
 | Gate | State | Code-owned outcome | Exit criteria |
 | --- | --- | --- | --- |
-| `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Thirteen focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
+| `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Eighteen focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
 | `RESEARCH-EXEC1` | Planned | Host adapter that drives a research run through source capture, evidence append, artifact publication, and evaluator dispatch while retaining one Code Run identity | Integration tests prove restart, cancellation, contiguous evidence, artifact immutability, and exact Code/Use binding across a real workspace |
-| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding to an immutable evaluator result without introducing a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, or evidence drift |
+| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to an immutable evaluator result without introducing a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, evidence, duplicate-id, or partial-batch drift |
 
 The delivered contract slice is documented in
 [Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
@@ -272,6 +272,13 @@ and inclusion of the evaluator's evidence snapshot digest, while preserving an
 policy resolution. Existing unbound v1 findings remain readable with their
 legacy digest identity; new bindings use a digest that includes the evaluator
 record, so result replacement cannot masquerade as the same finding.
+
+`ResearchReviewBatchV1` is the bounded publication boundary for one evaluator
+response. It requires one project/Run/evaluation-record/evidence identity for
+all findings, canonical finding ordering, and an updated batch digest after an
+explicit resolution or waiver. It remains a validation primitive: reviewer
+rubrics, severity thresholds, approval, retention, and publication stay with
+the host or Desktop.
 
 ### 3.3.1 Workflow result convergence
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -316,11 +316,12 @@ pub use prompts::{AgentStyle, DetectionConfidence, PlanningMode, SystemPromptSlo
 pub use research::{
     ResearchArtifactKindV1, ResearchContractError, ResearchEventV1, ResearchEvidenceFactKindV1,
     ResearchEvidenceFactV1, ResearchProvenanceReceiptV1, ResearchReproducibilityV1,
-    ResearchReviewCategoryV1, ResearchReviewFindingV1, ResearchReviewLocationV1,
-    ResearchReviewSeverityV1, ResearchReviewStatusV1, ResearchRunStatusV1, ResearchRunV1,
-    RESEARCH_ARTIFACT_KINDS, RESEARCH_EVENT_SCHEMA_V1, RESEARCH_EVIDENCE_FACT_SCHEMA_V1,
-    RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1, RESEARCH_REVIEW_FINDING_SCHEMA_V1,
-    RESEARCH_RUN_SCHEMA_V1,
+    ResearchReviewBatchV1, ResearchReviewCategoryV1, ResearchReviewFindingV1,
+    ResearchReviewLocationV1, ResearchReviewSeverityV1, ResearchReviewStatusV1,
+    ResearchRunStatusV1, ResearchRunV1, RESEARCH_ARTIFACT_KINDS, RESEARCH_EVENT_SCHEMA_V1,
+    RESEARCH_EVIDENCE_FACT_SCHEMA_V1, RESEARCH_MAX_REVIEW_FINDINGS,
+    RESEARCH_PROVENANCE_RECEIPT_SCHEMA_V1, RESEARCH_REVIEW_BATCH_SCHEMA_V1,
+    RESEARCH_REVIEW_FINDING_SCHEMA_V1, RESEARCH_RUN_SCHEMA_V1,
 };
 pub use rl_trajectory::{RlTrajectoryConfig, RlTrajectoryMode, RlTrajectoryRecorder};
 pub use run::{

--- a/core/src/research/mod.rs
+++ b/core/src/research/mod.rs
@@ -10,6 +10,7 @@ mod event;
 mod evidence;
 mod provenance;
 mod review;
+mod review_batch;
 mod run;
 
 pub use error::ResearchContractError;
@@ -25,6 +26,9 @@ pub use provenance::{
 pub use review::{
     ResearchReviewCategoryV1, ResearchReviewFindingV1, ResearchReviewLocationV1,
     ResearchReviewSeverityV1, ResearchReviewStatusV1, RESEARCH_REVIEW_FINDING_SCHEMA_V1,
+};
+pub use review_batch::{
+    ResearchReviewBatchV1, RESEARCH_MAX_REVIEW_FINDINGS, RESEARCH_REVIEW_BATCH_SCHEMA_V1,
 };
 pub use run::{
     ResearchReproducibilityV1, ResearchRunStatusV1, ResearchRunV1, RESEARCH_RUN_SCHEMA_V1,

--- a/core/src/research/review_batch.rs
+++ b/core/src/research/review_batch.rs
@@ -1,0 +1,310 @@
+//! Bounded, digest-bound batches of reviewer findings.
+
+use super::{
+    digest, validate_digest_field, validate_id, ResearchContractError, ResearchReviewFindingV1,
+};
+use serde::{Deserialize, Serialize};
+
+pub const RESEARCH_REVIEW_BATCH_SCHEMA_V1: &str = "a3s.code.review-batch.v1";
+pub const RESEARCH_MAX_REVIEW_FINDINGS: usize = 512;
+const RESEARCH_REVIEW_BATCH_DIGEST_DOMAIN: &str = "a3s.code.review-batch.identity.v1";
+
+/// One immutable projection of an evaluator result into bounded findings.
+///
+/// A batch does not define a rubric or a business decision. It only prevents
+/// a host from publishing a partially mixed reviewer response: every finding
+/// must belong to the same project/run, evaluation record, and evidence
+/// snapshot. Human resolution remains an explicit operation on each finding.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResearchReviewBatchV1 {
+    pub schema: String,
+    pub batch_id: String,
+    pub project_id: String,
+    pub run_id: String,
+    pub evaluation_record_digest: String,
+    pub evidence_digest: String,
+    pub findings: Vec<ResearchReviewFindingV1>,
+    pub batch_digest: String,
+}
+
+impl ResearchReviewBatchV1 {
+    pub fn new(
+        batch_id: impl Into<String>,
+        project_id: impl Into<String>,
+        run_id: impl Into<String>,
+        evaluation_record_digest: impl Into<String>,
+        evidence_digest: impl Into<String>,
+        mut findings: Vec<ResearchReviewFindingV1>,
+    ) -> Result<Self, ResearchContractError> {
+        findings.sort_unstable_by(|left, right| left.finding_id.cmp(&right.finding_id));
+        let mut batch = Self {
+            schema: RESEARCH_REVIEW_BATCH_SCHEMA_V1.to_owned(),
+            batch_id: batch_id.into(),
+            project_id: project_id.into(),
+            run_id: run_id.into(),
+            evaluation_record_digest: evaluation_record_digest.into(),
+            evidence_digest: evidence_digest.into(),
+            findings,
+            batch_digest: String::new(),
+        };
+        batch.validate_without_digest()?;
+        batch.batch_digest = batch.expected_digest()?;
+        Ok(batch)
+    }
+
+    pub fn validate(&self) -> Result<(), ResearchContractError> {
+        self.validate_without_digest()?;
+        validate_digest_field("batchDigest", &self.batch_digest)?;
+        if self.batch_digest != self.expected_digest()? {
+            return Err(ResearchContractError::DigestMismatch("batchDigest"));
+        }
+        Ok(())
+    }
+
+    /// Resolve one finding and rebind the batch identity atomically.
+    pub fn resolve_finding(
+        &mut self,
+        finding_id: &str,
+        resolution_digest: impl Into<String>,
+    ) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        let finding = self
+            .findings
+            .iter_mut()
+            .find(|finding| finding.finding_id == finding_id)
+            .ok_or(ResearchContractError::InvalidField("findingId"))?;
+        finding.resolve(resolution_digest)?;
+        self.batch_digest = self.expected_digest()?;
+        self.validate()
+    }
+
+    /// Waive one finding and rebind the batch identity atomically.
+    pub fn waive_finding(
+        &mut self,
+        finding_id: &str,
+        resolution_digest: impl Into<String>,
+    ) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        let finding = self
+            .findings
+            .iter_mut()
+            .find(|finding| finding.finding_id == finding_id)
+            .ok_or(ResearchContractError::InvalidField("findingId"))?;
+        finding.waive(resolution_digest)?;
+        self.batch_digest = self.expected_digest()?;
+        self.validate()
+    }
+
+    fn validate_without_digest(&self) -> Result<(), ResearchContractError> {
+        if self.schema != RESEARCH_REVIEW_BATCH_SCHEMA_V1 {
+            return Err(ResearchContractError::UnsupportedSchema);
+        }
+        validate_id("batchId", &self.batch_id)?;
+        validate_id("projectId", &self.project_id)?;
+        validate_id("runId", &self.run_id)?;
+        validate_digest_field("evaluationRecordDigest", &self.evaluation_record_digest)?;
+        validate_digest_field("evidenceDigest", &self.evidence_digest)?;
+        if self.findings.is_empty() || self.findings.len() > RESEARCH_MAX_REVIEW_FINDINGS {
+            return Err(ResearchContractError::InvalidField("findings"));
+        }
+        for pair in self.findings.windows(2) {
+            if pair[0].finding_id >= pair[1].finding_id {
+                return Err(ResearchContractError::InvalidField("findings"));
+            }
+        }
+        for finding in &self.findings {
+            finding.validate()?;
+            if finding.project_id != self.project_id || finding.run_id != self.run_id {
+                return Err(ResearchContractError::InvalidField("finding.identity"));
+            }
+            if finding.evaluation_record_digest.as_deref()
+                != Some(self.evaluation_record_digest.as_str())
+            {
+                return Err(ResearchContractError::InvalidField(
+                    "finding.evaluationRecordDigest",
+                ));
+            }
+            if finding
+                .evidence_digests
+                .binary_search(&self.evidence_digest)
+                .is_err()
+            {
+                return Err(ResearchContractError::InvalidField(
+                    "finding.evidenceDigest",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn expected_digest(&self) -> Result<String, ResearchContractError> {
+        #[derive(Serialize)]
+        struct Identity<'a> {
+            schema: &'a str,
+            batch_id: &'a str,
+            project_id: &'a str,
+            run_id: &'a str,
+            evaluation_record_digest: &'a str,
+            evidence_digest: &'a str,
+            findings: &'a [ResearchReviewFindingV1],
+        }
+        digest(
+            RESEARCH_REVIEW_BATCH_DIGEST_DOMAIN,
+            &Identity {
+                schema: &self.schema,
+                batch_id: &self.batch_id,
+                project_id: &self.project_id,
+                run_id: &self.run_id,
+                evaluation_record_digest: &self.evaluation_record_digest,
+                evidence_digest: &self.evidence_digest,
+                findings: &self.findings,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evaluation::{EvaluationRecordV1, EvaluationResultV1, ExecutionTargetV1};
+    use crate::research::{
+        ResearchReviewCategoryV1, ResearchReviewSeverityV1, ResearchReviewStatusV1,
+    };
+
+    fn digest(ch: char) -> String {
+        format!("sha256:{}", ch.to_string().repeat(64))
+    }
+
+    fn finding(id: &str, record: &EvaluationRecordV1) -> ResearchReviewFindingV1 {
+        ResearchReviewFindingV1::new(
+            id,
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::Citation,
+            ResearchReviewSeverityV1::Warning,
+            "citation needs review",
+            None,
+            vec![record.result.evidence_digest.clone()],
+            record.result.evaluator_id.clone(),
+            3,
+        )
+        .unwrap()
+        .bind_evaluation_record(record)
+        .unwrap()
+    }
+
+    fn record() -> EvaluationRecordV1 {
+        EvaluationRecordV1::new(
+            EvaluationResultV1::new(
+                "reviewer",
+                ExecutionTargetV1::new("session-1", "run-1"),
+                "aux-1",
+                "needs_review",
+                serde_json::json!({"finding_count": 2}),
+                digest('b'),
+            )
+            .unwrap(),
+            2,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn batch_sorts_findings_and_keeps_human_decisions_explicit() {
+        let record = record();
+        let mut batch = ResearchReviewBatchV1::new(
+            "batch-1",
+            "project-1",
+            "run-1",
+            record.record_digest.clone(),
+            record.result.evidence_digest.clone(),
+            vec![finding("finding-2", &record), finding("finding-1", &record)],
+        )
+        .unwrap();
+        assert_eq!(batch.findings[0].finding_id, "finding-1");
+        assert!(batch
+            .findings
+            .iter()
+            .all(|finding| finding.status == ResearchReviewStatusV1::Open));
+        let before = batch.batch_digest.clone();
+        batch.resolve_finding("finding-1", digest('c')).unwrap();
+        assert_ne!(before, batch.batch_digest);
+        assert!(batch.validate().is_ok());
+    }
+
+    #[test]
+    fn batch_rejects_mixed_run_or_evidence_and_tampering() {
+        let record = record();
+        let other_run_record = EvaluationRecordV1::new(
+            EvaluationResultV1::new(
+                "reviewer",
+                ExecutionTargetV1::new("session-2", "run-2"),
+                "aux-2",
+                "needs_review",
+                serde_json::json!({"finding_count": 1}),
+                digest('b'),
+            )
+            .unwrap(),
+            2,
+        )
+        .unwrap();
+        let mixed = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-2",
+            digest('a'),
+            ResearchReviewCategoryV1::Citation,
+            ResearchReviewSeverityV1::Warning,
+            "citation needs review",
+            None,
+            vec![other_run_record.result.evidence_digest.clone()],
+            "reviewer",
+            3,
+        )
+        .unwrap()
+        .bind_evaluation_record(&other_run_record)
+        .unwrap();
+        assert_eq!(
+            ResearchReviewBatchV1::new(
+                "batch-1",
+                "project-1",
+                "run-1",
+                record.record_digest.clone(),
+                record.result.evidence_digest.clone(),
+                vec![mixed],
+            ),
+            Err(ResearchContractError::InvalidField("finding.identity"))
+        );
+
+        let mut other = finding("finding-1", &record);
+        other.run_id = "run-2".to_owned();
+        assert!(matches!(
+            ResearchReviewBatchV1::new(
+                "batch-1",
+                "project-1",
+                "run-1",
+                record.record_digest.clone(),
+                record.result.evidence_digest.clone(),
+                vec![other],
+            ),
+            Err(ResearchContractError::DigestMismatch("findingDigest"))
+        ));
+
+        let mut batch = ResearchReviewBatchV1::new(
+            "batch-1",
+            "project-1",
+            "run-1",
+            record.record_digest.clone(),
+            record.result.evidence_digest.clone(),
+            vec![finding("finding-1", &record)],
+        )
+        .unwrap();
+        batch.findings[0].message = "tampered".to_owned();
+        assert_eq!(
+            batch.validate(),
+            Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+}

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -27,6 +27,7 @@ interpret a review finding as approval.
 | `ResearchEvidenceFactV1` | `a3s.code.evidence-fact.v1` | Append-only, digest-only observation with a monotonic sequence and bounded metadata. |
 | `ResearchProvenanceReceiptV1` | `a3s.code.provenance-receipt.v1` | Binds an artifact to its inputs, workflow, code, environment, provider, optional model/seed, and validation output. |
 | `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; an optional immutable evaluation-record binding prevents evaluator, Run, or evidence drift; resolution and waiver are explicit lifecycle transitions. |
+| `ResearchReviewBatchV1` | `a3s.code.review-batch.v1` | Bounded immutable projection of one evaluator result into findings; all findings share the same project, Run, evaluation record, and evidence snapshot. |
 | `ResearchEventV1` | `a3s.code.science-event.v1` | Digest-only project/run event projection for Desktop and other hosts. |
 
 All IDs and text are bounded. Digests use the existing Code SHA-256 format.
@@ -63,6 +64,8 @@ raw model/tool output.
    `ResearchReviewFindingV1` values. Bind each finding to the exact
    `EvaluationRecordV1` with `bind_evaluation_record`; Code verifies that the
    evaluator, Run, and evidence snapshot match before accepting the binding.
+   Group the bound findings in a `ResearchReviewBatchV1` before publication so
+   a partial or mixed evaluator response cannot be presented as one review.
 5. Let the host apply its rubric, human approval, retention, and publication
    policy; Code only validates the supplied identities and lifecycle.
 


### PR DESCRIPTION
## Summary
- add ResearchReviewBatchV1 as a bounded publication boundary for reviewer responses
- require one project, Run, evaluation-record, and evidence identity for every finding
- canonicalize finding order and rebind batch digests after explicit resolve/waive transitions
- retain host-owned rubric, thresholds, approval, retention, and publication semantics

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable test --locked --no-default-features -p a3s-code-core research:: --lib (18 passed)
- cargo +stable clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings
- git diff --check