### PR TITLE
test(review): qualify lifecycle recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Reviewer batch lifecycle qualification now reopens resolved and waived
+  findings from strict JSON and preserves terminal transition guards across a
+  process restart.
 - Research and evaluation identity fields now reject both trailing and embedded
   CR/LF line endings. Reviewer IDs, messages, locations, and evaluator targets
   therefore cannot cross a line-delimited boundary with an ambiguous shape.

--- a/core/src/research/review_batch.rs
+++ b/core/src/research/review_batch.rs
@@ -438,4 +438,64 @@ mod tests {
             Err(ResearchContractError::DigestMismatch("findingDigest"))
         );
     }
+
+    #[test]
+    fn closed_batch_round_trip_preserves_terminal_finding_state() {
+        let record = record();
+        let mut resolved = ResearchReviewBatchV1::new(
+            "resolved-wire-batch",
+            "project-1",
+            "run-1",
+            record.record_digest.clone(),
+            record.result.evidence_digest.clone(),
+            vec![finding("finding-1", &record)],
+        )
+        .unwrap();
+        resolved.resolve_finding("finding-1", digest('c')).unwrap();
+        let reopened: ResearchReviewBatchV1 =
+            serde_json::from_slice(&serde_json::to_vec(&resolved).unwrap()).unwrap();
+        assert_eq!(reopened, resolved);
+        assert_eq!(
+            reopened.findings[0].status,
+            ResearchReviewStatusV1::Resolved
+        );
+        assert!(reopened.validate().is_ok());
+        assert_eq!(
+            reopened.clone().resolve_finding("finding-1", digest('d')),
+            Err(ResearchContractError::InvalidTransition {
+                from: "resolved",
+                to: "resolved"
+            })
+        );
+        assert_eq!(
+            reopened.clone().waive_finding("finding-1", digest('e')),
+            Err(ResearchContractError::InvalidTransition {
+                from: "resolved",
+                to: "waived"
+            })
+        );
+
+        let mut waived = ResearchReviewBatchV1::new(
+            "waived-wire-batch",
+            "project-1",
+            "run-1",
+            record.record_digest.clone(),
+            record.result.evidence_digest.clone(),
+            vec![finding("finding-2", &record)],
+        )
+        .unwrap();
+        waived.waive_finding("finding-2", digest('f')).unwrap();
+        let mut reopened: ResearchReviewBatchV1 =
+            serde_json::from_slice(&serde_json::to_vec(&waived).unwrap()).unwrap();
+        assert_eq!(reopened, waived);
+        assert_eq!(reopened.findings[0].status, ResearchReviewStatusV1::Waived);
+        assert!(reopened.validate().is_ok());
+        assert_eq!(
+            reopened.resolve_finding("finding-2", digest('1')),
+            Err(ResearchContractError::InvalidTransition {
+                from: "waived",
+                to: "resolved"
+            })
+        );
+    }
 }

--- a/manual/RESEARCH_CONTRACTS.md
+++ b/manual/RESEARCH_CONTRACTS.md
@@ -47,7 +47,9 @@ Review findings start `open`; only `resolve` or `waive` with a content digest
 can close them. Optional source/artifact locations use one-based coordinates:
 line and column zero are rejected, and a column cannot appear without a line.
 A finding or run whose fields were changed without updating its digest is
-rejected before any transition can rebind the tampered value.
+rejected before any transition can rebind the tampered value. Serialized
+resolved and waived batches reopen with their terminal state and continue to
+reject every subsequent resolution transition.
 
 A `ResearchReviewBatchV1` may contain zero findings. This is the canonical
 representation of a clean reviewer result; the bound evaluator record remains


### PR DESCRIPTION
## Summary
- qualify resolved and waived reviewer batches across strict JSON restart
- preserve terminal finding state and reject every subsequent resolution transition
- document the recovery invariant

## Validation
- cargo +1.97.1 fmt --all -- --check
- review batch tests: 5 passed
- research execution qualification: 3 passed