### PR TITLE
fix(review): require open findings for new batches

### DIFF
--- a/core/src/research/review_batch.rs
+++ b/core/src/research/review_batch.rs
@@ -2,6 +2,7 @@
 
 use super::{
     digest, validate_digest_field, validate_id, ResearchContractError, ResearchReviewFindingV1,
+    ResearchReviewStatusV1,
 };
 use serde::{Deserialize, Serialize};
 
@@ -36,7 +37,10 @@ impl ResearchReviewBatchV1 {
     /// The identity-only [`new`](Self::new) constructor remains available for
     /// compatibility with callers that only have wire-level digests. New
     /// reviewer pipelines should use this constructor so the project/run
-    /// namespace and evaluator evidence snapshot are closed at admission.
+    /// namespace and evaluator evidence snapshot are closed at admission. A
+    /// newly admitted batch must contain only open findings; resolved or
+    /// waived findings must be restored from the already-published batch and
+    /// changed through the explicit transition methods below.
     pub fn new_for_run(
         batch_id: impl Into<String>,
         run: &crate::research::ResearchRunV1,
@@ -53,6 +57,13 @@ impl ResearchReviewBatchV1 {
             findings,
         )?;
         batch.validate_for_run(run, record)?;
+        if batch
+            .findings
+            .iter()
+            .any(|finding| !matches!(finding.status, ResearchReviewStatusV1::Open))
+        {
+            return Err(ResearchContractError::InvalidField("finding.status"));
+        }
         Ok(batch)
     }
 

--- a/core/tests/research_execution_qualification.rs
+++ b/core/tests/research_execution_qualification.rs
@@ -657,6 +657,21 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
         Some(reopened_receipt.receipt_digest.as_str())
     );
 
+    let mut preclosed_finding = batch.findings[0].clone();
+    preclosed_finding.resolve(digest('9')).unwrap();
+    assert_eq!(
+        ResearchReviewBatchV1::new_for_run(
+            "research-review-batch-preclosed",
+            &research,
+            &reopened_record,
+            evidence.snapshot_digest.clone(),
+            vec![preclosed_finding],
+        ),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "finding.status"
+        ))
+    );
+
     #[derive(serde::Serialize)]
     struct ForgedFindingIdentity<'a> {
         schema: &'a str,


### PR DESCRIPTION
### Summary
- require `open` findings when admitting a new Run-aware review batch
- preserve resolved/waived batches for explicit transition/replay paths
- cover pre-closed batch rejection in research execution qualification

### Validation
- cargo +1.97.1 fmt --all -- --check
- cargo +1.97.1 test --locked --no-default-features -p a3s-code-core research::review_batch --lib (3 passed)
- cargo +1.97.1 test --locked --no-default-features --test research_execution_qualification --quiet (3 passed)