### PR TITLE
fix(review): reject trailing line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Research and evaluation identity fields now reject both trailing and embedded
+  CR/LF line endings. Reviewer IDs, messages, locations, and evaluator targets
+  therefore cannot cross a line-delimited boundary with an ambiguous shape.
 - Reviewer finding locations now reject zero-based or orphaned coordinates;
   optional columns require a one-based line so citation and figure/code links
   cannot carry ambiguous source positions.

--- a/core/src/evaluation/identity.rs
+++ b/core/src/evaluation/identity.rs
@@ -109,7 +109,7 @@ impl ExecutionFrameV1 {
             if branch.is_empty()
                 || branch.len() > MAX_BRANCH_BYTES
                 || branch.contains('\0')
-                || branch.lines().count() != 1
+                || branch.contains(['\r', '\n'])
             {
                 return Err(IdentityError::InvalidField("branch"));
             }
@@ -173,7 +173,7 @@ fn validate_id(field: &'static str, value: &str) -> Result<(), IdentityError> {
     if value.is_empty()
         || value.len() > EVALUATION_MAX_ID_BYTES
         || value.contains('\0')
-        || value.lines().count() != 1
+        || value.contains(['\r', '\n'])
     {
         return Err(IdentityError::InvalidField(field));
     }
@@ -213,5 +213,16 @@ mod tests {
             Err(IdentityError::InvalidField("parent"))
         ));
         assert_eq!(EventCursorV1::new(u64::MAX).next(), None);
+    }
+
+    #[test]
+    fn target_rejects_trailing_line_endings_in_identity_fields() {
+        for run_id in ["run-1\n", "run-1\r", "run-1\r\n"] {
+            let target = ExecutionTargetV1::new("session-1", run_id);
+            assert_eq!(
+                target.validate(),
+                Err(IdentityError::InvalidField("run_id"))
+            );
+        }
     }
 }

--- a/core/src/evaluation/result.rs
+++ b/core/src/evaluation/result.rs
@@ -408,7 +408,7 @@ fn validate_text(
     if value.is_empty()
         || value.len() > max_bytes
         || value.contains('\0')
-        || value.lines().count() != 1
+        || value.contains(['\r', '\n'])
     {
         return Err(EvaluationStoreError::InvalidField(field));
     }
@@ -433,6 +433,23 @@ mod tests {
             super::super::identity::digest_bytes("evidence", b"fixture"),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn evaluator_identity_fields_reject_trailing_line_endings() {
+        for evaluator_id in ["reviewer\n", "reviewer\r", "reviewer\r\n"] {
+            assert!(matches!(
+                EvaluationResultV1::new(
+                    evaluator_id,
+                    target(),
+                    "aux-1",
+                    "observed",
+                    serde_json::json!({"finding_count": 1}),
+                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+                Err(EvaluationStoreError::InvalidField("evaluator_id"))
+            ));
+        }
     }
 
     #[test]

--- a/core/src/research/mod.rs
+++ b/core/src/research/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn validate_id(field: &'static str, value: &str) -> Result<(), Resear
     if value.is_empty()
         || value.len() > RESEARCH_MAX_ID_BYTES
         || value.contains('\0')
-        || value.lines().count() != 1
+        || value.contains(['\r', '\n'])
     {
         return Err(ResearchContractError::InvalidField(field));
     }
@@ -57,11 +57,36 @@ pub(crate) fn validate_text(
     if value.is_empty()
         || value.len() > max_bytes
         || value.contains('\0')
-        || value.lines().count() > 1
+        || value.contains(['\r', '\n'])
     {
         return Err(ResearchContractError::InvalidField(field));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_identifiers_reject_all_ascii_line_endings() {
+        for value in ["reviewer\n", "reviewer\r", "reviewer\r\n", "reviewer\nnext"] {
+            assert_eq!(
+                validate_id("id", value),
+                Err(ResearchContractError::InvalidField("id"))
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_text_rejects_all_ascii_line_endings() {
+        for value in ["finding\n", "finding\r", "finding\r\n", "finding\nnext"] {
+            assert_eq!(
+                validate_text("text", value, 128),
+                Err(ResearchContractError::InvalidField("text"))
+            );
+        }
+    }
 }
 
 pub(crate) fn validate_digest_field(

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -30,7 +30,8 @@ interpret a review finding as approval.
 | `ResearchReviewBatchV1` | `a3s.code.review-batch.v1` | Bounded immutable projection of one evaluator result into findings; all findings share the same project, Run, evaluation record, and evidence snapshot. |
 | `ResearchEventV1` | `a3s.code.science-event.v1` | Digest-only project/run event projection for Desktop and other hosts. |
 
-All IDs and text are bounded. Digests use the existing Code SHA-256 format.
+All IDs and text are bounded and reject both embedded and trailing CR/LF line
+endings at the Code boundary. Digests use the existing Code SHA-256 format.
 Maps and digest lists are canonicalized before identity calculation, and every
 value uses `deny_unknown_fields` so an older host cannot silently accept a
 newer shape.


### PR DESCRIPTION
## Summary
- close the trailing CR/LF validation gap in native research contracts
- apply the same strict boundary to evaluation targets and evaluator identities
- add regression tests for LF, CR, and CRLF suffixes

## Validation
- cargo +1.97.1 fmt --all -- --check
- evaluation identity tests: 3 passed
- evaluation result tests: 6 passed
- research contract tests: 29 passed
- research execution qualification: 3 passed