### PR TITLE
Fence reviewer provenance to provider and seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot carry ambiguous source positions.
 - Added strict Run-aware provenance binding for reviewer findings. Hosts can
   pass the admitted `ResearchRunV1` so Code rejects project-revision drift in
-  addition to project, Run, artifact, and evidence-input mismatches; the
-  object-only compatibility binding remains available for older callers.
+  addition to provider, random-seed, project, Run, artifact, and evidence-input
+  mismatches; the object-only compatibility binding remains available for older
+  callers.
 - Added schema-v2 integrity fencing for persistent zvec generations. Reopen
   validates chunk payload digests, stable IDs, ranges, canonical digests, and
   duplicate IDs; corrupted generations fail closed and are rebuilt from the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,7 @@ decides how to search, review, approve, retain, and publish results.
 | --- | --- | --- | --- |
 | `RESEARCH-CONTRACT1` | Delivered | Versioned `ResearchRunV1`, `ResearchEvidenceFactV1`, `ResearchProvenanceReceiptV1`, `ResearchReviewFindingV1`, and `ResearchEventV1` values with bounded fields, canonical digest identity, strict schemas, and lifecycle validation | Twenty focused unit tests pass; tampering, invalid transitions, metadata bounds, digest ordering, event naming, and strict unknown-field rejection fail closed |
 | `RESEARCH-EXEC1` | Delivered | Host adapter qualification drives a research run through source capture, evidence append, create-only content-addressed artifact publication, and evaluator dispatch while retaining one Code Run identity; exact execution-target validation and explicit Run-aware Core-event projection are covered | `research_execution_qualification` passes restart/replay, cancellation terminality, contiguous evidence, artifact immutability, file-backed evaluator dispatch/result recovery, and exact Code/Use binding checks |
-| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to immutable evaluator and optional artifact-provenance records without introducing a Core rubric; strict Run-aware provenance binding also fences project-revision drift, and finding locations enforce one-based line/column coordinates | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, project-revision, evidence, provenance, duplicate-id, partial-batch drift, and malformed source locations |
+| `RESEARCH-REVIEW1` | In progress | Host-owned reviewer composition over the generic evaluation substrate, with Code binding each finding and bounded finding batch to immutable evaluator and optional artifact-provenance records without introducing a Core rubric; strict Run-aware provenance binding also fences project-revision, provider, and seed drift, and finding locations enforce one-based line/column coordinates | Reviewer checks citations, calculations, figure/code links, and reproducibility through injected policy; Code remains policy-neutral and rejects evaluator, Run, project-revision, provider, seed, evidence, provenance, duplicate-id, partial-batch drift, and malformed source locations |
 
 The delivered contract slice is documented in
 [Native Research Contracts](manual/RESEARCH_CONTRACTS.md). It is deliberately
@@ -288,8 +288,9 @@ artifact and the reproducibility receipt used to produce it.
 
 When the admitted `ResearchRunV1` is available, hosts should use
 `bind_provenance_receipt_for_run`. In addition to the artifact, project, Run,
-and evidence checks, this verifies that the receipt's project revision is the
-revision admitted for that Run. The compatibility method
+and evidence checks, this verifies that the receipt's project revision,
+provider, and random seed are the values admitted for that Run. The
+compatibility method
 `bind_provenance_receipt` intentionally keeps its original object-only
 semantics for older integrations.
 

--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -289,6 +289,16 @@ impl ResearchReviewFindingV1 {
                 "provenanceReceipt.projectRevision",
             ));
         }
+        if receipt.provider_id != run.provider_id {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.providerId",
+            ));
+        }
+        if receipt.random_seed != run.random_seed {
+            return Err(ResearchContractError::InvalidField(
+                "provenanceReceipt.randomSeed",
+            ));
+        }
         self.bind_provenance_receipt(receipt)
     }
 

--- a/core/tests/research_execution_qualification.rs
+++ b/core/tests/research_execution_qualification.rs
@@ -508,6 +508,83 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
             "provenanceReceipt.projectRevision"
         ))
     );
+
+    let provider_drift_receipt = ResearchProvenanceReceiptV1::new(
+        "research-project",
+        9,
+        &run.id,
+        "figure-1",
+        ResearchArtifactKindV1::Figure,
+        reference.content_digest.clone(),
+        vec![evidence.snapshot_digest.clone()],
+        digest_bytes("research-workflow", b"workflow-v1"),
+        digest_bytes("research-code", b"code-v1"),
+        digest_bytes("research-environment", b"env-v1"),
+        "other-provider",
+        Some(digest_bytes("research-model", b"fixture-model")),
+        Some(41),
+        Some(digest_bytes("research-validation", b"validated")),
+    )
+    .unwrap();
+    let provider_drift_finding = ResearchReviewFindingV1::new(
+        "finding-drifted-provider",
+        "research-project",
+        &run.id,
+        reference.content_digest.clone(),
+        ResearchReviewCategoryV1::Reproducibility,
+        ResearchReviewSeverityV1::Warning,
+        "The provenance provider must match the admitted Run.",
+        None,
+        vec![evidence.snapshot_digest.clone()],
+        "research-reviewer",
+        61_006,
+    )
+    .unwrap();
+    assert_eq!(
+        provider_drift_finding.bind_provenance_receipt_for_run(&provider_drift_receipt, &research),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "provenanceReceipt.providerId"
+        ))
+    );
+
+    let seed_drift_receipt = ResearchProvenanceReceiptV1::new(
+        "research-project",
+        9,
+        &run.id,
+        "figure-1",
+        ResearchArtifactKindV1::Figure,
+        reference.content_digest.clone(),
+        vec![evidence.snapshot_digest.clone()],
+        digest_bytes("research-workflow", b"workflow-v1"),
+        digest_bytes("research-code", b"code-v1"),
+        digest_bytes("research-environment", b"env-v1"),
+        "fixture-provider",
+        Some(digest_bytes("research-model", b"fixture-model")),
+        Some(42),
+        Some(digest_bytes("research-validation", b"validated")),
+    )
+    .unwrap();
+    let seed_drift_finding = ResearchReviewFindingV1::new(
+        "finding-drifted-seed",
+        "research-project",
+        &run.id,
+        reference.content_digest.clone(),
+        ResearchReviewCategoryV1::Reproducibility,
+        ResearchReviewSeverityV1::Warning,
+        "The provenance seed must match the admitted Run.",
+        None,
+        vec![evidence.snapshot_digest.clone()],
+        "research-reviewer",
+        61_007,
+    )
+    .unwrap();
+    assert_eq!(
+        seed_drift_finding.bind_provenance_receipt_for_run(&seed_drift_receipt, &research),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "provenanceReceipt.randomSeed"
+        ))
+    );
+
     let batch = ResearchReviewBatchV1::new(
         "research-review-batch-1",
         "research-project",

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -67,8 +67,8 @@ raw model/tool output.
    `ResearchProvenanceReceiptV1`. Bind a finding to that receipt with
    `ResearchReviewFindingV1::bind_provenance_receipt_for_run`, passing the
    admitted `ResearchRunV1`; Code checks the exact project, Run, project
-   revision, artifact digest, and at least one retained input evidence digest
-   without interpreting the scientific rubric. The older
+   revision, provider, random seed, artifact digest, and at least one retained
+   input evidence digest without interpreting the scientific rubric. The older
    `bind_provenance_receipt` form remains available for callers that do not
    retain the admitted Run, but cannot perform the project-revision check.
 4. Run a host-selected evaluator through the generic Code evaluation


### PR DESCRIPTION
## Summary
- require strict reviewer provenance receipts to match the admitted Run provider and random seed
- extend research qualification with provider and seed drift rejection
- document the stronger reproducibility boundary

## Validation
- cargo +stable fmt --all -- --check
- cargo +stable test --locked --no-default-features --test research_execution_qualification
- cargo +stable clippy --locked --no-default-features -p a3s-code-core --lib -- -D warnings