### PR TITLE
test(sdk): qualify provider pool health projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discovery lists the read-only operation. A repeated noisy-neighbor
   qualification confirms independent provider pools continue making progress
   while a blocked pool's waiters are cancelled and retained counters settle.
+- Added the versioned `model-generation-pool-health-v1` cross-SDK fixture.
+  Public Node.js, Python, and Go Session projections now share one bounded
+  redaction and aggregate contract; the opt-in Go bridge check exercises the
+  same contract through JSONL without retaining provider labels, credentials,
+  routing URLs, prompts, or request payloads.
 - Added bounded provider-pool health evidence. `TaskScheduler::quota_health`
   retains at most 64 recent digest-only quota epochs with admission, release,
   cancellation, rejection, peak, and wait-time counters. Sessions expose the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -495,12 +495,19 @@ cancellation, release, and bounded retention counters settle. No provider
 label, endpoint credential, prompt, output, or task label is added to scheduler
 state.
 
-The next admission slice is **P3/KRN-8 host qualification evidence**: exercise
-the common projection through real Node/Python/Go runtime fixtures and retain
-only bounded aggregate outcomes for release diagnostics. It must remain
-read-only metadata, avoid a second scheduler or metrics store, preserve the
-single Flow lease authority, and keep Gateway/host policy responsible for rate
-limits and billing.
+**P3/KRN-8 host qualification evidence is delivered.** The versioned
+`sdk/evaluation/model-generation-pool-health-v1.json` fixture is consumed by
+the public Node.js, Python, and Go Session surfaces. Each adapter checks the
+same digest-only identity, local reservation conservation, shared/local
+capacity bounds, bounded aggregate field set, and recursive redaction list;
+the Go adapter additionally exercises the real Rust JSONL bridge when
+`A3S_CODE_GO_BRIDGE_TEST_BINARY` is configured. The default fixture uses an
+unreachable endpoint and sentinel credential, so it makes no provider request
+and cannot turn a health read into a billing operation. Core's existing
+admission tests remain the authority for active, cancelled, released, and
+retained scheduler epochs. No second scheduler or metrics store was added;
+Flow remains the sole lease authority and Gateway/hosts own rate limits and
+billing.
 
 ### 3.4 Scoped capability program
 

--- a/sdk/evaluation/README.md
+++ b/sdk/evaluation/README.md
@@ -49,6 +49,25 @@ The Node fixture gate is part of `npm test`. Python and Go collect the fixture
 contract in their normal test suites; their real-provider tests skip unless
 `A3S_REAL_EVAL_ROOT` is set.
 
+## Provider-pool health fixture
+
+[`model-generation-pool-health-v1.json`](model-generation-pool-health-v1.json)
+is the language-neutral contract for the read-only provider/model capacity
+projection. It locks the schema and identity fields, a maximum sample window,
+the aggregate fields that may be retained, and the field names that must never
+appear in diagnostics. Node.js and Python run the fixture through their public
+native Session APIs; Go runs it through the public SDK and also has an opt-in
+Rust bridge path via `A3S_CODE_GO_BRIDGE_TEST_BINARY`.
+
+Each runner samples no more than three observations in the default test,
+checks local reservation conservation and shared identity equality, and emits
+only bounded maxima/counters in its aggregate. The fixture deliberately uses
+an unreachable endpoint and a sentinel credential: no model request is made,
+and the sentinel can only be detected if a secret or routing value leaks into
+the returned diagnostic object. These tests qualify projection shape and
+redaction; scheduler admission, cancellation, and release behavior remain
+covered by Core's provider-pool tests.
+
 ## Real DeepSeek matrix
 
 Build the native SDK artifact required by the language under test. For Go,

--- a/sdk/evaluation/model-generation-pool-health-v1.json
+++ b/sdk/evaluation/model-generation-pool-health-v1.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "report_schema_version": 1,
+  "fixture_id": "model-generation-pool-health-v1",
+  "sample_limit": 8,
+  "max_concurrency": 64,
+  "required_snapshot_fields": [
+    "pool",
+    "localMaxConcurrency",
+    "localReserved",
+    "localAvailable"
+  ],
+  "required_identity_fields": [
+    "schema",
+    "domain",
+    "digest"
+  ],
+  "aggregate_fields": [
+    "sampleCount",
+    "maxLocalReserved",
+    "maxSchedulerActive",
+    "maxSchedulerPending",
+    "admitted",
+    "released",
+    "cancelled",
+    "rejected"
+  ],
+  "forbidden_fields": [
+    "provider",
+    "model",
+    "endpoint",
+    "url",
+    "api_key",
+    "apiKey",
+    "authorization",
+    "prompt",
+    "request",
+    "label",
+    "secret",
+    "token"
+  ]
+}

--- a/sdk/go/model_generation_pool_health_fixture_test.go
+++ b/sdk/go/model_generation_pool_health_fixture_test.go
@@ -1,0 +1,245 @@
+package code
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type modelGenerationPoolHealthFixture struct {
+	SchemaVersion          uint     `json:"schema_version"`
+	ReportSchemaVersion    uint     `json:"report_schema_version"`
+	FixtureID              string   `json:"fixture_id"`
+	SampleLimit            uint     `json:"sample_limit"`
+	MaxConcurrency         uint64   `json:"max_concurrency"`
+	RequiredSnapshotFields []string `json:"required_snapshot_fields"`
+	RequiredIdentityFields []string `json:"required_identity_fields"`
+	AggregateFields        []string `json:"aggregate_fields"`
+	ForbiddenFields        []string `json:"forbidden_fields"`
+}
+
+func loadModelGenerationPoolHealthFixture(t *testing.T) modelGenerationPoolHealthFixture {
+	t.Helper()
+	_, source, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve Go fixture source path")
+	}
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(source), "..", "evaluation", "model-generation-pool-health-v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture modelGenerationPoolHealthFixture
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.SchemaVersion != 1 || fixture.ReportSchemaVersion != 1 ||
+		fixture.FixtureID == "" || fixture.SampleLimit == 0 || fixture.MaxConcurrency == 0 {
+		t.Fatalf("invalid model-generation pool health fixture: %#v", fixture)
+	}
+	return fixture
+}
+
+func TestModelGenerationPoolHealthFixtureWithRuntime(t *testing.T) {
+	fixture := loadModelGenerationPoolHealthFixture(t)
+	digest := sha256.Sum256([]byte("model-generation-pool-health-fixture"))
+	identity := ExecutionIdentityV1{
+		Schema: "a3s.code.execution-identity.v1",
+		Domain: "a3s.code.model-generation-pool.identity.v1",
+		Digest: "sha256:" + hex.EncodeToString(digest[:]),
+	}
+	runtime := &fakeRuntime{
+		request: func(_ context.Context, operation string, _ map[string]any) (any, error) {
+			if operation != "session_model_generation_pool_health" {
+				t.Fatalf("unexpected operation %q", operation)
+			}
+			return &ModelGenerationPoolHealthSnapshot{
+				Pool:                ModelGenerationPool{Identity: identity, MaxConcurrency: 1},
+				LocalMaxConcurrency: 1,
+				LocalAvailable:      1,
+				Scheduler: &TaskSchedulerQuotaHealthSnapshot{
+					Identity:  identity,
+					MaxActive: 1,
+					Observed:  true,
+				},
+			}, nil
+		},
+	}
+	session := testSession(runtime)
+	var aggregate modelGenerationPoolHealthAggregate
+	for sample := uint(0); sample < fixture.SampleLimit && sample < 3; sample++ {
+		health, err := session.ModelGenerationPoolHealth(context.Background())
+		if err != nil || health == nil {
+			t.Fatalf("pool health = %#v, %v", health, err)
+		}
+		validateModelGenerationPoolHealthFixture(t, health, fixture)
+		aggregate.observe(health)
+	}
+	if aggregate.SampleCount == 0 || aggregate.SampleCount > uint64(fixture.SampleLimit) {
+		t.Fatalf("aggregate sample count = %d", aggregate.SampleCount)
+	}
+	encoded, err := json.Marshal(aggregate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	assertFixtureFields(t, fields, fixture.AggregateFields)
+	assertNoForbiddenFields(t, fields, fixture.ForbiddenFields)
+}
+
+// TestModelGenerationPoolHealthFixtureWithRustBridge exercises the same
+// fixture through the real Go JSONL bridge when a matching bridge binary is
+// available. It is opt-in so ordinary SDK unit tests stay hermetic.
+func TestModelGenerationPoolHealthFixtureWithRustBridge(t *testing.T) {
+	binary := os.Getenv("A3S_CODE_GO_BRIDGE_TEST_BINARY")
+	if binary == "" {
+		t.Skip("set A3S_CODE_GO_BRIDGE_TEST_BINARY to run the Rust bridge fixture")
+	}
+	fixture := loadModelGenerationPoolHealthFixture(t)
+	ctx := context.Background()
+	agent, err := Create(ctx, `
+default_model = "openai/fixture-model"
+providers "openai" {
+  apiKey = "fixture-key"
+  baseUrl = "https://fixture.invalid/v1"
+  models "fixture-model" {
+    name = "Fixture Model"
+  }
+}
+`, WithLocalRuntimeOptions(WithBridgePath(binary)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = agent.Close(context.Background()) })
+	session, err := agent.Session(ctx, t.TempDir(), &SessionOptions{SessionID: "pool-health-fixture"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	health, err := session.ModelGenerationPoolHealth(ctx)
+	if err != nil || health == nil {
+		t.Fatalf("real bridge pool health = %#v, %v", health, err)
+	}
+	validateModelGenerationPoolHealthFixture(t, health, fixture)
+	if err := session.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type modelGenerationPoolHealthAggregate struct {
+	SampleCount         uint64 `json:"sampleCount"`
+	MaxLocalReserved    uint64 `json:"maxLocalReserved"`
+	MaxSchedulerActive  uint64 `json:"maxSchedulerActive"`
+	MaxSchedulerPending uint64 `json:"maxSchedulerPending"`
+	Admitted            uint64 `json:"admitted"`
+	Released            uint64 `json:"released"`
+	Cancelled           uint64 `json:"cancelled"`
+	Rejected            uint64 `json:"rejected"`
+}
+
+func (aggregate *modelGenerationPoolHealthAggregate) observe(health *ModelGenerationPoolHealthSnapshot) {
+	aggregate.SampleCount++
+	if health.LocalReserved > aggregate.MaxLocalReserved {
+		aggregate.MaxLocalReserved = health.LocalReserved
+	}
+	if health.Scheduler == nil {
+		return
+	}
+	if health.Scheduler.Active > aggregate.MaxSchedulerActive {
+		aggregate.MaxSchedulerActive = health.Scheduler.Active
+	}
+	if health.Scheduler.Pending > aggregate.MaxSchedulerPending {
+		aggregate.MaxSchedulerPending = health.Scheduler.Pending
+	}
+	if health.Scheduler.Admitted > aggregate.Admitted {
+		aggregate.Admitted = health.Scheduler.Admitted
+	}
+	if health.Scheduler.Released > aggregate.Released {
+		aggregate.Released = health.Scheduler.Released
+	}
+	if health.Scheduler.Cancelled > aggregate.Cancelled {
+		aggregate.Cancelled = health.Scheduler.Cancelled
+	}
+	if health.Scheduler.Rejected > aggregate.Rejected {
+		aggregate.Rejected = health.Scheduler.Rejected
+	}
+}
+
+func validateModelGenerationPoolHealthFixture(t *testing.T, health *ModelGenerationPoolHealthSnapshot, fixture modelGenerationPoolHealthFixture) {
+	t.Helper()
+	encoded, err := json.Marshal(health)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatal(err)
+	}
+	assertFixtureFields(t, fields, fixture.RequiredSnapshotFields)
+	assertNoForbiddenFields(t, fields, fixture.ForbiddenFields)
+	if health.Pool.MaxConcurrency == 0 || health.Pool.MaxConcurrency > fixture.MaxConcurrency {
+		t.Fatalf("pool max concurrency = %d", health.Pool.MaxConcurrency)
+	}
+	if health.LocalReserved+health.LocalAvailable != health.LocalMaxConcurrency ||
+		health.LocalMaxConcurrency > health.Pool.MaxConcurrency {
+		t.Fatalf("invalid local capacity: %#v", health)
+	}
+	if health.Pool.Identity.Schema == "" || health.Pool.Identity.Domain == "" || health.Pool.Identity.Digest == "" {
+		t.Fatalf("incomplete pool identity: %#v", health.Pool.Identity)
+	}
+	if health.Scheduler != nil {
+		if health.Scheduler.Identity != health.Pool.Identity {
+			t.Fatalf("scheduler identity drift: %#v vs %#v", health.Scheduler.Identity, health.Pool.Identity)
+		}
+		if health.Scheduler.MaxActive != health.Pool.MaxConcurrency ||
+			health.Scheduler.Active > health.Scheduler.MaxActive ||
+			health.Scheduler.Pending > health.Scheduler.MaxActive {
+			t.Fatalf("invalid scheduler capacity: %#v", health.Scheduler)
+		}
+	}
+	identityFields, ok := fields["pool"].(map[string]any)["identity"].(map[string]any)
+	if !ok {
+		t.Fatal("pool identity is not an object")
+	}
+	assertFixtureFields(t, identityFields, fixture.RequiredIdentityFields)
+}
+
+func assertFixtureFields(t *testing.T, object map[string]any, required []string) {
+	t.Helper()
+	for _, field := range required {
+		if _, ok := object[field]; !ok {
+			t.Fatalf("missing fixture field %q in %#v", field, object)
+		}
+	}
+}
+
+func assertNoForbiddenFields(t *testing.T, value any, forbidden []string) {
+	t.Helper()
+	blocked := make(map[string]struct{}, len(forbidden))
+	for _, field := range forbidden {
+		blocked[field] = struct{}{}
+	}
+	var visit func(any)
+	visit = func(current any) {
+		switch value := current.(type) {
+		case map[string]any:
+			for key, child := range value {
+				if _, ok := blocked[key]; ok {
+					t.Fatalf("forbidden diagnostic field %q", key)
+				}
+				visit(child)
+			}
+		case []any:
+			for _, child := range value {
+				visit(child)
+			}
+		}
+	}
+	visit(value)
+}

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -50,7 +50,7 @@
     "test": "npm run test:release-manifest && npm run test:evaluation-protocol && npm run test:runtime && npm run test:fixtures",
     "test:release-manifest": "node --test scripts/release-manifest.test.mjs scripts/patch-loader.test.mjs",
     "test:evaluation-protocol": "node ../../scripts/generate_evaluation_protocol_artifacts.mjs --check && node ../../scripts/check_evaluation_protocol_artifacts.mjs",
-    "test:runtime": "node test.mjs && node test_budget_guard.mjs && node test_callback_safety.mjs && node test_confirmation_inheritance.mjs && node test_session_close.mjs && node test_workspace_retrieval.mjs && node test_serve.mjs && node test-helpers.mjs",
+    "test:runtime": "node test.mjs && node test_budget_guard.mjs && node test_callback_safety.mjs && node test_confirmation_inheritance.mjs && node test_session_close.mjs && node test_model_generation_pool_health_fixture.mjs && node test_workspace_retrieval.mjs && node test_serve.mjs && node test-helpers.mjs",
     "test:fixtures": "node test_workspace_retrieval_real_deepseek.mjs --validate-fixture",
     "test:types": "tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --strict --skipLibCheck test-types.ts",
     "test:helpers": "node test-helpers.mjs"

--- a/sdk/node/src/tests.rs
+++ b/sdk/node/src/tests.rs
@@ -62,6 +62,207 @@ fn sdk_capability_inventory_is_projected_from_core_without_drift() {
 }
 
 #[test]
+fn model_generation_pool_health_fixture_is_bounded_and_secret_free() {
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "../../evaluation/model-generation-pool-health-v1.json"
+    ))
+    .expect("model-generation pool health fixture is valid JSON");
+    assert_eq!(fixture["schema_version"], 1);
+    assert_eq!(fixture["report_schema_version"], 1);
+    let sample_limit = fixture["sample_limit"]
+        .as_u64()
+        .expect("fixture sample limit")
+        .min(3);
+    assert!(sample_limit > 0);
+
+    let session = build_test_session();
+    let mut aggregate: Option<NodePoolHealthAggregate> = None;
+    for _ in 0..sample_limit {
+        let health = fallback_runtime()
+            .block_on(session.model_generation_pool_health())
+            .expect("Node pool health projection succeeds")
+            .expect("fixture client publishes a provider pool");
+        assert_node_pool_health_fixture(&health, &fixture);
+        let scheduler = health.scheduler.as_ref();
+        let sample = NodePoolHealthAggregate {
+            sample_count: 0,
+            max_local_reserved: health.local_reserved,
+            max_scheduler_active: scheduler.map(|value| value.active).unwrap_or(0),
+            max_scheduler_pending: scheduler.map(|value| value.pending).unwrap_or(0),
+            admitted: scheduler.map(|value| value.admitted).unwrap_or(0),
+            released: scheduler.map(|value| value.released).unwrap_or(0),
+            cancelled: scheduler.map(|value| value.cancelled).unwrap_or(0),
+            rejected: scheduler.map(|value| value.rejected).unwrap_or(0),
+        };
+        aggregate = Some(match aggregate {
+            Some(mut previous) => {
+                previous.sample_count += 1;
+                previous.max_local_reserved = previous.max_local_reserved.max(sample.max_local_reserved);
+                previous.max_scheduler_active = previous.max_scheduler_active.max(sample.max_scheduler_active);
+                previous.max_scheduler_pending = previous.max_scheduler_pending.max(sample.max_scheduler_pending);
+                previous.admitted = previous.admitted.max(sample.admitted);
+                previous.released = previous.released.max(sample.released);
+                previous.cancelled = previous.cancelled.max(sample.cancelled);
+                previous.rejected = previous.rejected.max(sample.rejected);
+                previous
+            }
+            None => NodePoolHealthAggregate {
+                sample_count: 1,
+                ..sample
+            },
+        });
+    }
+
+    let aggregate = aggregate.expect("at least one health sample");
+    let aggregate_json = serde_json::json!({
+        "sampleCount": aggregate.sample_count,
+        "maxLocalReserved": aggregate.max_local_reserved,
+        "maxSchedulerActive": aggregate.max_scheduler_active,
+        "maxSchedulerPending": aggregate.max_scheduler_pending,
+        "admitted": aggregate.admitted,
+        "released": aggregate.released,
+        "cancelled": aggregate.cancelled,
+        "rejected": aggregate.rejected,
+    });
+    let expected_fields = fixture["aggregate_fields"]
+        .as_array()
+        .expect("fixture aggregate fields")
+        .iter()
+        .map(|value| value.as_str().expect("aggregate field name"))
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual_fields = aggregate_json
+        .as_object()
+        .expect("aggregate object")
+        .keys()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(actual_fields, expected_fields);
+    assert!(aggregate.sample_count <= fixture["sample_limit"].as_u64().unwrap());
+}
+
+#[derive(Default)]
+struct NodePoolHealthAggregate {
+    sample_count: u64,
+    max_local_reserved: i64,
+    max_scheduler_active: i64,
+    max_scheduler_pending: i64,
+    admitted: i64,
+    released: i64,
+    cancelled: i64,
+    rejected: i64,
+}
+
+fn assert_node_pool_health_fixture(
+    health: &ModelGenerationPoolHealthSnapshot,
+    fixture: &serde_json::Value,
+) {
+    let snapshot = serde_json::json!({
+        "pool": {
+            "identity": {
+                "schema": health.pool.identity.schema.clone(),
+                "domain": health.pool.identity.domain.clone(),
+                "digest": health.pool.identity.digest.clone(),
+            },
+            "maxConcurrency": health.pool.max_concurrency,
+        },
+        "localMaxConcurrency": health.local_max_concurrency,
+        "localReserved": health.local_reserved,
+        "localAvailable": health.local_available,
+        "scheduler": health.scheduler.as_ref().map(|value| serde_json::json!({
+            "identity": {
+                "schema": value.identity.schema.clone(),
+                "domain": value.identity.domain.clone(),
+                "digest": value.identity.digest.clone(),
+            },
+            "maxActive": value.max_active,
+            "observed": value.observed,
+            "live": value.live,
+            "active": value.active,
+            "pending": value.pending,
+            "blocked": value.blocked,
+            "admitted": value.admitted,
+            "released": value.released,
+            "cancelled": value.cancelled,
+            "rejected": value.rejected,
+            "peakActive": value.peak_active,
+            "totalWaitMicros": value.total_wait_micros,
+            "averageWaitMicros": value.average_wait_micros,
+            "maxWaitMicros": value.max_wait_micros,
+        })),
+    });
+    for field in fixture["required_snapshot_fields"]
+        .as_array()
+        .expect("fixture snapshot fields")
+    {
+        let field = field.as_str().expect("snapshot field name");
+        assert!(snapshot.get(field).is_some(), "missing snapshot field {field}");
+    }
+    let forbidden = fixture["forbidden_fields"]
+        .as_array()
+        .expect("fixture forbidden fields")
+        .iter()
+        .map(|value| value.as_str().expect("forbidden field name"))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_no_forbidden_node_keys(&snapshot, &forbidden);
+    let identity = snapshot["pool"]["identity"]
+        .as_object()
+        .expect("pool identity object");
+    for field in fixture["required_identity_fields"]
+        .as_array()
+        .expect("fixture identity fields")
+    {
+        let field = field.as_str().expect("identity field name");
+        assert!(identity.get(field).is_some(), "missing identity field {field}");
+    }
+    let max_concurrency = fixture["max_concurrency"]
+        .as_i64()
+        .expect("fixture max concurrency");
+    assert!(health.pool.max_concurrency > 0);
+    assert!(health.pool.max_concurrency <= max_concurrency);
+    assert!(health.local_max_concurrency >= 0);
+    assert!(health.local_max_concurrency <= health.pool.max_concurrency);
+    assert!(health.local_reserved >= 0);
+    assert!(health.local_available >= 0);
+    assert_eq!(
+        health.local_reserved + health.local_available,
+        health.local_max_concurrency
+    );
+    assert_eq!(
+        health.pool.identity.domain,
+        a3s_code_core::execution_identity::MODEL_GENERATION_POOL_IDENTITY_DOMAIN_V1
+    );
+    assert!(health.pool.identity.digest.starts_with("sha256:"));
+    if let Some(scheduler) = &health.scheduler {
+        assert_eq!(scheduler.identity.schema, health.pool.identity.schema);
+        assert_eq!(scheduler.identity.domain, health.pool.identity.domain);
+        assert_eq!(scheduler.identity.digest, health.pool.identity.digest);
+        assert_eq!(scheduler.max_active, health.pool.max_concurrency);
+        assert!(scheduler.active <= scheduler.max_active);
+        assert!(scheduler.pending <= scheduler.max_active);
+    }
+}
+
+fn assert_no_forbidden_node_keys(
+    value: &serde_json::Value,
+    forbidden: &std::collections::BTreeSet<&str>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, child) in object {
+                assert!(!forbidden.contains(key.as_str()), "forbidden diagnostic field {key}");
+                assert_no_forbidden_node_keys(child, forbidden);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                assert_no_forbidden_node_keys(child, forbidden);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
 fn moli_diagnostics_are_projected_without_installing() {
     let info = crate::moli_runtime::moli_runtime_info(None);
     assert_eq!(info.schema, a3s_code_core::MOLI_RUNTIME_INFO_SCHEMA_V1);

--- a/sdk/node/test_model_generation_pool_health_fixture.mjs
+++ b/sdk/node/test_model_generation_pool_health_fixture.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import mod from './index.js'
+
+const fixture = JSON.parse(fs.readFileSync(
+  new URL('../evaluation/model-generation-pool-health-v1.json', import.meta.url),
+  'utf8',
+))
+assert.equal(fixture.schema_version, 1)
+assert.equal(fixture.report_schema_version, 1)
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'a3s-node-pool-health-'))
+const config = `
+default_model = "openai/fixture-model"
+providers "openai" {
+  apiKey = "fixture-key-never-sent"
+  baseUrl = "https://fixture.invalid/v1"
+  models "fixture-model" {
+    name = "Fixture Model"
+  }
+}
+`.trim()
+
+const agent = await mod.Agent.create(config)
+const session = agent.session(root, {
+  sessionId: 'node-pool-health-fixture',
+  planningMode: 'disabled',
+})
+
+try {
+  const snapshots = []
+  for (let index = 0; index < Math.min(fixture.sample_limit, 3); index += 1) {
+    const health = await session.modelGenerationPoolHealth()
+    assert.ok(health, 'configured provider must publish pool health')
+    snapshots.push(health)
+    for (const field of fixture.required_snapshot_fields) {
+      assert.ok(Object.hasOwn(health, field), `missing snapshot field ${field}`)
+    }
+    assert.ok(health.pool.maxConcurrency > 0)
+    assert.ok(health.pool.maxConcurrency <= fixture.max_concurrency)
+    assert.equal(
+      health.localReserved + health.localAvailable,
+      health.localMaxConcurrency,
+    )
+    assert.ok(health.localMaxConcurrency <= health.pool.maxConcurrency)
+    for (const field of fixture.required_identity_fields) {
+      assert.ok(Object.hasOwn(health.pool.identity, field), `missing identity field ${field}`)
+    }
+    assert.equal(
+      health.pool.identity.domain,
+      'a3s.code.model-generation-pool.identity.v1',
+    )
+    assert.match(health.pool.identity.digest, /^sha256:[0-9a-f]{64}$/)
+    if (health.scheduler) {
+      assert.deepEqual(health.scheduler.identity, health.pool.identity)
+      assert.equal(health.scheduler.maxActive, health.pool.maxConcurrency)
+      assert.ok(health.scheduler.active <= health.scheduler.maxActive)
+      assert.ok(health.scheduler.pending <= health.scheduler.maxActive)
+    }
+  }
+  assert.equal(snapshots.length, Math.min(fixture.sample_limit, 3))
+
+  const aggregate = {
+    sampleCount: snapshots.length,
+    maxLocalReserved: Math.max(...snapshots.map((value) => value.localReserved)),
+    maxSchedulerActive: Math.max(...snapshots.map((value) => value.scheduler?.active ?? 0)),
+    maxSchedulerPending: Math.max(...snapshots.map((value) => value.scheduler?.pending ?? 0)),
+    admitted: Math.max(...snapshots.map((value) => value.scheduler?.admitted ?? 0)),
+    released: Math.max(...snapshots.map((value) => value.scheduler?.released ?? 0)),
+    cancelled: Math.max(...snapshots.map((value) => value.scheduler?.cancelled ?? 0)),
+    rejected: Math.max(...snapshots.map((value) => value.scheduler?.rejected ?? 0)),
+  }
+  assert.deepEqual(
+    Object.keys(aggregate).sort(),
+    [...fixture.aggregate_fields].sort(),
+  )
+  const forbidden = new Set(fixture.forbidden_fields)
+  const walk = (value) => {
+    if (Array.isArray(value)) {
+      value.forEach(walk)
+      return
+    }
+    if (value && typeof value === 'object') {
+      for (const [key, child] of Object.entries(value)) {
+        assert.equal(forbidden.has(key), false, `forbidden diagnostic field ${key}`)
+        walk(child)
+      }
+    }
+  }
+  walk({ snapshots, aggregate })
+} finally {
+  await session.closeAsync()
+  await agent.close()
+}
+
+console.log('node model-generation pool health fixture passed')

--- a/sdk/python/src/tests.rs
+++ b/sdk/python/src/tests.rs
@@ -87,6 +87,200 @@ fn sdk_capability_inventory_is_projected_from_core_without_drift() {
 }
 
 #[test]
+fn model_generation_pool_health_fixture_is_bounded_and_secret_free() {
+    let fixture: serde_json::Value = serde_json::from_str(include_str!(
+        "../../evaluation/model-generation-pool-health-v1.json"
+    ))
+    .expect("model-generation pool health fixture is valid JSON");
+    assert_eq!(fixture["schema_version"], 1);
+    assert_eq!(fixture["report_schema_version"], 1);
+    let sample_limit = fixture["sample_limit"]
+        .as_u64()
+        .expect("fixture sample limit")
+        .min(3);
+    assert!(sample_limit > 0);
+
+    let session = build_test_session();
+    let mut aggregate: Option<PythonPoolHealthAggregate> = None;
+    for _ in 0..sample_limit {
+        let snapshot = serde_json::to_value(
+            get_runtime()
+                .block_on(session.inner.model_generation_pool_health())
+                .expect("Python pool health projection succeeds")
+                .expect("fixture client publishes a provider pool"),
+        )
+        .expect("serialize Python pool health");
+        assert_python_pool_health_fixture(&snapshot, &fixture);
+        let scheduler = snapshot.get("scheduler");
+        let sample = PythonPoolHealthAggregate {
+            sample_count: 0,
+            max_local_reserved: snapshot["localReserved"].as_u64().unwrap_or(0),
+            max_scheduler_active: scheduler
+                .and_then(|value| value.get("active"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            max_scheduler_pending: scheduler
+                .and_then(|value| value.get("pending"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            admitted: scheduler
+                .and_then(|value| value.get("admitted"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            released: scheduler
+                .and_then(|value| value.get("released"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            cancelled: scheduler
+                .and_then(|value| value.get("cancelled"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            rejected: scheduler
+                .and_then(|value| value.get("rejected"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+        };
+        aggregate = Some(match aggregate {
+            Some(mut previous) => {
+                previous.sample_count += 1;
+                previous.max_local_reserved = previous.max_local_reserved.max(sample.max_local_reserved);
+                previous.max_scheduler_active = previous.max_scheduler_active.max(sample.max_scheduler_active);
+                previous.max_scheduler_pending = previous.max_scheduler_pending.max(sample.max_scheduler_pending);
+                previous.admitted = previous.admitted.max(sample.admitted);
+                previous.released = previous.released.max(sample.released);
+                previous.cancelled = previous.cancelled.max(sample.cancelled);
+                previous.rejected = previous.rejected.max(sample.rejected);
+                previous
+            }
+            None => PythonPoolHealthAggregate {
+                sample_count: 1,
+                ..sample
+            },
+        });
+    }
+
+    let aggregate = aggregate.expect("at least one health sample");
+    let aggregate_json = serde_json::json!({
+        "sampleCount": aggregate.sample_count,
+        "maxLocalReserved": aggregate.max_local_reserved,
+        "maxSchedulerActive": aggregate.max_scheduler_active,
+        "maxSchedulerPending": aggregate.max_scheduler_pending,
+        "admitted": aggregate.admitted,
+        "released": aggregate.released,
+        "cancelled": aggregate.cancelled,
+        "rejected": aggregate.rejected,
+    });
+    let expected_fields = fixture["aggregate_fields"]
+        .as_array()
+        .expect("fixture aggregate fields")
+        .iter()
+        .map(|value| value.as_str().expect("aggregate field name"))
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual_fields = aggregate_json
+        .as_object()
+        .expect("aggregate object")
+        .keys()
+        .map(String::as_str)
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(actual_fields, expected_fields);
+    assert!(aggregate.sample_count <= fixture["sample_limit"].as_u64().unwrap());
+}
+
+#[derive(Default)]
+struct PythonPoolHealthAggregate {
+    sample_count: u64,
+    max_local_reserved: u64,
+    max_scheduler_active: u64,
+    max_scheduler_pending: u64,
+    admitted: u64,
+    released: u64,
+    cancelled: u64,
+    rejected: u64,
+}
+
+fn assert_python_pool_health_fixture(
+    snapshot: &serde_json::Value,
+    fixture: &serde_json::Value,
+) {
+    let object = snapshot.as_object().expect("pool health object");
+    for field in fixture["required_snapshot_fields"]
+        .as_array()
+        .expect("fixture snapshot fields")
+    {
+        let field = field.as_str().expect("snapshot field name");
+        assert!(object.contains_key(field), "missing snapshot field {field}");
+    }
+    let forbidden = fixture["forbidden_fields"]
+        .as_array()
+        .expect("fixture forbidden fields")
+        .iter()
+        .map(|value| value.as_str().expect("forbidden field name"))
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_no_forbidden_python_keys(snapshot, &forbidden);
+    let identity = &snapshot["pool"]["identity"];
+    for field in fixture["required_identity_fields"]
+        .as_array()
+        .expect("fixture identity fields")
+    {
+        let field = field.as_str().expect("identity field name");
+        assert!(identity.get(field).is_some(), "missing identity field {field}");
+    }
+    let max_concurrency = fixture["max_concurrency"]
+        .as_u64()
+        .expect("fixture max concurrency");
+    let pool_max = snapshot["pool"]["maxConcurrency"]
+        .as_u64()
+        .expect("pool max concurrency");
+    let local_max = snapshot["localMaxConcurrency"]
+        .as_u64()
+        .expect("local max concurrency");
+    assert!(pool_max > 0 && pool_max <= max_concurrency);
+    assert!(local_max <= pool_max);
+    assert_eq!(
+        snapshot["localReserved"].as_u64().unwrap()
+            + snapshot["localAvailable"].as_u64().unwrap(),
+        local_max
+    );
+    assert_eq!(
+        identity["domain"],
+        a3s_code_core::execution_identity::MODEL_GENERATION_POOL_IDENTITY_DOMAIN_V1
+    );
+    assert!(identity["digest"].as_str().unwrap().starts_with("sha256:"));
+    if let Some(scheduler) = snapshot.get("scheduler") {
+        assert_eq!(scheduler["identity"], identity.clone());
+        assert_eq!(scheduler["maxActive"], snapshot["pool"]["maxConcurrency"]);
+        assert!(
+            scheduler["active"].as_u64().unwrap()
+                <= scheduler["maxActive"].as_u64().unwrap()
+        );
+        assert!(
+            scheduler["pending"].as_u64().unwrap()
+                <= scheduler["maxActive"].as_u64().unwrap()
+        );
+    }
+}
+
+fn assert_no_forbidden_python_keys(
+    value: &serde_json::Value,
+    forbidden: &std::collections::BTreeSet<&str>,
+) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for (key, child) in object {
+                assert!(!forbidden.contains(key.as_str()), "forbidden diagnostic field {key}");
+                assert_no_forbidden_python_keys(child, forbidden);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                assert_no_forbidden_python_keys(child, forbidden);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
 fn moli_diagnostics_are_projected_without_installing() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {

--- a/sdk/python/tests/test_model_generation_pool_health_fixture.py
+++ b/sdk/python/tests/test_model_generation_pool_health_fixture.py
@@ -1,0 +1,114 @@
+"""Cross-SDK contract checks for secret-free provider-pool health."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from a3s_code import Agent, SessionOptions
+
+
+FIXTURE = json.loads(
+    (
+        Path(__file__).resolve().parents[2]
+        / "evaluation"
+        / "model-generation-pool-health-v1.json"
+    ).read_text(encoding="utf-8")
+)
+INLINE_CONFIG = """
+default_model = "openai/fixture-model"
+providers "openai" {
+  apiKey = "fixture-key-never-sent"
+  baseUrl = "https://fixture.invalid/v1"
+  models "fixture-model" {
+    name = "Fixture Model"
+  }
+}
+""".strip()
+
+
+def _assert_no_forbidden_fields(value: Any) -> None:
+    forbidden = set(FIXTURE["forbidden_fields"])
+    if isinstance(value, dict):
+        for key, child in value.items():
+            assert key not in forbidden, f"forbidden diagnostic field {key}"
+            _assert_no_forbidden_fields(child)
+    elif isinstance(value, list):
+        for child in value:
+            _assert_no_forbidden_fields(child)
+
+
+def _assert_snapshot(health: dict[str, Any]) -> None:
+    for field in FIXTURE["required_snapshot_fields"]:
+        assert field in health, f"missing snapshot field {field}"
+    assert 0 < health["pool"]["maxConcurrency"] <= FIXTURE["max_concurrency"]
+    assert health["localReserved"] + health["localAvailable"] == health[
+        "localMaxConcurrency"
+    ]
+    assert health["localMaxConcurrency"] <= health["pool"]["maxConcurrency"]
+    identity = health["pool"]["identity"]
+    for field in FIXTURE["required_identity_fields"]:
+        assert field in identity, f"missing identity field {field}"
+    assert identity["domain"] == "a3s.code.model-generation-pool.identity.v1"
+    assert identity["digest"].startswith("sha256:")
+    scheduler = health.get("scheduler")
+    if scheduler is not None:
+        assert scheduler["identity"] == identity
+        assert scheduler["maxActive"] == health["pool"]["maxConcurrency"]
+        assert scheduler["active"] <= scheduler["maxActive"]
+        assert scheduler["pending"] <= scheduler["maxActive"]
+    _assert_no_forbidden_fields(health)
+
+
+def test_model_generation_pool_health_fixture() -> None:
+    async def scenario() -> None:
+        agent = await Agent.create_async(INLINE_CONFIG)
+        with tempfile.TemporaryDirectory(prefix="a3s-python-pool-health-") as workspace:
+            options = SessionOptions()
+            options.session_id = "python-pool-health-fixture"
+            session = await agent.session_async(workspace, options)
+            try:
+                snapshots = []
+                for _ in range(min(FIXTURE["sample_limit"], 3)):
+                    health = session.model_generation_pool_health()
+                    assert health is not None
+                    _assert_snapshot(health)
+                    snapshots.append(health)
+                aggregate = {
+                    "sampleCount": len(snapshots),
+                    "maxLocalReserved": max(value["localReserved"] for value in snapshots),
+                    "maxSchedulerActive": max(
+                        (value.get("scheduler") or {}).get("active", 0)
+                        for value in snapshots
+                    ),
+                    "maxSchedulerPending": max(
+                        (value.get("scheduler") or {}).get("pending", 0)
+                        for value in snapshots
+                    ),
+                    "admitted": max(
+                        (value.get("scheduler") or {}).get("admitted", 0)
+                        for value in snapshots
+                    ),
+                    "released": max(
+                        (value.get("scheduler") or {}).get("released", 0)
+                        for value in snapshots
+                    ),
+                    "cancelled": max(
+                        (value.get("scheduler") or {}).get("cancelled", 0)
+                        for value in snapshots
+                    ),
+                    "rejected": max(
+                        (value.get("scheduler") or {}).get("rejected", 0)
+                        for value in snapshots
+                    ),
+                }
+                assert set(aggregate) == set(FIXTURE["aggregate_fields"])
+                _assert_no_forbidden_fields(aggregate)
+            finally:
+                await session.close_async()
+        await agent.close_async()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Adds the P3/KRN-8 host qualification slice for provider/model generation-pool health.\n\n- adds versioned sdk/evaluation/model-generation-pool-health-v1.json contract\n- exercises the public Node.js and Python Session surfaces with bounded samples\n- adds Go SDK validation plus an opt-in real Rust JSONL bridge test\n- asserts digest-only identity, local reservation conservation, shared identity equality, capacity bounds, bounded aggregate fields, and recursive redaction\n- updates SDK evaluation docs, Roadmap, and Unreleased changelog\n\nValidation:\n- cargo +stable fmt --all -- --check\n- cargo +stable check --manifest-path sdk/node/Cargo.toml --locked --no-default-features --tests\n- cargo +stable check --manifest-path sdk/python/Cargo.toml --locked --no-default-features --tests\n- go test ./... (sdk/go)\n- Node/Python fixture scripts syntax and JSON contract checks\n\nThe native Node/Python runtime scripts require their built artifacts; the opt-in Go bridge path requires A3S_CODE_GO_BRIDGE_TEST_BINARY. Core remains the authority for active/cancelled/released admission lifecycle tests; no second scheduler or metrics store is introduced.