### PR TITLE
feat: bind review findings to provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Research review findings can now bind an optional immutable provenance
+  receipt. Code rejects project, Run, artifact, and evidence-input drift while
+  preserving legacy finding identities and keeping reviewer policy host-owned.
 - Added cross-host provider-pool health consumption. Node.js, Python, and Go
   sessions expose the same secret-free local/shared projection (the Go JSONL
   bridge advertises `session_model_generation_pool_health`), and capability

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,7 @@ decides how to search, review, approve, retain, and publish results.
 | --- | --- | --- | --- |
 | `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Twenty focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
 | `RESEARCH-EXEC1` | Delivered | Host adapter qualification drives a research run through source capture, evidence append, create-only content-addressed artifact publication, and evaluator dispatch while retaining one Code Run identity; exact execution-target validation and explicit Run-aware Core-event projection are covered | `research_execution_qualification` passes restart/replay, cancellation terminality, contiguous evidence, artifact immutability, file-backed evaluator dispatch/result recovery, and exact Code/Use binding checks |
-| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to an immutable evaluator result without introducing a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, evidence, duplicate-id, or partial-batch drift |
+| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to immutable evaluator and optional artifact-provenance records without introducing a Core rubric | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, evidence, provenance, duplicate-id, or partial-batch drift |
 
 The delivered contract slice is documented in
 [Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
@@ -279,6 +279,12 @@ all findings, canonical finding ordering, and an updated batch digest after an
 explicit resolution or waiver. It remains a validation primitive: reviewer
 rubrics, severity thresholds, approval, retention, and publication stay with
 the host or Desktop.
+
+Findings may additionally carry a provenance-receipt digest. The optional
+binding is backward compatible with legacy findings, but once present it is
+included in the finding digest and cannot be replaced without producing a new
+finding identity. This makes a reviewer observation address both the exact
+artifact and the reproducibility receipt used to produce it.
 
 ### 3.3.1 Workflow result convergence
 

--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -105,6 +105,11 @@ pub struct ResearchReviewFindingV1 {
     /// findings created before evaluator-result binding was available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub evaluation_record_digest: Option<String>,
+    /// Optional digest of the immutable provenance receipt for the reviewed
+    /// artifact.  It is optional for compatibility with findings created
+    /// before provenance binding was available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_receipt_digest: Option<String>,
     pub observed_at_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_digest: Option<String>,
@@ -142,6 +147,7 @@ impl ResearchReviewFindingV1 {
             evidence_digests,
             evaluator_id: evaluator_id.into(),
             evaluation_record_digest: None,
+            provenance_receipt_digest: None,
             observed_at_ms,
             resolution_digest: None,
             finding_digest: String::new(),
@@ -194,6 +200,51 @@ impl ResearchReviewFindingV1 {
             ));
         }
         self.evaluation_record_digest = Some(record.record_digest.clone());
+        self.finding_digest = self.expected_digest()?;
+        self.validate()?;
+        Ok(self)
+    }
+
+    /// Bind this finding to the exact provenance receipt for its artifact.
+    ///
+    /// A provenance receipt is host-produced, but Code can still reject an
+    /// artifact/project/Run mismatch and require that the finding retain one
+    /// of the receipt's input evidence digests.  This keeps reviewer policy
+    /// outside Core while preventing a valid receipt from being attached to a
+    /// different scientific object.
+    pub fn bind_provenance_receipt(
+        mut self,
+        receipt: &crate::research::ResearchProvenanceReceiptV1,
+    ) -> Result<Self, ResearchContractError> {
+        self.validate()?;
+        receipt
+            .validate()
+            .map_err(|_| ResearchContractError::InvalidField("provenanceReceipt"))?;
+        if receipt.project_id != self.project_id {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.projectId",
+            ));
+        }
+        if receipt.run_id != self.run_id {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.runId",
+            ));
+        }
+        if receipt.artifact_digest != self.artifact_digest {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.artifactDigest",
+            ));
+        }
+        if !receipt
+            .input_digests
+            .iter()
+            .any(|digest| self.evidence_digests.binary_search(digest).is_ok())
+        {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.inputDigests",
+            ));
+        }
+        self.provenance_receipt_digest = Some(receipt.receipt_digest.clone());
         self.finding_digest = self.expected_digest()?;
         self.validate()?;
         Ok(self)
@@ -277,6 +328,9 @@ impl ResearchReviewFindingV1 {
         if let Some(evaluation_record_digest) = &self.evaluation_record_digest {
             validate_digest_field("evaluationRecordDigest", evaluation_record_digest)?;
         }
+        if let Some(provenance_receipt_digest) = &self.provenance_receipt_digest {
+            validate_digest_field("provenanceReceiptDigest", provenance_receipt_digest)?;
+        }
         Ok(())
     }
 
@@ -299,6 +353,46 @@ impl ResearchReviewFindingV1 {
             resolution_digest: Option<&'a str>,
         }
         let Some(evaluation_record_digest) = self.evaluation_record_digest.as_deref() else {
+            if let Some(provenance_receipt_digest) = self.provenance_receipt_digest.as_deref() {
+                #[derive(Serialize)]
+                struct ProvenanceBoundIdentity<'a> {
+                    schema: &'a str,
+                    finding_id: &'a str,
+                    project_id: &'a str,
+                    run_id: &'a str,
+                    artifact_digest: &'a str,
+                    category: ResearchReviewCategoryV1,
+                    severity: ResearchReviewSeverityV1,
+                    status: ResearchReviewStatusV1,
+                    message: &'a str,
+                    location: &'a Option<ResearchReviewLocationV1>,
+                    evidence_digests: &'a [String],
+                    evaluator_id: &'a str,
+                    provenance_receipt_digest: &'a str,
+                    observed_at_ms: u64,
+                    resolution_digest: Option<&'a str>,
+                }
+                return digest(
+                    RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
+                    &ProvenanceBoundIdentity {
+                        schema: &self.schema,
+                        finding_id: &self.finding_id,
+                        project_id: &self.project_id,
+                        run_id: &self.run_id,
+                        artifact_digest: &self.artifact_digest,
+                        category: self.category,
+                        severity: self.severity,
+                        status: self.status,
+                        message: &self.message,
+                        location: &self.location,
+                        evidence_digests: &self.evidence_digests,
+                        evaluator_id: &self.evaluator_id,
+                        provenance_receipt_digest,
+                        observed_at_ms: self.observed_at_ms,
+                        resolution_digest: self.resolution_digest.as_deref(),
+                    },
+                );
+            }
             return digest(
                 RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
                 &LegacyIdentity {
@@ -319,6 +413,47 @@ impl ResearchReviewFindingV1 {
                 },
             );
         };
+        let Some(provenance_receipt_digest) = self.provenance_receipt_digest.as_deref() else {
+            #[derive(Serialize)]
+            struct BoundIdentity<'a> {
+                schema: &'a str,
+                finding_id: &'a str,
+                project_id: &'a str,
+                run_id: &'a str,
+                artifact_digest: &'a str,
+                category: ResearchReviewCategoryV1,
+                severity: ResearchReviewSeverityV1,
+                status: ResearchReviewStatusV1,
+                message: &'a str,
+                location: &'a Option<ResearchReviewLocationV1>,
+                evidence_digests: &'a [String],
+                evaluator_id: &'a str,
+                evaluation_record_digest: &'a str,
+                observed_at_ms: u64,
+                resolution_digest: Option<&'a str>,
+            }
+            return digest(
+                RESEARCH_REVIEW_FINDING_DIGEST_DOMAIN,
+                &BoundIdentity {
+                    schema: &self.schema,
+                    finding_id: &self.finding_id,
+                    project_id: &self.project_id,
+                    run_id: &self.run_id,
+                    artifact_digest: &self.artifact_digest,
+                    category: self.category,
+                    severity: self.severity,
+                    status: self.status,
+                    message: &self.message,
+                    location: &self.location,
+                    evidence_digests: &self.evidence_digests,
+                    evaluator_id: &self.evaluator_id,
+                    evaluation_record_digest,
+                    observed_at_ms: self.observed_at_ms,
+                    resolution_digest: self.resolution_digest.as_deref(),
+                },
+            );
+        };
+
         #[derive(Serialize)]
         struct BoundIdentity<'a> {
             schema: &'a str,
@@ -334,6 +469,7 @@ impl ResearchReviewFindingV1 {
             evidence_digests: &'a [String],
             evaluator_id: &'a str,
             evaluation_record_digest: &'a str,
+            provenance_receipt_digest: &'a str,
             observed_at_ms: u64,
             resolution_digest: Option<&'a str>,
         }
@@ -353,6 +489,7 @@ impl ResearchReviewFindingV1 {
                 evidence_digests: &self.evidence_digests,
                 evaluator_id: &self.evaluator_id,
                 evaluation_record_digest,
+                provenance_receipt_digest,
                 observed_at_ms: self.observed_at_ms,
                 resolution_digest: self.resolution_digest.as_deref(),
             },
@@ -458,6 +595,118 @@ mod tests {
         assert_eq!(
             tampered.validate(),
             Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+
+    #[test]
+    fn finding_binds_the_exact_artifact_provenance_without_importing_policy() {
+        let evidence_digest = digest('b');
+        let receipt = crate::research::ResearchProvenanceReceiptV1::new(
+            "project-1",
+            4,
+            "run-1",
+            "figure-1",
+            crate::research::ResearchArtifactKindV1::Figure,
+            digest('a'),
+            vec![evidence_digest.clone(), digest('c')],
+            digest('d'),
+            digest('e'),
+            digest('f'),
+            "fixture-provider",
+            Some(digest('1')),
+            Some(7),
+            Some(digest('2')),
+        )
+        .unwrap();
+        let finding = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::FigureCode,
+            ResearchReviewSeverityV1::Warning,
+            "Figure provenance must remain reproducible.",
+            None,
+            vec![evidence_digest],
+            "reproducibility-reviewer",
+            8,
+        )
+        .unwrap()
+        .bind_provenance_receipt(&receipt)
+        .unwrap();
+
+        assert_eq!(
+            finding.provenance_receipt_digest.as_deref(),
+            Some(receipt.receipt_digest.as_str())
+        );
+        assert!(finding.validate().is_ok());
+        let mut tampered = finding;
+        tampered.provenance_receipt_digest = Some(digest('9'));
+        assert_eq!(
+            tampered.validate(),
+            Err(ResearchContractError::DigestMismatch("findingDigest"))
+        );
+    }
+
+    #[test]
+    fn finding_rejects_provenance_from_another_artifact_or_evidence_window() {
+        let receipt = crate::research::ResearchProvenanceReceiptV1::new(
+            "project-1",
+            4,
+            "run-1",
+            "figure-1",
+            crate::research::ResearchArtifactKindV1::Figure,
+            digest('a'),
+            vec![digest('b')],
+            digest('c'),
+            digest('d'),
+            digest('e'),
+            "fixture-provider",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let other_artifact = ResearchReviewFindingV1::new(
+            "finding-1",
+            "project-1",
+            "run-1",
+            digest('f'),
+            ResearchReviewCategoryV1::FigureCode,
+            ResearchReviewSeverityV1::Warning,
+            "wrong artifact",
+            None,
+            vec![digest('b')],
+            "reviewer",
+            8,
+        )
+        .unwrap();
+        assert_eq!(
+            other_artifact.bind_provenance_receipt(&receipt),
+            Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.artifactDigest"
+            ))
+        );
+
+        let other_evidence = ResearchReviewFindingV1::new(
+            "finding-2",
+            "project-1",
+            "run-1",
+            digest('a'),
+            ResearchReviewCategoryV1::FigureCode,
+            ResearchReviewSeverityV1::Warning,
+            "wrong evidence",
+            None,
+            vec![digest('f')],
+            "reviewer",
+            8,
+        )
+        .unwrap();
+        assert_eq!(
+            other_evidence.bind_provenance_receipt(&receipt),
+            Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.inputDigests"
+            ))
         );
     }
 

--- a/core/tests/research_execution_qualification.rs
+++ b/core/tests/research_execution_qualification.rs
@@ -466,6 +466,8 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
         61_004,
     )
     .unwrap()
+    .bind_provenance_receipt(&reopened_receipt)
+    .unwrap()
     .bind_evaluation_record(&reopened_record)
     .unwrap();
     let batch = ResearchReviewBatchV1::new(
@@ -479,6 +481,10 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
     .unwrap();
     assert!(batch.validate().is_ok());
     assert_eq!(batch.findings[0].status, ResearchReviewStatusV1::Open);
+    assert_eq!(
+        batch.findings[0].provenance_receipt_digest.as_deref(),
+        Some(reopened_receipt.receipt_digest.as_str())
+    );
 }
 
 #[tokio::test]

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -26,7 +26,7 @@ interpret a review finding as approval.
 | `ResearchRunV1` | `a3s.code.research-run.v1` | Binds project revision, source/evidence snapshots, Code/Use capability identity, provider/model, reproducibility promise, and lifecycle status. |
 | `ResearchEvidenceFactV1` | `a3s.code.evidence-fact.v1` | Append-only, digest-only observation with a monotonic sequence and bounded metadata. |
 | `ResearchProvenanceReceiptV1` | `a3s.code.provenance-receipt.v1` | Binds an artifact to its inputs, workflow, code, environment, provider, optional model/seed, and validation output. |
-| `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; an optional immutable evaluation-record binding prevents evaluator, Run, or evidence drift; resolution and waiver are explicit lifecycle transitions. |
+| `ResearchReviewFindingV1` | `a3s.code.review-finding.v1` | Bounded host-produced observation linked to exact artifact and evidence digests; optional immutable provenance-receipt and evaluation-record bindings prevent artifact, evaluator, Run, or evidence drift; resolution and waiver are explicit lifecycle transitions. |
 | `ResearchReviewBatchV1` | `a3s.code.review-batch.v1` | Bounded immutable projection of one evaluator result into findings; all findings share the same project, Run, evaluation record, and evidence snapshot. |
 | `ResearchEventV1` | `a3s.code.science-event.v1` | Digest-only project/run event projection for Desktop and other hosts. |
 
@@ -62,7 +62,10 @@ raw model/tool output.
    Use `ResearchEventV1::from_core_event_for_run` when adapting Core events so
    an opaque operation id cannot be mistaken for the bare Run id.
 3. Materialize each output as a content-addressed artifact and publish a
-   `ResearchProvenanceReceiptV1`.
+   `ResearchProvenanceReceiptV1`. Bind a finding to that receipt with
+   `ResearchReviewFindingV1::bind_provenance_receipt`; Code checks the exact
+   project, Run, artifact digest, and at least one retained input evidence
+   digest without interpreting the scientific rubric.
 4. Run a host-selected evaluator through the generic Code evaluation
    substrate, then project its bounded observations into
    `ResearchReviewFindingV1` values. Bind each finding to the exact


### PR DESCRIPTION
## Summary
- add optional `ResearchReviewFindingV1` provenance-receipt binding
- reject project, Run, artifact, and evidence-input drift while preserving legacy digests
- extend the end-to-end research qualification and docs

## Validation
- `cargo +stable fmt --all -- --check`
- `cargo +stable check --locked --no-default-features --tests`
- `cargo +stable clippy --locked --no-default-features --test research_execution_qualification -- -D warnings`
- `cargo +stable test --locked --no-default-features -p a3s-code-core research:: --lib` (22 passed)
- `cargo +stable test --locked --no-default-features --test research_execution_qualification` (3 passed)