### PR TITLE
docs(site): format home-copy for Pages deploy

### DIFF
--- a/website/theme/components/home-copy.ts
+++ b/website/theme/components/home-copy.ts
@@ -108,8 +108,7 @@ export const copy = {
       '装好 a3s code，找个项目试一下。要嵌进产品时，再选 Rust、Node.js、Python 或 Go。',
     ctaPrimary: '查看快速开始',
     ctaSecondary: '查看 API',
-    footer:
-      'MIT · 用 Rust 写的 · Terminal / Rust / Node.js / Python / Go',
+    footer: 'MIT · 用 Rust 写的 · Terminal / Rust / Node.js / Python / Go',
   },
   en: {
     eyebrow: 'Open source · embeddable agent runtime',


### PR DESCRIPTION
## Summary
- Fix Prettier on `home-copy.ts` so docs-pages can deploy the plain-language copy from #133

## Test plan
- [x] `npx prettier --check theme/components/home-copy.ts`
- [ ] Pages deploy succeeds on main


Made with [Cursor](https://cursor.com)