### PR TITLE
Bind reviewer provenance to the admitted Run revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reviewer finding locations now reject zero-based or orphaned coordinates;
   optional columns require a one-based line so citation and figure/code links
   cannot carry ambiguous source positions.
+- Added strict Run-aware provenance binding for reviewer findings. Hosts can
+  pass the admitted `ResearchRunV1` so Code rejects project-revision drift in
+  addition to project, Run, artifact, and evidence-input mismatches; the
+  object-only compatibility binding remains available for older callers.
 - Added schema-v2 integrity fencing for persistent zvec generations. Reopen
   validates chunk payload digests, stable IDs, ranges, canonical digests, and
   duplicate IDs; corrupted generations fail closed and are rebuilt from the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,7 @@ decides how to search, review, approve, retain, and publish results.
 | --- | --- | --- | --- |
 | `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Twenty focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
 | `RESEARCH-EXEC1` | Delivered | Host adapter qualification drives a research run through source capture, evidence append, create-only content-addressed artifact publication, and evaluator dispatch while retaining one Code Run identity; exact execution-target validation and explicit Run-aware Core-event projection are covered | `research_execution_qualification` passes restart/replay, cancellation terminality, contiguous evidence, artifact immutability, file-backed evaluator dispatch/result recovery, and exact Code/Use binding checks |
-| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to immutable evaluator and optional artifact-provenance records without introducing a Core rubric; finding locations enforce one-based line/column coordinates | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, evidence, provenance, duplicate-id, partial-batch drift, and malformed source locations |
+| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to immutable evaluator and optional artifact-provenance records without introducing a Core rubric; strict Run-aware provenance binding also fences project-revision drift, and finding locations enforce one-based line/column coordinates | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, project-revision, evidence, provenance, duplicate-id, partial-batch drift, and malformed source locations |
 
 The delivered contract slice is documented in
 [Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
@@ -285,6 +285,13 @@ binding is backward compatible with legacy findings, but once present it is
 included in the finding digest and cannot be replaced without producing a new
 finding identity. This makes a reviewer observation address both the exact
 artifact and the reproducibility receipt used to produce it.
+
+When the admitted `ResearchRunV1` is available, hosts should use
+`bind_provenance_receipt_for_run`. In addition to the artifact, project, Run,
+and evidence checks, this verifies that the receipt's project revision is the
+revision admitted for that Run. The compatibility method
+`bind_provenance_receipt` intentionally keeps its original object-only
+semantics for older integrations.
 
 ### 3.3.1 Workflow result convergence
 

--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -260,6 +260,38 @@ impl ResearchReviewFindingV1 {
         Ok(self)
     }
 
+    /// Bind this finding to a provenance receipt and the exact research Run
+    /// admission that produced it.
+    ///
+    /// [`bind_provenance_receipt`](Self::bind_provenance_receipt) remains
+    /// available for compatibility with callers that only have the finding
+    /// and receipt.  New reviewer pipelines should pass the admitted Run as
+    /// well so Code can reject a receipt from another project revision.
+    pub fn bind_provenance_receipt_for_run(
+        self,
+        receipt: &crate::research::ResearchProvenanceReceiptV1,
+        run: &crate::research::ResearchRunV1,
+    ) -> Result<Self, ResearchContractError> {
+        self.validate()?;
+        run.validate()
+            .map_err(|_| ResearchContractError::InvalidField("researchRun"))?;
+        if run.project_id != self.project_id {
+            return Err(ResearchContractError::InvalidField("researchRun.projectId"));
+        }
+        if run.run_id != self.run_id {
+            return Err(ResearchContractError::InvalidField("researchRun.runId"));
+        }
+        receipt
+            .validate()
+            .map_err(|_| ResearchContractError::InvalidField("provenanceReceipt"))?;
+        if receipt.project_revision != run.project_revision {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.projectRevision",
+            ));
+        }
+        self.bind_provenance_receipt(receipt)
+    }
+
     pub fn resolve(
         &mut self,
         resolution_digest: impl Into<String>,

--- a/core/tests/research_execution_qualification.rs
+++ b/core/tests/research_execution_qualification.rs
@@ -466,10 +466,48 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
         61_004,
     )
     .unwrap()
-    .bind_provenance_receipt(&reopened_receipt)
+    .bind_provenance_receipt_for_run(&reopened_receipt, &research)
     .unwrap()
     .bind_evaluation_record(&reopened_record)
     .unwrap();
+
+    let drifted_receipt = ResearchProvenanceReceiptV1::new(
+        "research-project",
+        8,
+        &run.id,
+        "figure-1",
+        ResearchArtifactKindV1::Figure,
+        reference.content_digest.clone(),
+        vec![evidence.snapshot_digest.clone()],
+        digest_bytes("research-workflow", b"workflow-v1"),
+        digest_bytes("research-code", b"code-v1"),
+        digest_bytes("research-environment", b"env-v1"),
+        "fixture-provider",
+        Some(digest_bytes("research-model", b"fixture-model")),
+        Some(41),
+        Some(digest_bytes("research-validation", b"validated")),
+    )
+    .unwrap();
+    let drifted_finding = ResearchReviewFindingV1::new(
+        "finding-drifted-revision",
+        "research-project",
+        &run.id,
+        reference.content_digest.clone(),
+        ResearchReviewCategoryV1::Reproducibility,
+        ResearchReviewSeverityV1::Warning,
+        "The provenance revision must match the admitted Run.",
+        None,
+        vec![evidence.snapshot_digest.clone()],
+        "research-reviewer",
+        61_005,
+    )
+    .unwrap();
+    assert_eq!(
+        drifted_finding.bind_provenance_receipt_for_run(&drifted_receipt, &research),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "provenanceReceipt.projectRevision"
+        ))
+    );
     let batch = ResearchReviewBatchV1::new(
         "research-review-batch-1",
         "research-project",

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -65,9 +65,12 @@ raw model/tool output.
    an opaque operation id cannot be mistaken for the bare Run id.
 3. Materialize each output as a content-addressed artifact and publish a
    `ResearchProvenanceReceiptV1`. Bind a finding to that receipt with
-   `ResearchReviewFindingV1::bind_provenance_receipt`; Code checks the exact
-   project, Run, artifact digest, and at least one retained input evidence
-   digest without interpreting the scientific rubric.
+   `ResearchReviewFindingV1::bind_provenance_receipt_for_run`, passing the
+   admitted `ResearchRunV1`; Code checks the exact project, Run, project
+   revision, artifact digest, and at least one retained input evidence digest
+   without interpreting the scientific rubric. The older
+   `bind_provenance_receipt` form remains available for callers that do not
+   retain the admitted Run, but cannot perform the project-revision check.
 4. Run a host-selected evaluator through the generic Code evaluation
    substrate, then project its bounded observations into
    `ResearchReviewFindingV1` values. Bind each finding to the exact


### PR DESCRIPTION
## Summary
- add a Run-aware provenance binding for reviewer findings
- reject project-revision drift while preserving the object-only compatibility API
- extend the research qualification fixture and contract docs

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable test --locked --no-default-features -p a3s-code-core research::review::tests:: --lib
- cargo +stable test --locked --no-default-features --test research_execution_qualification
- cargo +stable clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings