### PR TITLE
fix(review): allow clean reviewer batches

### DIFF
--- a/core/src/research/review_batch.rs
+++ b/core/src/research/review_batch.rs
@@ -14,7 +14,9 @@ const RESEARCH_REVIEW_BATCH_DIGEST_DOMAIN: &str = "a3s.code.review-batch.identit
 /// A batch does not define a rubric or a business decision. It only prevents
 /// a host from publishing a partially mixed reviewer response: every finding
 /// must belong to the same project/run, evaluation record, and evidence
-/// snapshot. Human resolution remains an explicit operation on each finding.
+/// snapshot. A batch may contain zero findings to represent a clean reviewer
+/// result; the evaluator record remains the authoritative result and evidence
+/// identity. Human resolution remains an explicit operation on each finding.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ResearchReviewBatchV1 {
@@ -177,7 +179,7 @@ impl ResearchReviewBatchV1 {
         validate_id("runId", &self.run_id)?;
         validate_digest_field("evaluationRecordDigest", &self.evaluation_record_digest)?;
         validate_digest_field("evidenceDigest", &self.evidence_digest)?;
-        if self.findings.is_empty() || self.findings.len() > RESEARCH_MAX_REVIEW_FINDINGS {
+        if self.findings.len() > RESEARCH_MAX_REVIEW_FINDINGS {
             return Err(ResearchContractError::InvalidField("findings"));
         }
         for pair in self.findings.windows(2) {
@@ -378,5 +380,22 @@ mod tests {
             batch.validate(),
             Err(ResearchContractError::DigestMismatch("findingDigest"))
         );
+    }
+
+    #[test]
+    fn empty_batch_represents_a_clean_review_result() {
+        let record = record();
+        let batch = ResearchReviewBatchV1::new(
+            "clean-batch",
+            "project-1",
+            "run-1",
+            record.record_digest.clone(),
+            record.result.evidence_digest.clone(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert!(batch.findings.is_empty());
+        assert!(batch.validate().is_ok());
     }
 }

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -48,6 +48,11 @@ line and column zero are rejected, and a column cannot appear without a line.
 A finding or run whose fields were changed without updating its digest is
 rejected before any transition can rebind the tampered value.
 
+A `ResearchReviewBatchV1` may contain zero findings. This is the canonical
+representation of a clean reviewer result; the bound evaluator record remains
+the source of the decision and evidence identity, so hosts do not need to
+invent a synthetic finding merely to publish a successful review.
+
 Evidence facts and events carry sequence numbers, but contiguous ordering and
 durability remain host responsibilities. The payloads intentionally contain
 digests and bounded metadata rather than prompts, source text, credentials, or


### PR DESCRIPTION
## Summary
- allow `ResearchReviewBatchV1` to represent a clean evaluator result with zero findings
- keep evaluator record and evidence digests as the authoritative identity
- add a regression test and document the contract

## Validation
- `cargo +1.97.1 fmt --all -- --check`
- `cargo +1.97.1 test --locked --no-default-features -p a3s-code-core research::review_batch --lib`

The focused test suite passes (3 tests).