### PR TITLE
fix(review): require admitted research runs

### DIFF
--- a/core/src/research/review.rs
+++ b/core/src/research/review.rs
@@ -238,8 +238,7 @@ impl ResearchReviewFindingV1 {
         run: &crate::research::ResearchRunV1,
     ) -> Result<Self, ResearchContractError> {
         self.validate()?;
-        run.validate()
-            .map_err(|_| ResearchContractError::InvalidField("researchRun"))?;
+        run.validate_reviewable()?;
         if run.project_id != self.project_id {
             return Err(ResearchContractError::InvalidField("researchRun.projectId"));
         }
@@ -320,8 +319,7 @@ impl ResearchReviewFindingV1 {
         run: &crate::research::ResearchRunV1,
     ) -> Result<Self, ResearchContractError> {
         self.validate()?;
-        run.validate()
-            .map_err(|_| ResearchContractError::InvalidField("researchRun"))?;
+        run.validate_reviewable()?;
         if run.project_id != self.project_id {
             return Err(ResearchContractError::InvalidField("researchRun.projectId"));
         }

--- a/core/src/research/review_batch.rs
+++ b/core/src/research/review_batch.rs
@@ -108,8 +108,7 @@ impl ResearchReviewBatchV1 {
         record: &crate::evaluation::EvaluationRecordV1,
     ) -> Result<(), ResearchContractError> {
         self.validate()?;
-        run.validate()
-            .map_err(|_| ResearchContractError::InvalidField("researchRun"))?;
+        run.validate_reviewable()?;
         record
             .validate()
             .map_err(|_| ResearchContractError::InvalidField("evaluationRecord"))?;

--- a/core/src/research/run.rs
+++ b/core/src/research/run.rs
@@ -152,6 +152,22 @@ impl ResearchRunV1 {
         Ok(())
     }
 
+    /// Validate that this Run has crossed the admission boundary before a
+    /// host attaches reviewer evidence or findings to it.
+    ///
+    /// A planned Run has not yet frozen an executable identity, so accepting
+    /// review output for it would allow an evaluator result to exist without
+    /// a corresponding admitted research execution. Terminal and checkpoint
+    /// states remain reviewable because hosts may inspect completed or failed
+    /// artifacts after execution.
+    pub(crate) fn validate_reviewable(&self) -> Result<(), ResearchContractError> {
+        self.validate()?;
+        if matches!(self.status, ResearchRunStatusV1::Planned) {
+            return Err(ResearchContractError::InvalidField("researchRun.status"));
+        }
+        Ok(())
+    }
+
     pub fn transition_to(
         &mut self,
         next: ResearchRunStatusV1,

--- a/core/tests/research_execution_qualification.rs
+++ b/core/tests/research_execution_qualification.rs
@@ -641,6 +641,40 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
         ))
     );
 
+    let planned_research = ResearchRunV1::new(
+        &run.id,
+        "research-project",
+        9,
+        digest_bytes("research-source", b"source-snapshot"),
+        evidence.snapshot_digest.clone(),
+        capability_binding.clone(),
+        "fixture-provider",
+        "fixture-model",
+        ResearchReproducibilityV1::Deterministic,
+        Some(41),
+    )
+    .unwrap();
+    let unadmitted_finding = ResearchReviewFindingV1::new(
+        "finding-unadmitted-run",
+        "research-project",
+        &run.id,
+        reference.content_digest.clone(),
+        ResearchReviewCategoryV1::Reproducibility,
+        ResearchReviewSeverityV1::Warning,
+        "Reviewer output requires an admitted Run.",
+        None,
+        vec![evidence.snapshot_digest.clone()],
+        "research-reviewer",
+        61_010,
+    )
+    .unwrap();
+    assert_eq!(
+        unadmitted_finding.bind_evaluation_record_for_run(&reopened_record, &planned_research),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "researchRun.status"
+        ))
+    );
+
     let batch = ResearchReviewBatchV1::new_for_run(
         "research-review-batch-1",
         &research,
@@ -655,6 +689,18 @@ async fn research_execution_restarts_with_contiguous_evidence_and_exact_bindings
     assert_eq!(
         batch.findings[0].provenance_receipt_digest.as_deref(),
         Some(reopened_receipt.receipt_digest.as_str())
+    );
+    assert_eq!(
+        ResearchReviewBatchV1::new_for_run(
+            "research-review-batch-unadmitted",
+            &planned_research,
+            &reopened_record,
+            evidence.snapshot_digest.clone(),
+            vec![batch.findings[0].clone()],
+        ),
+        Err(a3s_code_core::ResearchContractError::InvalidField(
+            "researchRun.status"
+        ))
     );
 
     let mut preclosed_finding = batch.findings[0].clone();


### PR DESCRIPTION
### Summary
- centralize the reviewable Run admission invariant
- reject findings and batches bound to a planned research Run
- keep checkpointed and terminal Runs reviewable for post-run inspection
- add qualification coverage for both finding and batch paths

### Validation
- cargo +1.97.1 fmt --all -- --check
- cargo +1.97.1 test --locked --no-default-features -p a3s-code-core research:: --lib (26 passed)
- cargo +1.97.1 test --locked --no-default-features --test research_execution_qualification --quiet (3 passed)